### PR TITLE
Add Labels which are needed by Watcher

### DIFF
--- a/operator/api/v1alpha1/operator_labels.go
+++ b/operator/api/v1alpha1/operator_labels.go
@@ -18,7 +18,9 @@ const (
 	ModuleName     = OperatorPrefix + Separator + "module-name"
 	ModuleVersion  = OperatorPrefix + Separator + "module-version"
 	OperatorName   = "lifecycle-manager"
-	OwnerByFormat  = "%s__%s"
+	OwnedByLabel   = "operator.kyma-project.io/owned-by"
+	OwnedByFormat  = "%s__%s"
+	WatchedByLabel = "operator.kyma-project.io/watched-by"
 )
 
 func GetMatchingLabelsForModule(module *Module) client.MatchingLabels {

--- a/operator/api/v1alpha1/operator_labels.go
+++ b/operator/api/v1alpha1/operator_labels.go
@@ -18,9 +18,9 @@ const (
 	ModuleName     = OperatorPrefix + Separator + "module-name"
 	ModuleVersion  = OperatorPrefix + Separator + "module-version"
 	OperatorName   = "lifecycle-manager"
-	OwnedByLabel   = "operator.kyma-project.io/owned-by"
+	OwnedByLabel   =  OperatorPrefix + Separator + "owned-by"
 	OwnedByFormat  = "%s__%s"
-	WatchedByLabel = "operator.kyma-project.io/watched-by"
+	WatchedByLabel = OperatorPrefix + Separator + "watched-by"
 )
 
 func GetMatchingLabelsForModule(module *Module) client.MatchingLabels {

--- a/operator/api/v1alpha1/operator_labels.go
+++ b/operator/api/v1alpha1/operator_labels.go
@@ -18,6 +18,7 @@ const (
 	ModuleName     = OperatorPrefix + Separator + "module-name"
 	ModuleVersion  = OperatorPrefix + Separator + "module-version"
 	OperatorName   = "lifecycle-manager"
+	OwnerByFormat  = "%s__%s"
 )
 
 func GetMatchingLabelsForModule(module *Module) client.MatchingLabels {

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -152,7 +152,9 @@ func (r *KymaReconciler) synchronizeRemote(ctx context.Context, kyma *v1alpha1.K
 	if err := syncContext.SynchronizeRemoteKyma(ctx, remoteKyma); err != nil {
 		return fmt.Errorf("could not synchronize remote kyma: %w", err)
 	}
-
+	if err := syncContext.InsertWatcherLabels(ctx, remoteKyma); err != nil {
+		return fmt.Errorf("could not ensure runtime-watcher labels are set: %w", err)
+	}
 	syncContext.ReplaceWithVirtualKyma(kyma, remoteKyma)
 
 	return nil

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -152,9 +152,6 @@ func (r *KymaReconciler) synchronizeRemote(ctx context.Context, kyma *v1alpha1.K
 	if err := syncContext.SynchronizeRemoteKyma(ctx, remoteKyma); err != nil {
 		return fmt.Errorf("could not synchronize remote kyma: %w", err)
 	}
-	if err := syncContext.InsertWatcherLabels(ctx, remoteKyma); err != nil {
-		return fmt.Errorf("could not ensure runtime-watcher labels are set: %w", err)
-	}
 	syncContext.ReplaceWithVirtualKyma(kyma, remoteKyma)
 
 	return nil

--- a/operator/controllers/setup.go
+++ b/operator/controllers/setup.go
@@ -3,10 +3,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/operator/pkg/module/sync/runner_impl.go
+++ b/operator/pkg/module/sync/runner_impl.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/watch"
 )
 
-func New(clnt client.Client) Runner { 
+func New(clnt client.Client) Runner { //nolint:ireturn
 	return &runnerImpl{clnt}
 }
 

--- a/operator/pkg/module/sync/runner_impl.go
+++ b/operator/pkg/module/sync/runner_impl.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/watch"
 )
 
-func New(clnt client.Client) Runner { //nolint:ireturn
+func New(clnt client.Client) Runner { 
 	return &runnerImpl{clnt}
 }
 

--- a/operator/pkg/remote/kyma_synchronization_context.go
+++ b/operator/pkg/remote/kyma_synchronization_context.go
@@ -296,7 +296,7 @@ func (c *KymaSynchronizationContext) InsertWatcherLabels(remoteKyma *v1alpha1.Ky
 		remoteKyma.Labels = make(map[string]string)
 	}
 
-	remoteKyma.Labels["operator.kyma-project.io/owned-by"] = fmt.Sprintf(v1alpha1.OwnerByFormat,
+	remoteKyma.Labels[v1alpha1.OwnedByLabel] = fmt.Sprintf(v1alpha1.OwnedByFormat,
 		c.ControlPlaneKyma.Namespace, c.ControlPlaneKyma.Name)
-	remoteKyma.Labels["operator.kyma-project.io/watched-by"] = v1alpha1.OperatorName
+	remoteKyma.Labels[v1alpha1.WatchedByLabel] = v1alpha1.OperatorName
 }

--- a/operator/pkg/remote/kyma_synchronization_context.go
+++ b/operator/pkg/remote/kyma_synchronization_context.go
@@ -297,6 +297,10 @@ func (c *KymaSynchronizationContext) InsertWatcherLabels(ctx context.Context, re
 	ownedByValue := fmt.Sprintf("%s__%s", c.ControlPlaneKyma.Namespace, c.ControlPlaneKyma.Name)
 	watchedByValue := "lifecycle-manager"
 
+	if remoteKyma.Labels == nil {
+		remoteKyma.Labels = make(map[string]string)
+	}
+
 	remoteKyma.Labels["operator.kyma-project.io/owned-by"] = ownedByValue
 	remoteKyma.Labels["operator.kyma-project.io/watched-by"] = watchedByValue
 


### PR DESCRIPTION
If Sync is enabled on the KymaCR then, it will be ensured the needed Labels for the Watcher are set.