### PR TITLE
feat: introduce (remote) client cache to reduce remote reconciliation latency

### DIFF
--- a/operator/controllers/module_catalog_controller.go
+++ b/operator/controllers/module_catalog_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 
+	"github.com/kyma-project/lifecycle-manager/operator/pkg/remote"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -18,6 +19,7 @@ type ModuleCatalogReconciler struct {
 	client.Client
 	record.EventRecorder
 	RequeueIntervals
+	RemoteClientCache *remote.ClientCache
 }
 
 const (
@@ -31,7 +33,7 @@ const (
 func (r *ModuleCatalogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Catalog Sync loop starting for", "resource", req.NamespacedName.String())
-	catalogSync := catalog.NewSync(r.Client, r.EventRecorder, catalog.Settings{
+	catalogSync := catalog.NewSync(r.Client, r.EventRecorder, r.RemoteClientCache, catalog.Settings{
 		Namespace: req.Namespace,
 		Name:      CatalogName,
 	})

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -138,6 +138,9 @@ var _ = BeforeSuite(func() {
 		Failure: 1 * time.Second,
 		Waiting: 1 * time.Second,
 	}
+
+	remoteClientCache := remote.NewClientCache()
+
 	err = (&controllers.KymaReconciler{
 		Client:           k8sManager.GetClient(),
 		EventRecorder:    k8sManager.GetEventRecorderFor(operatorv1alpha1.OperatorName),
@@ -145,12 +148,14 @@ var _ = BeforeSuite(func() {
 		VerificationSettings: signature.VerificationSettings{
 			EnableVerification: false,
 		},
+		RemoteClientCache: remoteClientCache,
 	}).SetupWithManager(k8sManager, controller.Options{}, listenerAddr)
 	Expect(err).ToNot(HaveOccurred())
 	err = (&controllers.ModuleCatalogReconciler{
-		Client:           k8sManager.GetClient(),
-		EventRecorder:    k8sManager.GetEventRecorderFor(operatorv1alpha1.OperatorName),
-		RequeueIntervals: intervals,
+		Client:            k8sManager.GetClient(),
+		EventRecorder:     k8sManager.GetEventRecorderFor(operatorv1alpha1.OperatorName),
+		RequeueIntervals:  intervals,
+		RemoteClientCache: remoteClientCache,
 	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/operator/pkg/catalog/sync.go
+++ b/operator/pkg/catalog/sync.go
@@ -14,10 +14,11 @@ import (
 type Sync struct {
 	Catalog
 	record.EventRecorder
+	*remote.ClientCache
 }
 
-func NewSync(client client.Client, recorder record.EventRecorder, settings Settings) *Sync {
-	return &Sync{Catalog: New(client, settings), EventRecorder: recorder}
+func NewSync(client client.Client, recorder record.EventRecorder, cache *remote.ClientCache, settings Settings) *Sync {
+	return &Sync{Catalog: New(client, settings), EventRecorder: recorder, ClientCache: cache}
 }
 
 func (s *Sync) Cleanup(
@@ -51,7 +52,9 @@ func (s *Sync) syncRemote(
 	controlPlaneKyma *v1alpha1.Kyma,
 	moduleTemplateList *v1alpha1.ModuleTemplateList,
 ) error {
-	syncContext, err := remote.InitializeKymaSynchronizationContext(ctx, s.Catalog.Client(), controlPlaneKyma)
+	syncContext, err := remote.InitializeKymaSynchronizationContext(
+		ctx, s.Catalog.Client(), controlPlaneKyma, s.ClientCache,
+	)
 	if err != nil {
 		err = fmt.Errorf("catalog sync failed: %w", err)
 		s.Event(controlPlaneKyma, "Warning", "CatalogSyncError", err.Error())

--- a/operator/pkg/remote/client_cache.go
+++ b/operator/pkg/remote/client_cache.go
@@ -1,0 +1,39 @@
+package remote
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ClientCacheID client.ObjectKey
+
+func NewClientCache() *ClientCache {
+	return &ClientCache{internal: &sync.Map{}}
+}
+
+// ClientCache is an optimized concurrency-safe in-memory cache based on sync.Map.
+// It is mainly written so that a program that needs multiple Clients in different goroutines
+// can access them without recreation. It does this by holding a concurrency-safe reference map
+// based on an access key (ClientCacheID). It is not optimized for multi-write scenarios, but rather
+// append-only cases where clients are expected to live longer than their calling goroutine.
+//
+// It thus borrows the same optimizations from it:
+// The ClientCache type is optimized for when the entry for a given
+// key is only ever written once but read many times, as in caches that only grow.
+type ClientCache struct {
+	internal *sync.Map
+}
+
+func (cache *ClientCache) Get(key ClientCacheID) client.Client {
+	value, ok := cache.internal.Load(key)
+	if !ok {
+		return nil
+	}
+
+	return value.(client.Client)
+}
+
+func (cache *ClientCache) Set(key ClientCacheID, value client.Client) {
+	cache.internal.Store(key, value)
+}


### PR DESCRIPTION
ClientCache is an optimized concurrency-safe in-memory cache based on sync.Map. It is mainly written so that a program that needs multiple Clients in different goroutines can access them without recreation. It does this by holding a concurrency-safe reference map based on an access key (ClientCacheID). It is not optimized for multi-write scenarios, but rather append-only cases where clients are expected to live longer than their calling goroutine.

It thus borrows the same optimizations from it: The ClientCache type is optimized for when the entry for a given key is only ever written once but read many times, as in caches that only grow.