### PR TITLE
Fix broken links + Add some details

### DIFF
--- a/docs/developer/creating-test-environment.md
+++ b/docs/developer/creating-test-environment.md
@@ -36,18 +36,11 @@ To bundle your module image and operator, please refer to the detailed informati
 
 
    ```sh
-# single-cluster setup
    chmod 755 ./operator/config/samples/secret/k3d-secret-gen.sh
    ./operator/config/samples/secret/k3d-secret-gen.sh
    ```
 
-   ```sh
-# dual-cluster setup
-   chmod 755 ./operator/config/samples/secret/k3d-secret-gen.sh
-   ./operator/config/samples/secret/k3d-secret-gen.sh -d
-   ```
-
-   > _**NOTE:**_ In the **single-cluster setup**, adjust your contexts for applying the secret using KCP_CLUSTER_CTX and SKR_CLUSTER_CTX.
+   > _**NOTE:**_ In the **single-cluster setup**, adjust your contexts for applying the secret using `KCP_CLUSTER_CTX` and `SKR_CLUSTER_CTX` - both should point to the same cluster.
 
 4. To install the Module Manager CRDs, check out `https://github.com/kyma-project/module-manager`, navigate to the operator `cd operator`, and run `make install`.
 
@@ -82,7 +75,32 @@ To bundle your module image and operator, please refer to the detailed informati
       kubectl apply -f kyma.yaml
       ```
 
-   3. Check the progress of your Kyma installation; for example, with `kubectl get kyma -n kyma-system -ojsonpath={".items[0].status"} | yq -P`. You should get a result like this:
+   3. Check the progress of your Kyma installation with:
+      ```sh
+      kubectl get kyma -n kyma-system -ojsonpath={".items[0].status"} | yq -P
+      ```
+      You should get results like this:
+      ```yaml
+             conditions:
+               - lastTransitionTime: "2022-08-18T18:10:09Z"
+                 message: module is Ready
+                 reason: template
+                 status: "True"
+                 type: Ready
+             moduleInfos:
+               - moduleName: template
+                 name: templatekyma-sample
+                 namespace: kyma-system
+                 templateInfo:
+                   channel: stable
+                   generation: 1
+                   gvk:
+                     group: operator.kyma-project.io
+                     kind: Manifest
+                     version: v1alpha1
+             observedGeneration: 1
+             state: Ready
+             ```
 
 ### Verify installation
 

--- a/docs/developer/creating-test-environment.md
+++ b/docs/developer/creating-test-environment.md
@@ -18,7 +18,7 @@ You can choose between either a single-cluster or a two-cluster setup.
 
 ### Create module operator and bundle module
 
-To bundle your module image and operator, please refer to the detailed information inside [template-operator docs](../../samples/template-operator/README.md).
+To bundle your module image and operator, please refer to the detailed information inside [template-operator docs](../../samples/template-operator/README.md#bundling-and-installation).
 
 ### Install Kyma and run lifecycle-manager operator
 
@@ -32,19 +32,26 @@ To bundle your module image and operator, please refer to the detailed informati
 
 3. Create a Secret to access the cluster which acts as SKR:
 
-   Go to `https://github.com/kyma-project/lifecycle-manager` and run the following commands:
+   Go to `https://github.com/kyma-project/lifecycle-manager` and run the following commands, to create a secret and apply it to the KCP Cluster:
+
 
    ```sh
+# single-cluster setup
    chmod 755 ./operator/config/samples/secret/k3d-secret-gen.sh
    ./operator/config/samples/secret/k3d-secret-gen.sh
-   kubectl apply -f ./operator/config/samples/secret/skr-secret.yaml
    ```
 
-   > _**NOTE:**_ In the two-cluster setup, adjust your contexts for applying the secret using KCP_CLUSTER_CTX and SKR_CLUSTER_CTX.
+   ```sh
+# dual-cluster setup
+   chmod 755 ./operator/config/samples/secret/k3d-secret-gen.sh
+   ./operator/config/samples/secret/k3d-secret-gen.sh -d
+   ```
+
+   > _**NOTE:**_ In the **single-cluster setup**, adjust your contexts for applying the secret using KCP_CLUSTER_CTX and SKR_CLUSTER_CTX.
 
 4. To install the Module Manager CRDs, check out `https://github.com/kyma-project/module-manager`, navigate to the operator `cd operator`, and run `make install`.
 
-5. Run [module-manager](https://github.com/kyma-project/module-manager/operator) and [lifecycle-manager](https://github.com/kyma-project/lifecycle-manager/operator) in this order.
+5. Run [module-manager](https://github.com/kyma-project/module-manager/tree/main/operator) and [lifecycle-manager](https://github.com/kyma-project/lifecycle-manager/tree/main/operator) in this order.
    * local: run following commands against your cluster's kubeconfig
    ```makefile
     make install
@@ -63,7 +70,7 @@ To bundle your module image and operator, please refer to the detailed informati
 
     >_**NOTE:**_ for using Google Artifact Registry: if you use gcloud cli, make sure your local docker config (`~/.docker/config.json`) does not contains `gcloud` `credHelpers` entry, (e.g: `"europe-west3-docker.pkg.dev": "gcloud",`), otherwise this might cause authentication issue for module-manager while fetching remote oci image layer.
 
-   1. Make sure required module templates prepared as part of [Bundle your module](#bundle-your-module) are pushed to the KCP cluster. 
+   1. Make sure required module templates prepared as part of [Bundle your module](#create-module-operator-and-bundle-module) are pushed to the KCP cluster. 
 
    2. To create a request for Kyma installation of the module in `samples/template-operator` of the Lifecycle Manager, run:
 

--- a/operator/config/samples/secret/k3d-secret-gen.sh
+++ b/operator/config/samples/secret/k3d-secret-gen.sh
@@ -2,6 +2,7 @@
 : "${KCP_CLUSTER_CTX:=k3d-op-kcp}"
 : "${SKR_CLUSTER_CTX:=k3d-op-skr}"
 
+
 kubectl config use $SKR_CLUSTER_CTX
 
 echo "apiVersion: v1
@@ -19,4 +20,5 @@ data:
 kubectl config use $KCP_CLUSTER_CTX
 
 kubectl apply -f ./skr-secret.yaml
+
 rm ./skr-secret.yaml

--- a/operator/config/samples/secret/k3d-secret-gen.sh
+++ b/operator/config/samples/secret/k3d-secret-gen.sh
@@ -2,7 +2,6 @@
 : "${KCP_CLUSTER_CTX:=k3d-op-kcp}"
 : "${SKR_CLUSTER_CTX:=k3d-op-skr}"
 
-
 kubectl config use $SKR_CLUSTER_CTX
 
 echo "apiVersion: v1
@@ -20,5 +19,4 @@ data:
 kubectl config use $KCP_CLUSTER_CTX
 
 kubectl apply -f ./skr-secret.yaml
-
 rm ./skr-secret.yaml


### PR DESCRIPTION
This PR fixes some broken links in the documentation of the lifecycle-manager, plus it add a missing example