### PR TITLE
Decrease cpu/memory requests for lifecycle manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,8 +59,8 @@ spec:
             cpu: 1000m
             memory: 1024Mi
           requests:
-            cpu: 500m
-            memory: 512Mi
+            cpu:  10m
+            memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 ---


### PR DESCRIPTION
Make lifecycle manager deployable in smaller clusters. Fix for https://github.com/kyma-project/kyma/issues/16342