### PR TITLE
fix: unsafe decoder for descriptor after webhook

### DIFF
--- a/operator/api/v1alpha1/codec/unsafe/codec.go
+++ b/operator/api/v1alpha1/codec/unsafe/codec.go
@@ -1,0 +1,33 @@
+package unsafe
+
+import (
+	"encoding/json"
+
+	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+// DecodeV2 decodes a component into the given object.
+// DecodeV2 is much simpler than the library decode to allow for much faster decoding
+// it does not use reflection for obj analysis, by default does not allow validation and json schema checks
+// also it does not make use of the kubernetes yaml package internal yaml to json conversion
+// it is meant to be used inside controllers that already have validation running safely within their webhooks
+// and can assume valid state of an object during reconciliation
+// Because DecodeV2 does not need to introspect the metadata of the descriptor, it does not need to
+// call an explicit Unmarshal on the metadata twice for Version Interpretation.
+func DecodeV2(data []byte, obj *v2.ComponentDescriptor) error {
+	if err := json.Unmarshal(data, obj); err != nil {
+		return err
+	}
+
+	return v2.DefaultComponent(obj)
+}
+
+// EncodeV2 encodes a component or component list into the given object.
+// EncodeV2 is much simpler than the library version to allow for much faster encoding.
+func EncodeV2(obj *v2.ComponentDescriptor) ([]byte, error) {
+	obj.Metadata.Version = v2.SchemaVersion
+	if err := v2.DefaultComponent(obj); err != nil {
+		return nil, err
+	}
+	return json.Marshal(obj)
+}

--- a/operator/api/v1alpha1/kyma_types.go
+++ b/operator/api/v1alpha1/kyma_types.go
@@ -193,6 +193,11 @@ type ModuleStatus struct {
 	// ModuleName is the unique identifier of the module.
 	ModuleName string `json:"moduleName"`
 
+	// Generation tracks the active Generation of the Module. In case the tracked Module spec changes,
+	// the new Generation will differ from the one tracked in the cluster and thus trigger a reconciliation
+	// based on the original content of ModuleTemplate
+	Generation int64 `json:"generation,omitempty"`
+
 	// It contains information about the last parsed ModuleTemplate in Context of the Installation.
 	// This will update when Channel or the ModuleTemplate is changed.
 	// +optional
@@ -212,7 +217,7 @@ type TemplateInfo struct {
 	// Namespace is the namespace of the template
 	Namespace string `json:"namespace"`
 
-	// Generation tracks the active Generation of the ModuleTemplate. In Case it changes, the new Generation will differ
+	// Generation tracks the active Generation of the ModuleTemplate. In case it changes, the new Generation will differ
 	// from the one tracked in TemplateInfo and thus trigger a new reconciliation with a newly parser ModuleTemplate
 	Generation int64 `json:"generation,omitempty"`
 
@@ -376,19 +381,17 @@ func (kyma *Kyma) ContainsCondition(conditionType KymaConditionType,
 	return false
 }
 
-var ErrTemplateNotFound = errors.New("template not found")
+var ErrModuleStatusNotFound = errors.New("module status not found")
 
-func (kyma *Kyma) GetTemplateInfoByModuleName(
-	moduleName string,
-) (*TemplateInfo, error) {
+func (kyma *Kyma) GetModuleStatusByModuleName(moduleName string) (*ModuleStatus, error) {
 	for i := range kyma.Status.ModuleStatus {
 		moduleStatus := &kyma.Status.ModuleStatus[i]
 		if moduleStatus.ModuleName == moduleName {
-			return &moduleStatus.TemplateInfo, nil
+			return moduleStatus, nil
 		}
 	}
 	// should not happen
-	return nil, ErrTemplateNotFound
+	return nil, ErrModuleStatusNotFound
 }
 
 func IsValidState(state string) bool {

--- a/operator/api/v1alpha1/webhook_crd_test.go
+++ b/operator/api/v1alpha1/webhook_crd_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Webhook ValidationCreate Strict", func() {
 		Expect(k8sClient.Create(webhookServerContext, template)).Should(Succeed())
 
 		Expect(template.Spec.ModifyDescriptor(v1alpha1.ModifyDescriptorVersion(func(version *semver.Version) string {
-			return fmt.Sprintf("v%v.%v.%v", version.Major(), version.Minor(), version.Patch()-1)
+			return fmt.Sprintf("%v.%v.%v", version.Major(), version.Minor(), version.Patch()-1)
 		}))).ToNot(HaveOccurred())
 
 		err = k8sClient.Update(webhookServerContext, template)

--- a/operator/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/operator/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -209,6 +209,13 @@ spec:
                   module
                 items:
                   properties:
+                    generation:
+                      description: Generation tracks the active Generation of the
+                        Module. In case the tracked Module spec changes, the new Generation
+                        will differ from the one tracked in the cluster and thus trigger
+                        a reconciliation based on the original content of ModuleTemplate
+                      format: int64
+                      type: integer
                     moduleName:
                       description: ModuleName is the unique identifier of the module.
                       type: string
@@ -244,7 +251,7 @@ spec:
                           type: string
                         generation:
                           description: Generation tracks the active Generation of
-                            the ModuleTemplate. In Case it changes, the new Generation
+                            the ModuleTemplate. In case it changes, the new Generation
                             will differ from the one tracked in TemplateInfo and thus
                             trigger a new reconciliation with a newly parser ModuleTemplate
                           format: int64

--- a/operator/config/load_test/kustomization.yaml
+++ b/operator/config/load_test/kustomization.yaml
@@ -53,7 +53,7 @@ patches:
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --max-concurrent-reconciles=50
+        value: --max-concurrent-reconciles=100
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --rate-limiter-burst=2000
@@ -68,7 +68,10 @@ patches:
         value: --skr-webhook-cpu-limits=1000m
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --pprof=true
+        value: --pprof=true      
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --cache-sync-timeout=4m
     target:
       kind: Deployment
 

--- a/operator/config/watcher/kustomization.yaml
+++ b/operator/config/watcher/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook      
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --requeue-success-interval=20m     
+        value: --requeue-success-interval=10m     
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --requeue-waiting-interval=5s      

--- a/operator/controllers/kyma_controller_helper_test.go
+++ b/operator/controllers/kyma_controller_helper_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kyma-project/lifecycle-manager/operator/api/v1alpha1"
-	sampleCRDv1alpha1 "github.com/kyma-project/lifecycle-manager/operator/config/samples/component-integration-installed/crd/v1alpha1" //nolint:lll
+	sampleCRDv1alpha1 "github.com/kyma-project/lifecycle-manager/operator/config/samples/component-integration-installed/crd/v1alpha1"
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/module/common"
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/test"
 	"github.com/kyma-project/lifecycle-manager/operator/pkg/watch"

--- a/operator/controllers/kyma_controller_helper_test.go
+++ b/operator/controllers/kyma_controller_helper_test.go
@@ -274,7 +274,7 @@ func ModuleTemplatesLabelsCountMatch(
 				return err
 			}
 
-			descriptor, err := template.Spec.GetDescriptor()
+			descriptor, err := template.Spec.GetUnsafeDescriptor()
 			if err != nil {
 				return err
 			}

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gardener/component-spec/bindings-go v0.0.70
 	github.com/go-logr/logr v1.2.3
-	github.com/imdario/mergo v0.3.13
 	github.com/kyma-project/module-manager/operator v0.0.0-20221017152046-7690d9d91ca4
 	github.com/kyma-project/runtime-watcher/listener v0.0.0-20221006112208-0dd54057307c
 	github.com/onsi/ginkgo/v2 v2.1.6
@@ -82,6 +81,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/iancoleman/orderedmap v0.2.0 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/invopop/jsonschema v0.5.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect

--- a/operator/main.go
+++ b/operator/main.go
@@ -65,6 +65,7 @@ const (
 	defaultClientQPS              = 150
 	defaultClientBurst            = 150
 	defaultPprofServerTimeout     = 90 * time.Second
+	defaultCacheSyncTimeout       = 2 * time.Minute
 )
 
 var (
@@ -101,6 +102,7 @@ type FlagVar struct {
 	pprofServerTimeout                                                     time.Duration
 	failureBaseDelay, failureMaxDelay                                      time.Duration
 	rateLimiterBurst, rateLimiterFrequency                                 int
+	cacheSyncTimeout                                                       time.Duration
 }
 
 func main() {
@@ -175,6 +177,7 @@ func setupManager(flagVar *FlagVar, newCacheFunc cache.NewCacheFunc, scheme *run
 				Limiter: rate.NewLimiter(rate.Limit(flagVar.rateLimiterFrequency), flagVar.rateLimiterBurst),
 			}),
 		MaxConcurrentReconciles: flagVar.maxConcurrentReconciles,
+		CacheSyncTimeout:        flagVar.cacheSyncTimeout,
 	}
 
 	remoteClientCache := remote.NewClientCache()
@@ -279,6 +282,8 @@ func defineFlagVar() *FlagVar {
 		"Indicates the failure base delay in seconds for rate limiter.")
 	flag.DurationVar(&flagVar.failureMaxDelay, "failure-max-delay", failureMaxDelayDefault,
 		"Indicates the failure max delay in seconds")
+	flag.DurationVar(&flagVar.cacheSyncTimeout, "cache-sync-timeout", defaultCacheSyncTimeout,
+		"Indicates the cache sync timeout in seconds")
 	return flagVar
 }
 

--- a/operator/pkg/channel/lookup.go
+++ b/operator/pkg/channel/lookup.go
@@ -88,7 +88,7 @@ func CheckForOutdatedTemplate(
 	if moduleTemplate.Spec.Channel != moduleStatus.TemplateInfo.Channel {
 		checkLog.Info("outdated ModuleTemplate: channel skew")
 
-		descriptor, err := moduleTemplate.Spec.GetDescriptor()
+		descriptor, err := moduleTemplate.Spec.GetUnsafeDescriptor()
 		if err != nil {
 			checkLog.Error(err, "could not handle channel skew as descriptor from template cannot be fetched")
 			return

--- a/operator/pkg/module/common/module.go
+++ b/operator/pkg/module/common/module.go
@@ -64,6 +64,7 @@ func (m *Module) UpdateStatusAndReferencesFromUnstructured(unstructured *manifes
 	m.Status = unstructured.Status
 	m.SetResourceVersion(unstructured.GetResourceVersion())
 	m.SetOwnerReferences(unstructured.GetOwnerReferences())
+	m.SetGeneration(unstructured.GetGeneration())
 }
 
 func (m *Module) ContainsExpectedOwnerReference(ownerName string) bool {

--- a/operator/pkg/module/common/module.go
+++ b/operator/pkg/module/common/module.go
@@ -51,9 +51,11 @@ func (m *Module) ApplyLabels(
 	m.SetLabels(lbls)
 }
 
-func (m *Module) StateMismatchedWithTemplateInfo(info *v1alpha1.TemplateInfo) bool {
-	return info.Generation != m.Template.GetGeneration() ||
-		info.Channel != m.Template.Spec.Channel
+func (m *Module) StateMismatchedWithModuleStatus(moduleStatus *v1alpha1.ModuleStatus) bool {
+	templateStatusMismatch := m.TemplateOutdated &&
+		(moduleStatus.TemplateInfo.Generation != m.Template.GetGeneration() ||
+			moduleStatus.TemplateInfo.Channel != m.Template.Spec.Channel)
+	return templateStatusMismatch || moduleStatus.Generation != m.GetGeneration()
 }
 
 // UpdateStatusAndReferencesFromUnstructured updates the module with necessary information (status, ownerReference) from

--- a/operator/pkg/module/parse/template_to_module.go
+++ b/operator/pkg/module/parse/template_to_module.go
@@ -91,7 +91,7 @@ func NewManifestFromTemplate(
 	var layers img.Layers
 	var err error
 
-	if descriptor, err = template.Spec.GetDescriptor(); err != nil {
+	if descriptor, err = template.Spec.GetUnsafeDescriptor(); err != nil {
 		return nil, fmt.Errorf("could not decode the descriptor: %w", err)
 	}
 

--- a/operator/pkg/module/sync/runner_impl.go
+++ b/operator/pkg/module/sync/runner_impl.go
@@ -60,14 +60,12 @@ func (r *runnerImpl) Sync(ctx context.Context, kyma *v1alpha1.Kyma,
 
 		module.UpdateStatusAndReferencesFromUnstructured(manifest)
 
-		if module.TemplateOutdated {
-			templateInfo, err := kyma.GetTemplateInfoByModuleName(name)
-			if err != nil {
-				return false, err
-			}
-			if module.StateMismatchedWithTemplateInfo(templateInfo) {
-				return update()
-			}
+		moduleStatus, err := kyma.GetModuleStatusByModuleName(name)
+		if err != nil {
+			return false, err
+		}
+		if module.StateMismatchedWithModuleStatus(moduleStatus) {
+			return update()
 		}
 	}
 
@@ -138,15 +136,16 @@ func (r *runnerImpl) updateModuleStatusFromExistingModules(modules common.Module
 			ModuleName: module.Name,
 			Name:       module.Manifest.GetName(),
 			Namespace:  module.Manifest.GetNamespace(),
+			Generation: module.Manifest.GetGeneration(),
 			TemplateInfo: v1alpha1.TemplateInfo{
 				Name:       module.Template.Name,
 				Namespace:  module.Template.Namespace,
 				Channel:    module.Template.Spec.Channel,
 				Generation: module.Template.Generation,
 				GroupVersionKind: metav1.GroupVersionKind{
-					Group:   module.GroupVersionKind().Group,
-					Version: module.GroupVersionKind().Version,
-					Kind:    module.GroupVersionKind().Kind,
+					Group:   manifestV1alpha1.GroupVersionKind.Group,
+					Version: manifestV1alpha1.GroupVersionKind.Version,
+					Kind:    manifestV1alpha1.GroupVersionKind.Kind,
 				},
 				Version: descriptor.Version,
 			},

--- a/operator/pkg/module/sync/runner_impl.go
+++ b/operator/pkg/module/sync/runner_impl.go
@@ -133,7 +133,7 @@ func (r *runnerImpl) updateModuleStatusFromExistingModules(modules common.Module
 ) bool {
 	updateRequired := false
 	for _, module := range modules {
-		descriptor, _ := module.Template.Spec.GetDescriptor()
+		descriptor, _ := module.Template.Spec.GetUnsafeDescriptor()
 		latestModuleStatus := v1alpha1.ModuleStatus{
 			ModuleName: module.Name,
 			Name:       module.Manifest.GetName(),

--- a/operator/pkg/module/sync/runner_impl.go
+++ b/operator/pkg/module/sync/runner_impl.go
@@ -29,7 +29,8 @@ func (r *runnerImpl) Sync(ctx context.Context, kyma *v1alpha1.Kyma,
 	modules common.Modules,
 ) (bool, error) {
 	baseLogger := log.FromContext(ctx).WithName(client.ObjectKey{Name: kyma.Name, Namespace: kyma.Namespace}.String())
-	for name, module := range modules {
+	for name := range modules {
+		module := modules[name]
 		logger := module.Logger(baseLogger)
 
 		create := func() (bool, error) {


### PR DESCRIPTION
Introduces an unsafe OCM Decoder as controller-runtime does not have inbuilt decoding capabilities of runtime.RawExtension. This circumvents the needs for a cache. Per Reconcile Loop decode will still be called only once. If this still proves to be too much overhead (currently about 40% of reconcile loop, other 40% are spent on reconciling the remote Kyma and 20% are spent on the actual reconciliation loop), we should introduce an explicit generation-based cache in the controller.