### PR TITLE
feat: include pprof tracing into lifecycle-manager by flag

### DIFF
--- a/operator/config/load_test/kustomization.yaml
+++ b/operator/config/load_test/kustomization.yaml
@@ -63,6 +63,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --enable-module-catalog=false
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --pprof=true
     target:
       kind: Deployment
 

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -146,7 +146,7 @@ func (r *KymaReconciler) synchronizeRemote(ctx context.Context, kyma *v1alpha1.K
 	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx)
 	if err != nil {
 		return r.UpdateStatusFromErr(ctx, kyma, v1alpha1.StateError,
-			fmt.Errorf("could not fetch kyma updating remote kyma: %w", err))
+			fmt.Errorf("could not create or fetch remote kyma: %w", err))
 	}
 	if err := syncContext.SynchronizeRemoteKyma(ctx, remoteKyma); err != nil {
 		return r.UpdateStatusFromErr(ctx, kyma, v1alpha1.StateError,

--- a/operator/main.go
+++ b/operator/main.go
@@ -250,7 +250,7 @@ func defineFlagVar() *FlagVar {
 	flag.StringVar(&flagVar.skrWebhookCPULimits, "skr-webhook-cpu-limits", "0.1",
 		"The resources.limits.cpu for skr webhook.")
 	flag.BoolVar(&flagVar.pprof, "pprof", false,
-		"Wether to start up a pprof server.")
+		"Whether to start up a pprof server.")
 	flag.DurationVar(&flagVar.pprofServerTimeout, "pprof-server-timeout", defaultPprofServerTimeout,
 		"Timeout of Read / Write for the pprof server.")
 	return flagVar


### PR DESCRIPTION
Introduces a pprof listener endpoint for tracing memory and CPU consumption to use in load tests or debugging