### PR TITLE
chore: add kyma alpha deploy test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,49 @@ jobs:
           path: |
             operator/dry-run/*.yaml
 
+  cli-integration:
+    needs: [wait-for-img, kustomize]
+    name: "Kyma CLI Integration"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up k3d
+        run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
+      - name: Set up CLI
+        run: |
+          wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
+          chmod +x kyma-linux
+          mv kyma-linux /usr/local/bin/kyma
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          cache: true
+          go-version-file: 'operator/go.mod'
+          cache-dependency-path: 'operator/go.sum'
+
+      - name: Checkout Lifecycle-Manager
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}
+          path: $(go env GOPATH)/src/github.com/${{ github.repository }}
+
+      - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
+        if: github.event_name == 'pull_request'
+        run: |
+          cd $(go env GOPATH)/src/github.com/${{ github.repository }}
+          cd operator/config/manager
+          kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
+
+      - name: Checkout Module-Manager
+        uses: actions/checkout@v3
+        with:
+          repository: kyma-project/module-manager
+          path: $(go env GOPATH)/src/github.com/kyma-project/module-manager
+          ref: HEAD
+
+      - name: Run Deploy
+        run: kyma alpha deploy --source=local
+
   smoke:
     needs: [wait-for-img, kustomize]
     name: "Smoke"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,10 +83,10 @@ jobs:
       - name: Move Repos to SRC
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/lifecycle-manager $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/** $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/
           ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
-          mv $GITHUB_WORKSPACE/$MODULE_MANAGER/module-manager $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          mv $GITHUB_WORKSPACE/$MODULE_MANAGER/** $(go env GOPATH)/src/github.com/$MODULE_MANAGER/
           ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
-          path: /go/src/github.com/${{ github.repository }}
+          path: go/src/github.com/${{ github.repository }}
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
           repository: kyma-project/module-manager
-          path: /go/src/github.com/kyma-project/module-manager
+          path: go/src/github.com/kyma-project/module-manager
           ref: HEAD
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           repository: kyma-project/module-manager
           path: go/src/github.com/kyma-project/module-manager
-          ref: HEAD
+          ref: main
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           mv kyma-linux /usr/local/bin/kyma      
 
       - name: Run Provision
-        run: kyma provision k3d
+        run: kyma provision k3d -p 8083:80@loadbalancer -p 8443:443@loadbalancer --timeout 1m --k3d-arg --no-rollback
 
       - name: Run Deploy
         run: kyma alpha deploy --source=local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,16 +75,16 @@ jobs:
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
-          repository: $MODULE_MANAGER
-          path: $MODULE_MANAGER
+          repository: ${{ env.MODULE_MANAGER }}
+          path: ${{ env.MODULE_MANAGER }}
           ref: main
 
       - name: Move Repos to SRC
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/{{ .github.repository }}
           mv $GITHUB_WORKSPACE/{{ .github.repository }} $(go env GOPATH)/src/github.com/{{ .github.repository }}
-          mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
-          mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          mkdir -p $(go env GOPATH)/src/github.com/${{ env.MODULE_MANAGER }}
+          mv $GITHUB_WORKSPACE/${{ env.MODULE_MANAGER }} $(go env GOPATH)/src/github.com/${{ env.MODULE_MANAGER }}
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
+env:
+  MODULE_MANAGER: kyma-project/module-manager
 jobs:
   wait-for-img:
     name: "Wait for Image Build"
@@ -70,25 +71,25 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
-          path: lifecycle-manager
+          path: ${{ github.repository }}
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
-          repository: kyma-project/module-manager
-          path: module-manager
+          repository: $MODULE_MANAGER
+          path: $MODULE_MANAGER
           ref: main
 
       - name: Move Repos to SRC
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/lifecycle-manager
-          mv $GITHUB_WORKSPACE/lifecycle-manager $(go env GOPATH)/src/github.com/kyma-project/lifecycle-manager
-          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/module-manager
-          mv $GITHUB_WORKSPACE/module-manager $(go env GOPATH)/src/github.com/kyma-project/module-manager
+          mkdir -p $(go env GOPATH)/src/github.com/{{ .github.repository }}
+          mv $GITHUB_WORKSPACE/{{ .github.repository }} $(go env GOPATH)/src/github.com/{{ .github.repository }}
+          mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
-          cd $(go env GOPATH)/src/github.com/lifecycle-manager
+          cd $(go env GOPATH)/src/github.com/{{ .github.repository }}
           cd operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,12 +61,10 @@ jobs:
           wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
           chmod +x kyma-linux
           mv kyma-linux /usr/local/bin/kyma
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          cache: true
-          check-latest: true
+      - name: Set up kustomize V4
+        run: |
+          wget -qO - "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          mv kustomize /usr/local/bin/
 
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
-          cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          cd operator/config/manager
+          cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
 
       - name: Run Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-env:
-  MODULE_MANAGER: kyma-project/module-manager
 jobs:
   wait-for-img:
     name: "Wait for Image Build"
@@ -54,6 +52,9 @@ jobs:
     needs: [wait-for-img, kustomize]
     name: "Kyma CLI Integration"
     runs-on: ubuntu-latest
+    env:
+      MODULE_MANAGER: kyma-project/module-manager
+      LIFECYCLE_MANAGER: ${{ github.repository }}
     steps:
       - name: Set up k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
@@ -70,8 +71,8 @@ jobs:
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
         with:
-          repository: ${{ github.repository }}
-          path: ${{ github.repository }}
+          repository: ${{ env.LIFECYCLE_MANAGER }}
+          path: ${{ env.LIFECYCLE_MANAGER }}
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
@@ -80,8 +81,6 @@ jobs:
           ref: main
 
       - name: Move Repos to SRC
-        env:
-          LIFECYCLE_MANAGER: ${{ github.repository }}
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mv $GITHUB_WORKSPACE/{{ github.repository }} $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
@@ -91,7 +90,7 @@ jobs:
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
-          cd $(go env GOPATH)/src/github.com/{{ .github.repository }}
+          cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           cd operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,16 @@ jobs:
       - name: Run Deploy
         run: kyma alpha deploy --source=local
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          cache: true
+          go-version-file: 'tests/smoke/go.mod'
+          cache-dependency-path: 'tests/smoke/go.sum'
+
+      - name: Run Smoke Tests
+        run: cd tests/smoke && go test smoke_test.go -v -provision-type external
+
   smoke:
     needs: [wait-for-img, kustomize]
     name: "Smoke"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,18 +70,25 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
-          path: go/src/github.com/${{ github.repository }}
+          path: lifecycle-manager
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
           repository: kyma-project/module-manager
-          path: go/src/github.com/kyma-project/module-manager
+          path: module-manager
           ref: main
+
+      - name: Move Repos to SRC
+        run: |
+          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/lifecycle-manager
+          mv $GITHUB_WORKSPACE/lifecycle-manager $(go env GOPATH)/src/github.com/kyma-project/lifecycle-manager
+          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/module-manager
+          mv $GITHUB_WORKSPACE/module-manager $(go env GOPATH)/src/github.com/kyma-project/module-manager
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
-          cd $(go env GOPATH)/src/github.com/${{ github.repository }}
+          cd $(go env GOPATH)/src/github.com/lifecycle-manager
           cd operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}
-          path: $(go env GOPATH)/src/github.com/${{ github.repository }}
+          path: /go/src/github.com/${{ github.repository }}
+      - name: Checkout Module-Manager
+        uses: actions/checkout@v3
+        with:
+          repository: kyma-project/module-manager
+          path: /go/src/github.com/kyma-project/module-manager
+          ref: HEAD
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
@@ -78,13 +84,6 @@ jobs:
           cd $(go env GOPATH)/src/github.com/${{ github.repository }}
           cd operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
-
-      - name: Checkout Module-Manager
-        uses: actions/checkout@v3
-        with:
-          repository: kyma-project/module-manager
-          path: $(go env GOPATH)/src/github.com/kyma-project/module-manager
-          ref: HEAD
 
       - name: Run Deploy
         run: kyma alpha deploy --source=local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,11 +80,13 @@ jobs:
           ref: main
 
       - name: Move Repos to SRC
+        env:
+          LIFECYCLE_MANAGER: ${{ github.repository }}
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/{{ github.repository }}
-          mv $GITHUB_WORKSPACE/{{ github.repository }} $(go env GOPATH)/src/github.com/{{ github.repository }}
-          mkdir -p $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
-          mv $GITHUB_WORKSPACE/{{ env.MODULE_MANAGER }} $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
+          mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mv $GITHUB_WORKSPACE/{{ github.repository }} $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,16 @@ jobs:
           chmod +x kyma-linux
           mv kyma-linux /usr/local/bin/kyma
       - name: Run Provision
-        run: kyma provision k3d -p 8083:80@loadbalancer -p 8443:443@loadbalancer --timeout 1m --k3d-arg --no-rollback
+        env:
+          CLUSTER_NAME: "kyma"
+        run: |
+          kyma provision k3d \
+            -p 8083:80@loadbalancer \
+            -p 8443:443@loadbalancer \
+            --timeout 1m \
+            --k3d-arg --no-rollback \
+            --name $CLUSTER_NAME
+          k3d kubeconfig merge $CLUSTER_NAME -o $GITHUB_WORKSPACE/kubeconfig.yaml
       - name: Run Deploy
         run: kyma alpha deploy --source=local
       - name: Inject GOPATH into go Setup
@@ -103,7 +112,7 @@ jobs:
       - name: Run Smoke Tests
         run: |
           cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/tests/smoke
-          go test smoke_test.go -v -provision-type external
+          go test smoke_test.go -v -provision-type external --kubeconfig $GITHUB_WORKSPACE/kubeconfig.yaml
 
   smoke:
     needs: [wait-for-img, kustomize]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
             operator/dry-run/*.yaml
 
   cli-integration:
+    strategy:
+      matrix:
+        cli-stability: ["unstable"]
     needs: [wait-for-img, kustomize]
     name: "Kyma CLI Integration"
     runs-on: ubuntu-latest
@@ -86,7 +89,7 @@ jobs:
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
       - name: Set up CLI
         run: |
-          wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
+          wget -q https://storage.googleapis.com/kyma-cli-${{ matrix.cli-stability }}/kyma-linux
           chmod +x kyma-linux
           mv kyma-linux /usr/local/bin/kyma
       - name: Run Provision
@@ -107,6 +110,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
+          cache: true
           go-version-file: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.mod
           cache-dependency-path: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.sum
       - name: Run Smoke Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,10 @@ jobs:
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
           mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,8 @@ jobs:
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/{{ .github.repository }}
           mv $GITHUB_WORKSPACE/{{ .github.repository }} $(go env GOPATH)/src/github.com/{{ .github.repository }}
-          mkdir -p $(go env GOPATH)/src/github.com/${{ env.MODULE_MANAGER }}
-          mv $GITHUB_WORKSPACE/${{ env.MODULE_MANAGER }} $(go env GOPATH)/src/github.com/${{ env.MODULE_MANAGER }}
+          mkdir -p $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
+          mv $GITHUB_WORKSPACE/{{ env.MODULE_MANAGER }} $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,19 +72,21 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ env.LIFECYCLE_MANAGER }}
-          path: .
+          path: ${{ env.LIFECYCLE_MANAGER }}
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
           repository: ${{ env.MODULE_MANAGER }}
-          path: .
+          path: ${{ env.MODULE_MANAGER }}
           ref: main
 
       - name: Move Repos to SRC
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/
-          mv $GITHUB_WORKSPACE/* $(go env GOPATH)/src/github.com/kyma-project/
+          mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/lifecycle-manager $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          mv $GITHUB_WORKSPACE/$MODULE_MANAGER/module-manager $(go env GOPATH)/src/github.com/$MODULE_MANAGER
           ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Move Repos to SRC
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/
+          mkdir -p $(go env GOPATH)/src/github.com/kyma-project/
           mv $GITHUB_WORKSPACE/* $(go env GOPATH)/src/github.com/kyma-project/
           ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.mod
           cache-dependency-path: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.sum
       - name: Run Smoke Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Move Repos to SRC
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          mv $GITHUB_WORKSPACE/{{ github.repository }} $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
           mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
       MODULE_MANAGER: kyma-project/module-manager
       LIFECYCLE_MANAGER: ${{ github.repository }}
     steps:
-
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
         with:
@@ -66,7 +65,6 @@ jobs:
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/** $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/
-
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
@@ -77,7 +75,6 @@ jobs:
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
           mv $GITHUB_WORKSPACE/$MODULE_MANAGER/** $(go env GOPATH)/src/github.com/$MODULE_MANAGER/
-
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
@@ -85,30 +82,25 @@ jobs:
           mv kustomize /usr/local/bin/
           cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
-
       - name: Set up k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
-
       - name: Set up CLI
         run: |
           wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
           chmod +x kyma-linux
-          mv kyma-linux /usr/local/bin/kyma      
-
+          mv kyma-linux /usr/local/bin/kyma
       - name: Run Provision
         run: kyma provision k3d -p 8083:80@loadbalancer -p 8443:443@loadbalancer --timeout 1m --k3d-arg --no-rollback
-
       - name: Run Deploy
         run: kyma alpha deploy --source=local
-
       - name: Inject GOPATH into go Setup
         run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           cache: true
-          go-version-file: ${{ env.GOPATH }}/src/github.com/$LIFECYCLE_MANAGER/tests/smoke/go.mod
-          cache-dependency-path: ${{ env.GOPATH }}/src/github.com/$LIFECYCLE_MANAGER/tests/smoke/go.sum
+          go-version-file: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.mod
+          cache-dependency-path: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.sum
       - name: Run Smoke Tests
         run: |
           cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/tests/smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,46 +56,47 @@ jobs:
       MODULE_MANAGER: kyma-project/module-manager
       LIFECYCLE_MANAGER: ${{ github.repository }}
     steps:
-      - name: Set up k3d
-        run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
-      - name: Set up CLI
-        run: |
-          wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
-          chmod +x kyma-linux
-          mv kyma-linux /usr/local/bin/kyma
-      - name: Set up kustomize V4
-        run: |
-          wget -qO - "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          mv kustomize /usr/local/bin/
 
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
         with:
           repository: ${{ env.LIFECYCLE_MANAGER }}
           path: ${{ env.LIFECYCLE_MANAGER }}
+      - name: Move Lifecycle-Manager
+        run: |
+          mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/** $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/
+
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
           repository: ${{ env.MODULE_MANAGER }}
           path: ${{ env.MODULE_MANAGER }}
           ref: main
-
-      - name: Move Repos to SRC
+      - name: Move Module-Manager
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          ls $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER
-          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/** $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/
-          ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
-          ls $GITHUB_WORKSPACE/$MODULE_MANAGER
           mv $GITHUB_WORKSPACE/$MODULE_MANAGER/** $(go env GOPATH)/src/github.com/$MODULE_MANAGER/
-          ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image
         if: github.event_name == 'pull_request'
         run: |
+          wget -qO - "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          mv kustomize /usr/local/bin/
           cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/operator/config/manager
           kustomize edit set image controller="*:PR-${{ github.event.pull_request.number }}"
+
+      - name: Set up k3d
+        run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.6 bash
+
+      - name: Set up CLI
+        run: |
+          wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux
+          chmod +x kyma-linux
+          mv kyma-linux /usr/local/bin/kyma      
+
+      - name: Run Provision
+        run: kyma provision k3d
 
       - name: Run Deploy
         run: kyma alpha deploy --source=local

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,21 +72,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ${{ env.LIFECYCLE_MANAGER }}
-          path: ${{ env.LIFECYCLE_MANAGER }}
+          path: .
       - name: Checkout Module-Manager
         uses: actions/checkout@v3
         with:
           repository: ${{ env.MODULE_MANAGER }}
-          path: ${{ env.MODULE_MANAGER }}
+          path: .
           ref: main
 
       - name: Move Repos to SRC
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          mkdir -p $(go env GOPATH)/src/github.com/
+          mv $GITHUB_WORKSPACE/* $(go env GOPATH)/src/github.com/kyma-project/
           ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
-          mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
-          mv $GITHUB_WORKSPACE/$MODULE_MANAGER $(go env GOPATH)/src/github.com/$MODULE_MANAGER
           ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 
       - name: Override Kustomize Controller Image TAG in Pull Request to PR Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,15 +101,10 @@ jobs:
       - name: Run Deploy
         run: kyma alpha deploy --source=local
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          cache: true
-          go-version-file: 'tests/smoke/go.mod'
-          cache-dependency-path: 'tests/smoke/go.sum'
-
       - name: Run Smoke Tests
-        run: cd tests/smoke && go test smoke_test.go -v -provision-type external
+        run: |
+          cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/tests/smoke
+          go test smoke_test.go -v -provision-type external
 
   smoke:
     needs: [wait-for-img, kustomize]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,14 @@ jobs:
       - name: Run Deploy
         run: kyma alpha deploy --source=local
 
+      - name: Inject GOPATH into go Setup
+        run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          cache: true
+          go-version-file: ${{ env.GOPATH }}/src/github.com/$LIFECYCLE_MANAGER/tests/smoke/go.mod
+          cache-dependency-path: ${{ env.GOPATH }}/src/github.com/$LIFECYCLE_MANAGER/tests/smoke/go.sum
       - name: Run Smoke Tests
         run: |
           cd $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/tests/smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,9 +83,11 @@ jobs:
       - name: Move Repos to SRC
         run: |
           mkdir -p $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
+          ls $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER
           mv $GITHUB_WORKSPACE/$LIFECYCLE_MANAGER/** $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER/
           ls $(go env GOPATH)/src/github.com/$LIFECYCLE_MANAGER
           mkdir -p $(go env GOPATH)/src/github.com/$MODULE_MANAGER
+          ls $GITHUB_WORKSPACE/$MODULE_MANAGER
           mv $GITHUB_WORKSPACE/$MODULE_MANAGER/** $(go env GOPATH)/src/github.com/$MODULE_MANAGER/
           ls $(go env GOPATH)/src/github.com/$MODULE_MANAGER
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,10 +107,17 @@ jobs:
         run: kyma alpha deploy --source=local
       - name: Inject GOPATH into go Setup
         run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-cli-integration-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-cli-integration-
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          cache: true
           go-version-file: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.mod
           cache-dependency-path: ${{ env.GOPATH }}/src/github.com/${{ env.LIFECYCLE_MANAGER }}/tests/smoke/go.sum
       - name: Run Smoke Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,8 @@ jobs:
 
       - name: Move Repos to SRC
         run: |
-          mkdir -p $(go env GOPATH)/src/github.com/{{ .github.repository }}
-          mv $GITHUB_WORKSPACE/{{ .github.repository }} $(go env GOPATH)/src/github.com/{{ .github.repository }}
+          mkdir -p $(go env GOPATH)/src/github.com/{{ github.repository }}
+          mv $GITHUB_WORKSPACE/{{ github.repository }} $(go env GOPATH)/src/github.com/{{ github.repository }}
           mkdir -p $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
           mv $GITHUB_WORKSPACE/{{ env.MODULE_MANAGER }} $(go env GOPATH)/src/github.com/{{ env.MODULE_MANAGER }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           cache: true
-          go-version-file: 'operator/go.mod'
-          cache-dependency-path: 'operator/go.sum'
+          check-latest: true
 
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3


### PR DESCRIPTION
This adds the last necessary job for integration testing with Kyma CLI by providing a job that runs `kyma alpha deploy` for deploying the operators together, but with local sources as we edit the image to be from the PR instead