### PR TITLE
Fix catalog sync gen mismatch by always applying all ModuleTemplates irrespective of generation

### DIFF
--- a/operator/api/v1alpha1/operator_annotations.go
+++ b/operator/api/v1alpha1/operator_annotations.go
@@ -1,7 +1,5 @@
 package v1alpha1
 
 const (
-	LastSync                       = OperatorPrefix + Separator + "last-sync"
-	LastSyncGenerationControlPlane = OperatorPrefix + Separator + "last-sync-gen-control-plane"
-	LastSyncGenerationRuntime      = OperatorPrefix + Separator + "last-sync-gen-runtime"
+	LastSync = OperatorPrefix + Separator + "last-sync"
 )

--- a/operator/controllers/kyma_controller_helper_test.go
+++ b/operator/controllers/kyma_controller_helper_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"strconv"
 
 	ocm "github.com/gardener/component-spec/bindings-go/apis/v2"
 	. "github.com/onsi/ginkgo/v2"
@@ -233,29 +232,6 @@ func ModuleTemplatesExist(clnt client.Client, kyma *v1alpha1.Kyma) func() error 
 		}
 
 		return nil
-	}
-}
-
-func ModuleTemplatesLastSyncGenMatches(clnt client.Client, kyma *v1alpha1.Kyma) func() bool {
-	return func() bool {
-		for _, module := range kyma.Spec.Modules {
-			template, err := test.ModuleTemplateFactory(module, unstructured.Unstructured{})
-			if err != nil {
-				return false
-			}
-			if err := clnt.Get(ctx, client.ObjectKeyFromObject(template), template); err != nil {
-				return false
-			}
-			if template.GetAnnotations() == nil {
-				return false
-			}
-			if strconv.FormatInt(template.GetGeneration(), 10) !=
-				template.GetAnnotations()[v1alpha1.LastSyncGenerationRuntime] {
-				return false
-			}
-		}
-
-		return true
 	}
 }
 

--- a/operator/controllers/kyma_controller_remote_sync_test.go
+++ b/operator/controllers/kyma_controller_remote_sync_test.go
@@ -106,6 +106,5 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 		By("verifying the discovered override and checking the resetted label")
 		Eventually(ModuleTemplatesLabelsCountMatch(runtimeClient, kyma, 0), Timeout, Interval).Should(Succeed())
-		Eventually(ModuleTemplatesLastSyncGenMatches(runtimeClient, kyma), Timeout, Interval).Should(BeTrue())
 	})
 })

--- a/operator/pkg/catalog/remote_catalog.go
+++ b/operator/pkg/catalog/remote_catalog.go
@@ -115,7 +115,7 @@ func (*RemoteCatalog) CalculateDiffs(
 ) ([]*v1alpha1.ModuleTemplate, []*v1alpha1.ModuleTemplate) {
 	// these are various ModuleTemplate references which we will either have to create, update or delete from
 	// the remote
-	var diffToApply []*v1alpha1.ModuleTemplate
+	diffToApply := make([]*v1alpha1.ModuleTemplate, 0, len(runtimeList.Items))
 	var diffToDelete []*v1alpha1.ModuleTemplate
 
 	// now lets start using two frequency maps to discover diffs

--- a/operator/pkg/catalog/remote_catalog.go
+++ b/operator/pkg/catalog/remote_catalog.go
@@ -133,8 +133,7 @@ func (*RemoteCatalog) CalculateDiffs(
 		// if the controlPlane Template does not exist in the remote, we already know we need to create it
 		// in the runtime
 		if _, exists := existingOnRemote[controlPlane.Namespace+controlPlane.Name]; !exists {
-			prepareControlPlaneTemplateForRuntime(controlPlane)
-
+			prepareForSSA(controlPlane)
 			diffToApply = append(diffToApply, controlPlane)
 		}
 	}
@@ -148,20 +147,17 @@ func (*RemoteCatalog) CalculateDiffs(
 			diffToDelete = append(diffToDelete, remote)
 			continue
 		}
-		remote.ObjectMeta.SetManagedFields([]metav1.ManagedFieldsEntry{})
-
+		prepareForSSA(remote)
 		(&controlPlaneList.Items[controlPlaneIndex]).Spec.DeepCopyInto(&remote.Spec)
 		diffToApply = append(diffToApply, remote)
 	}
 	return diffToApply, diffToDelete
 }
 
-func prepareControlPlaneTemplateForRuntime(controlPlane *v1alpha1.ModuleTemplate) {
-	// we reset resource version and uid as we want to create new objects from control Plane diffs
-	controlPlane.SetResourceVersion("")
-	controlPlane.SetUID("")
-
-	controlPlane.ObjectMeta.SetManagedFields([]metav1.ManagedFieldsEntry{})
+func prepareForSSA(moduleTemplate *v1alpha1.ModuleTemplate) {
+	moduleTemplate.SetResourceVersion("")
+	moduleTemplate.SetUID("")
+	moduleTemplate.SetManagedFields([]metav1.ManagedFieldsEntry{})
 }
 
 func (c *RemoteCatalog) Delete(


### PR DESCRIPTION
This fixes a malbehaving implementation in the catalog sync that was trying to sync moduletemplates based on a label mismatch with generation. As this implementation is based on the assumption that generation incrementations can be precomputed easily (which they cannot, they have to be supported by a hash algorithm for the spec), we want to test wether we are okay with always applying all ModuleTemplates instead. In this scenario, we also calculate a diff, but always apply all ModuleTemplates instead of only applying when there is a label mismatch with the discovered generation.