### PR TITLE
Fix namespace sync by enforcing creation of the namespace and using this in catalog sync for module-templates

### DIFF
--- a/api/v1alpha1/operator_labels.go
+++ b/api/v1alpha1/operator_labels.go
@@ -10,14 +10,19 @@ const (
 	Separator      = "/"
 	ControllerName = OperatorPrefix + Separator + "controller-name"
 	ChannelLabel   = OperatorPrefix + Separator + "channel"
-	ManagedBy      = OperatorPrefix + Separator + "managed-by"
-	Finalizer      = OperatorPrefix + Separator + string(KymaKind)
-	KymaName       = OperatorPrefix + Separator + "kyma-name"
-	Signature      = OperatorPrefix + Separator + "signature"
-	ModuleName     = OperatorPrefix + Separator + "module-name"
-	OperatorName   = "lifecycle-manager"
-	OwnedByLabel   = OperatorPrefix + Separator + "owned-by"
-	OwnedByFormat  = "%s__%s"
+	// ManagedBy defines the controller managing the resource.
+	ManagedBy    = OperatorPrefix + Separator + "managed-by"
+	Finalizer    = OperatorPrefix + Separator + string(KymaKind)
+	KymaName     = OperatorPrefix + Separator + "kyma-name"
+	Signature    = OperatorPrefix + Separator + "signature"
+	ModuleName   = OperatorPrefix + Separator + "module-name"
+	OperatorName = "lifecycle-manager"
+	// OwnedByLabel defines the resource managing the resource. Differing from ManagedBy in that it does not reference
+	// controllers.
+	OwnedByLabel  = OperatorPrefix + Separator + "owned-by"
+	OwnedByFormat = "%s__%s"
+	// WatchedByLabel defines a redirect to a controller that should be getting a notification
+	// if this resource is changed.
 	WatchedByLabel = OperatorPrefix + Separator + "watched-by"
 )
 

--- a/api/v1alpha1/watcher_types.go
+++ b/api/v1alpha1/watcher_types.go
@@ -20,8 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const ManagedBylabel = "operator.kyma-project.io/managed-by"
-
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // WatcherSpec defines the desired state of Watcher.
@@ -158,7 +156,7 @@ func (w *Watcher) GetModuleName() string {
 	if w.Labels == nil {
 		return ""
 	}
-	return w.Labels[ManagedBylabel]
+	return w.Labels[ManagedBy]
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -48,7 +48,8 @@ var _ = Describe("Kyma with multiple module CRs in remote sync mode", Ordered, f
 
 	It("CR add from client should be synced in both clusters", func() {
 		By("Remote Kyma created")
-		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).Should(Succeed())
+		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).
+			Should(Succeed())
 		remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace)
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -85,7 +86,8 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 	It("Kyma CR should be synchronized in both clusters", func() {
 		By("Remote Kyma created")
-		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).Should(Succeed())
+		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).
+			Should(Succeed())
 
 		By("CR created in kcp")
 		for _, activeModule := range kyma.Spec.Modules {

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -48,8 +48,8 @@ var _ = Describe("Kyma with multiple module CRs in remote sync mode", Ordered, f
 
 	It("CR add from client should be synced in both clusters", func() {
 		By("Remote Kyma created")
-		Eventually(RemoteKymaExists(runtimeClient, kyma.GetName()), 30*time.Second, Interval).Should(Succeed())
-		remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName())
+		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).Should(Succeed())
+		remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("add skr-module-client to remoteKyma.spec.modules")
@@ -70,7 +70,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 	kyma.Spec.Sync = v1alpha1.Sync{
 		Enabled:      true,
 		Strategy:     v1alpha1.SyncStrategyLocalClient,
-		Namespace:    metav1.NamespaceDefault,
+		Namespace:    "sync-namespace",
 		NoModuleCopy: true,
 	}
 
@@ -85,7 +85,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 	It("Kyma CR should be synchronized in both clusters", func() {
 		By("Remote Kyma created")
-		Eventually(RemoteKymaExists(runtimeClient, kyma.GetName()), 30*time.Second, Interval).Should(Succeed())
+		Eventually(KymaExists(runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace), 30*time.Second, Interval).Should(Succeed())
 
 		By("CR created in kcp")
 		for _, activeModule := range kyma.Spec.Modules {
@@ -93,20 +93,22 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 		}
 
 		By("No spec.module in remote Kyma")
-		remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName())
+		remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.Spec.Sync.Namespace)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(remoteKyma.Spec.Modules).To(BeEmpty())
 
 		By("Remote Module Catalog created")
-		Eventually(ModuleTemplatesExist(runtimeClient, kyma), 30*time.Second, Interval).Should(Succeed())
+		Eventually(ModuleTemplatesExist(runtimeClient, kyma, true), 30*time.Second, Interval).Should(Succeed())
 		Expect(remoteKyma.ContainsCondition(v1alpha1.ConditionTypeReady,
 			v1alpha1.ConditionReasonModuleCatalogIsReady)).To(BeTrue())
 
 		By("updating a module template in the remote cluster to simulate unwanted modification")
 		Eventually(ModifyModuleTemplateSpecThroughLabels(runtimeClient, kyma,
-			ocm.Labels{ocm.Label{Name: "test", Value: json.RawMessage(`{"foo":"bar"}`)}}), Timeout, Interval).Should(Succeed())
+			ocm.Labels{ocm.Label{Name: "test", Value: json.RawMessage(`{"foo":"bar"}`)}},
+			true), Timeout, Interval).Should(Succeed())
 
 		By("verifying the discovered override and checking the resetted label")
-		Eventually(ModuleTemplatesLabelsCountMatch(runtimeClient, kyma, 0), Timeout, Interval).Should(Succeed())
+		Eventually(ModuleTemplatesLabelsCountMatch(
+			runtimeClient, kyma, 0, true), Timeout, Interval).Should(Succeed())
 	})
 })

