### PR TITLE
Move Manager Resource to Kustomize Component and change default label for selectors

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -16,8 +16,9 @@ commonLabels:
   app.kubernetes.io/managed-by: kustomize
   app.kubernetes.io/part-of: manual-deployment
 
-components:
+resources:
   - ../manager
+components:
   - ../crd
   - ../rbac
   # [ISTIO] To enable istio, uncomment all sections with 'ISTIO'.

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -9,8 +9,12 @@ namespace: kcp-system
 namePrefix: lifecycle-manager-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/instance: kcp-lifecycle-manager-main
+  app.kubernetes.io/name: kcp-lifecycle-manager
+  app.kubernetes.io/created-by: kustomize
+  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/part-of: manual-deployment
 
 components:
   - ../manager

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -12,10 +12,8 @@ namePrefix: lifecycle-manager-
 #commonLabels:
 #  someName: someValue
 
-resources:
-  - ../manager
-
 components:
+  - ../manager
   - ../crd
   - ../rbac
   # [ISTIO] To enable istio, uncomment all sections with 'ISTIO'.

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - manager.yaml
 
@@ -8,8 +11,6 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 images:
 - name: controller
   newName: eu.gcr.io/kyma-project/lifecycle-manager

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
+kind: Kustomization
 
 resources:
 - manager.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
+
 images:
 - name: controller
   newName: eu.gcr.io/kyma-project/lifecycle-manager

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/component: kyma-project.io/lifecycle-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,7 +11,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/component: kyma-project.io/lifecycle-manager
 spec:
   selector:
     matchLabels:

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/component: kyma-project.io/lifecycle-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:

--- a/operator/config/rbac/auth_proxy_service.yaml
+++ b/operator/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/component: kyma-project.io/lifecycle-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:


### PR DESCRIPTION
change all manual occurrences in manager.yaml and all relevant components, e.g. istio / monitoring:
control-plane: controller-manager => app.kubernetes.io/component: kyma-project.io/lifecycle-manager

Also changes common labels in kustomization:

```yaml
commonLabels:
  app.kubernetes.io/instance: kcp-lifecycle-manager-main
  app.kubernetes.io/name: kcp-lifecycle-manager
  app.kubernetes.io/created-by: kustomize
  app.kubernetes.io/managed-by: kustomize
  app.kubernetes.io/part-of: manual-deployment
```