### PR TITLE
fix: remove ErrNoComponentSpecified to not error out when there are no modules in Kyma

### DIFF
--- a/operator/api/v1alpha1/operator_labels.go
+++ b/operator/api/v1alpha1/operator_labels.go
@@ -18,7 +18,7 @@ const (
 	ModuleName     = OperatorPrefix + Separator + "module-name"
 	ModuleVersion  = OperatorPrefix + Separator + "module-version"
 	OperatorName   = "lifecycle-manager"
-	OwnedByLabel   =  OperatorPrefix + Separator + "owned-by"
+	OwnedByLabel   = OperatorPrefix + Separator + "owned-by"
 	OwnedByFormat  = "%s__%s"
 	WatchedByLabel = OperatorPrefix + Separator + "watched-by"
 )

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -45,8 +44,6 @@ import (
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/release"
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/status"
 )
-
-var ErrNoComponentSpecified = errors.New("no component specified")
 
 type RequeueIntervals struct {
 	Success time.Duration
@@ -124,11 +121,6 @@ func (r *KymaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if err != nil {
 			return ctrl.Result{RequeueAfter: r.RequeueIntervals.Failure}, err
 		}
-	}
-
-	if len(kyma.Spec.Modules) < 1 {
-		return ctrl.Result{}, r.UpdateStatusFromErr(ctx, kyma, v1alpha1.StateError,
-			fmt.Errorf("error parsing %s: %w", kyma.Name, ErrNoComponentSpecified))
 	}
 
 	// state handling

--- a/operator/controllers/kyma_controller_test.go
+++ b/operator/controllers/kyma_controller_test.go
@@ -26,9 +26,9 @@ var _ = Describe("Kyma with no ModuleTemplate", func() {
 	kyma := NewTestKyma("no-module-kyma")
 	RegisterDefaultLifecycleForKyma(kyma)
 
-	It("Should result in an error state", func() {
-		By("having transitioned the CR State to Error as there are no modules")
-		Eventually(IsKymaInState(kyma.GetName(), v1alpha1.StateError), timeout, interval).Should(BeTrue())
+	It("Should result in a ready state immediately", func() {
+		By("having transitioned the CR State to Ready as there are no modules")
+		Eventually(IsKymaInState(kyma.GetName(), v1alpha1.StateReady), timeout, interval).Should(BeTrue())
 	})
 
 	When("creating a Kyma CR with Module based on an Empty ModuleTemplate", func() {


### PR DESCRIPTION
Fixes #194 