### PR TITLE
chore: configurable rate limit adjustments and increased perf test limits for >10k Clusters

### DIFF
--- a/operator/config/load_test/patches/adjust_resources_in_deployment.yaml
+++ b/operator/config/load_test/patches/adjust_resources_in_deployment.yaml
@@ -12,8 +12,8 @@ spec:
         - name: manager
           resources:
             limits:
-              cpu: 4000m
-              memory: 6000Mi
+              cpu: 6000m
+              memory: 20000Mi
             requests:
               cpu: 1000m
               memory: 2000Mi

--- a/operator/main.go
+++ b/operator/main.go
@@ -234,7 +234,7 @@ func defineFlagVar() *FlagVar {
 			"if the operator decides that it needs to wait for a certain state to update before it can proceed "+
 			"(e.g. because of pending finalizers in the deletion process)")
 	flag.Float64Var(&flagVar.clientQPS, "k8s-client-qps", defaultClientQPS, "kubernetes client QPS")
-	flag.IntVar(&flagVar.clientBurst, "k8s-client-rateLimiterBurstDefault", defaultClientBurst, "kubernetes client Burst")
+	flag.IntVar(&flagVar.clientBurst, "k8s-client-burs", defaultClientBurst, "kubernetes client Burst")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-key-file", "",
 		"This verification key is used to verify modules against their signature")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-signature-names",

--- a/operator/main.go
+++ b/operator/main.go
@@ -257,7 +257,7 @@ func defineFlagVar() *FlagVar {
 		"Whether to start up a pprof server.")
 	flag.DurationVar(&flagVar.pprofServerTimeout, "pprof-server-timeout", defaultPprofServerTimeout,
 		"Timeout of Read / Write for the pprof server.")
-	flag.IntVar(&flagVar.rateLimiterBurst, "rate-limiter-rateLimiterBurstDefault", rateLimiterBurstDefault,
+	flag.IntVar(&flagVar.rateLimiterBurst, "rate-limiter-burst", rateLimiterBurstDefault,
 		"Indicates the rateLimiterBurstDefault value for the bucket rate limiter.")
 	flag.IntVar(&flagVar.rateLimiterFrequency, "rate-limiter-frequency", rateLimiterFrequencyDefault,
 		"Indicates the bucket rate limiter frequency, signifying no. of events per second.")

--- a/operator/main.go
+++ b/operator/main.go
@@ -234,7 +234,7 @@ func defineFlagVar() *FlagVar {
 			"if the operator decides that it needs to wait for a certain state to update before it can proceed "+
 			"(e.g. because of pending finalizers in the deletion process)")
 	flag.Float64Var(&flagVar.clientQPS, "k8s-client-qps", defaultClientQPS, "kubernetes client QPS")
-	flag.IntVar(&flagVar.clientBurst, "k8s-client-burs", defaultClientBurst, "kubernetes client Burst")
+	flag.IntVar(&flagVar.clientBurst, "k8s-client-burst", defaultClientBurst, "kubernetes client Burst")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-key-file", "",
 		"This verification key is used to verify modules against their signature")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-signature-names",

--- a/operator/main.go
+++ b/operator/main.go
@@ -53,10 +53,10 @@ import (
 )
 
 const (
-	baseDelay                     = 100 * time.Millisecond
-	maxDelay                      = 1000 * time.Second
-	limit                         = rate.Limit(30)
-	burst                         = 200
+	failureBaseDelayDefault       = 100 * time.Millisecond
+	failureMaxDelayDefault        = 1000 * time.Second
+	rateLimiterFrequencyDefault   = 30
+	rateLimiterBurstDefault       = 200
 	port                          = 9443
 	defaultRequeueSuccessInterval = 20 * time.Second
 	defaultRequeueFailureInterval = 10 * time.Second
@@ -98,6 +98,8 @@ type FlagVar struct {
 	pprof                                                                  bool
 	pprofAddr                                                              string
 	pprofServerTimeout                                                     time.Duration
+	failureBaseDelay, failureMaxDelay                                      time.Duration
+	rateLimiterBurst, rateLimiterFrequency                                 int
 }
 
 func main() {
@@ -166,8 +168,10 @@ func setupManager(flagVar *FlagVar, newCacheFunc cache.NewCacheFunc, scheme *run
 	}
 	options := controller.Options{
 		RateLimiter: workqueue.NewMaxOfRateLimiter(
-			workqueue.NewItemExponentialFailureRateLimiter(baseDelay, maxDelay),
-			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(limit, burst)}),
+			workqueue.NewItemExponentialFailureRateLimiter(flagVar.failureBaseDelay, flagVar.failureMaxDelay),
+			&workqueue.BucketRateLimiter{
+				Limiter: rate.NewLimiter(rate.Limit(flagVar.rateLimiterFrequency), flagVar.rateLimiterBurst),
+			}),
 		MaxConcurrentReconciles: flagVar.maxConcurrentReconciles,
 	}
 
@@ -230,7 +234,7 @@ func defineFlagVar() *FlagVar {
 			"if the operator decides that it needs to wait for a certain state to update before it can proceed "+
 			"(e.g. because of pending finalizers in the deletion process)")
 	flag.Float64Var(&flagVar.clientQPS, "k8s-client-qps", defaultClientQPS, "kubernetes client QPS")
-	flag.IntVar(&flagVar.clientBurst, "k8s-client-burst", defaultClientBurst, "kubernetes client Burst")
+	flag.IntVar(&flagVar.clientBurst, "k8s-client-rateLimiterBurstDefault", defaultClientBurst, "kubernetes client Burst")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-key-file", "",
 		"This verification key is used to verify modules against their signature")
 	flag.StringVar(&flagVar.moduleVerificationKeyFilePath, "module-verification-signature-names",
@@ -253,6 +257,14 @@ func defineFlagVar() *FlagVar {
 		"Whether to start up a pprof server.")
 	flag.DurationVar(&flagVar.pprofServerTimeout, "pprof-server-timeout", defaultPprofServerTimeout,
 		"Timeout of Read / Write for the pprof server.")
+	flag.IntVar(&flagVar.rateLimiterBurst, "rate-limiter-rateLimiterBurstDefault", rateLimiterBurstDefault,
+		"Indicates the rateLimiterBurstDefault value for the bucket rate limiter.")
+	flag.IntVar(&flagVar.rateLimiterFrequency, "rate-limiter-frequency", rateLimiterFrequencyDefault,
+		"Indicates the bucket rate limiter frequency, signifying no. of events per second.")
+	flag.DurationVar(&flagVar.failureBaseDelay, "failure-base-delay", failureBaseDelayDefault,
+		"Indicates the failure base delay in seconds for rate limiter.")
+	flag.DurationVar(&flagVar.failureMaxDelay, "failure-max-delay", failureMaxDelayDefault,
+		"Indicates the failure max delay in seconds")
 	return flagVar
 }
 


### PR DESCRIPTION
This introduce 4 flags to configure our burst/bucket client rate limiting in lifecycle manager dynamically and also increases performance test targets to achive >10k cluster scalability