--- a/controllers/kyma_controller_test.go
+++ b/controllers/kyma_controller_test.go
@@ -53,15 +53,15 @@ var _ = Describe("Kyma with empty ModuleTemplate", Ordered, func() {
 			Should(BeEquivalentTo(string(v1alpha1.StateReady)))
 
 		By("Kyma status contains expected condition")
-		kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName())
+		kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(
 			kymaInCluster.ContainsCondition(
 				v1alpha1.ConditionTypeReady,
 				v1alpha1.ConditionReasonModulesAreReady, metav1.ConditionTrue)).To(BeTrue())
 		By("Module Catalog created")
-		Eventually(ModuleTemplatesExist(controlPlaneClient, kyma), 10*time.Second, Interval).Should(Succeed())
-		kymaInCluster, err = GetKyma(ctx, controlPlaneClient, kyma.GetName())
+		Eventually(ModuleTemplatesExist(controlPlaneClient, kyma, false), 10*time.Second, Interval).Should(Succeed())
+		kymaInCluster, err = GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(
 			kymaInCluster.ContainsCondition(

--- a/controllers/kyma_moduleinfo_test.go
+++ b/controllers/kyma_moduleinfo_test.go
@@ -24,7 +24,7 @@ func noCondition() func() error {
 
 func expectCorrectNumberOfmoduleStatus(kymaName string) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		if err != nil {
 			return err
 		}
@@ -37,7 +37,7 @@ func expectCorrectNumberOfmoduleStatus(kymaName string) func() error {
 
 func expectmoduleStatusStateBecomeReady(kymaName string) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		if err != nil {
 			return err
 		}
@@ -52,7 +52,7 @@ func expectmoduleStatusStateBecomeReady(kymaName string) func() error {
 
 func updateAllModuleState(kymaName string, state v1alpha1.State) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func updateAllModuleState(kymaName string, state v1alpha1.State) func() error {
 
 func removeModule(kymaName string) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		createdKyma.Spec.Modules = v1alpha1.Modules{}
 		return controlPlaneClient.Update(ctx, createdKyma)

--- a/controllers/moduletemplate_test.go
+++ b/controllers/moduletemplate_test.go
@@ -14,7 +14,7 @@ var ErrManifestRemoteIsNotMatch = errors.New("Manifest.Spec.Remote is not match"
 
 func expectManifestSpecRemoteMatched(kymaName string, remoteFlag bool) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func expectManifestSpecRemoteMatched(kymaName string, remoteFlag bool) func() er
 
 func updateModuleTemplateTarget(kymaName string, target v1alpha1.Target) func() error {
 	return func() error {
-		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName)
+		createdKyma, err := GetKyma(ctx, controlPlaneClient, kymaName, "")
 		if err != nil {
 			return err
 		}

--- a/controllers/withwatcher/kyma_controller_test.go
+++ b/controllers/withwatcher/kyma_controller_test.go
@@ -131,7 +131,7 @@ func verifyWebhookConfig(
 	Expect(len(webhookNameParts)).To(Equal(expectedWebhookNamePartsLength))
 
 	moduleName := webhookNameParts[0]
-	expectedModuleName, exists := watcherCR.Labels[v1alpha1.ManagedBylabel]
+	expectedModuleName, exists := watcherCR.Labels[v1alpha1.ManagedBy]
 	Expect(exists).To(BeTrue())
 	Expect(moduleName).To(Equal(expectedModuleName))
 	Expect(*webhook.ClientConfig.Service.Path).To(Equal(fmt.Sprintf(servicePathTpl, moduleName)))

--- a/controllers/withwatcher/watcher_controller_helper_test.go
+++ b/controllers/withwatcher/watcher_controller_helper_test.go
@@ -67,7 +67,7 @@ func createWatcherCR(managerInstanceName string, statusOnly bool) *v1alpha1.Watc
 			Name:      fmt.Sprintf("%s-sample", managerInstanceName),
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
-				v1alpha1.ManagedBylabel: managerInstanceName,
+				v1alpha1.ManagedBy: managerInstanceName,
 			},
 		},
 		Spec: v1alpha1.WatcherSpec{

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -78,11 +78,14 @@ func DeleteModuleTemplates(ctx context.Context, kcpClient client.Client, kyma *v
 	}
 }
 
-func GetKyma(ctx context.Context, testClient client.Client, kymaName string) (*v1alpha1.Kyma, error) {
+func GetKyma(ctx context.Context, testClient client.Client, name, namespace string) (*v1alpha1.Kyma, error) {
 	kymaInCluster := &v1alpha1.Kyma{}
+	if namespace == "" {
+		namespace = v1.NamespaceDefault
+	}
 	err := testClient.Get(ctx, client.ObjectKey{
-		Namespace: v1.NamespaceDefault,
-		Name:      kymaName,
+		Namespace: namespace,
+		Name:      name,
 	}, kymaInCluster)
 	if err != nil {
 		return nil, err
@@ -92,7 +95,7 @@ func GetKyma(ctx context.Context, testClient client.Client, kymaName string) (*v
 
 func IsKymaInState(ctx context.Context, kcpClient client.Client, kymaName string, state v1alpha1.State) func() bool {
 	return func() bool {
-		kymaFromCluster, err := GetKyma(ctx, kcpClient, kymaName)
+		kymaFromCluster, err := GetKyma(ctx, kcpClient, kymaName, "")
 		if err != nil || kymaFromCluster.Status.State != state {
 			return false
 		}

--- a/skr-webhook/templates/deployment.yaml
+++ b/skr-webhook/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       labels:
         app: skr-webhook
+        operator.kyma-project.io/pod-restart-trigger: "{{.Values.triggerLabel}}"
     spec:
       serviceAccountName: {{.Release.Name}}-webhook-sa
       containers:

--- a/skr-webhook/values.yaml
+++ b/skr-webhook/values.yaml
@@ -2,6 +2,8 @@
 sidecar: true
 # -- Replicas
 replicas: 1
+# -- Trigger pod restart
+triggerLabel: ""
 image: 
   # -- Image repository
   repository: "eu.gcr.io/kyma-project"


### PR DESCRIPTION
Fixes #311 

Changes Proposed:

- Changes Catalog Sync to use `spec.sync.namespace` for all ModuleTemplates if given, otherwise uses Kyma Namespace
- Enforces Namespace if not created based on `spec.sync.namespace` or on Kyma Namespace if sync setting is not set
- Readds `operator.kyma-project.io/pod-restart-trigger` to the helm chart of skr watcher as it was mistakenly removed during the big move to root

WARNING: this adds another roundtrip to lifecycle manager synchronization for the server side apply patch, meaning it has a small performance impact. It could later on be revisited with a better conflict strategy but for now we assume lifecycle manager owns the namespace.