### PR TITLE
Replaced 'operator' with 'lifecycle-manager' occurrence in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lifecycle-manager
 
-Kyma is the opinionated set of Kubernetes based modular building blocks that includes the necessary capabilities to develop and run enterprise-grade cloud-native applications. Kyma operator is a tool that manages the lifecycle of these components in your cluster.
+Kyma is the opinionated set of Kubernetes based modular building blocks that includes the necessary capabilities to develop and run enterprise-grade cloud-native applications. Kyma's `lifecycle-manager` is a tool that manages the lifecycle of these components in your cluster.
 
 # Architecture
 


### PR DESCRIPTION
Just changed 'operator' word in one place where I thought it should be changed. OMG my first PR here. Feel free to reject, I probably messed up something. 