### PR TITLE
feat: introduce unified client and skr rate limit override

### DIFF
--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -101,7 +101,8 @@ func (r *KymaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	if kyma.Spec.Sync.Enabled {
 		var err error
-		if ctx, err = remote.InitializeSyncContext(ctx, kyma, r.Client, r.RemoteClientCache); err != nil {
+		if ctx, err = remote.InitializeSyncContext(ctx, kyma,
+			remote.NewClientWithConfig(r.Client, r.KcpRestConfig), r.RemoteClientCache); err != nil {
 			err := fmt.Errorf("initializing sync context failed: %w", err)
 			r.Event(kyma, "Warning", string(SyncContextError), err.Error())
 			return r.CtrlErr(ctx, kyma, err)
@@ -264,7 +265,7 @@ func (r *KymaReconciler) HandleProcessingState(ctx context.Context, kyma *v1alph
 	statusUpdateRequiredFromSKRWebhookSync := false
 	if kyma.Spec.Sync.Enabled {
 		if statusUpdateRequiredFromSKRWebhookSync, err = r.InstallWebhookChart(ctx, kyma,
-			r.RemoteClientCache, r.Client); err != nil {
+			r.RemoteClientCache, remote.NewClientWithConfig(r.Client, r.KcpRestConfig)); err != nil {
 			kyma.UpdateCondition(v1alpha1.ConditionReasonSKRWebhookIsReady, metav1.ConditionFalse)
 			return err
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -146,6 +146,7 @@ var _ = BeforeSuite(func() {
 			EnableVerification: false,
 		},
 		RemoteClientCache: remoteClientCache,
+		KcpRestConfig:     k8sManager.GetConfig(),
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: listenerAddr})
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -168,6 +168,7 @@ var _ = BeforeSuite(func() {
 			EnableVerification: false,
 		},
 		RemoteClientCache: remoteClientCache,
+		KcpRestConfig:     k8sManager.GetConfig(),
 	}).SetupWithManager(k8sManager, controller.Options{}, controllers.SetupUpSetting{ListenerAddr: listenerAddr})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/deploy/webhook_chart.go
+++ b/pkg/deploy/webhook_chart.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"github.com/kyma-project/lifecycle-manager/pkg/remote"
 	moduleTypes "github.com/kyma-project/module-manager/pkg/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Mode string
@@ -41,8 +39,8 @@ func ResolveSKRChartResourceName(resourceNameTpl string) string {
 	return fmt.Sprintf(resourceNameTpl, ReleaseName)
 }
 
-func prepareInstallInfo(ctx context.Context, chartPath, releaseName string, restConfig *rest.Config,
-	restClient client.Client, argsVals map[string]interface{},
+func prepareInstallInfo(ctx context.Context, chartPath, releaseName string,
+	clnt remote.Client, argsVals map[string]interface{},
 ) *moduleTypes.InstallInfo {
 	return &moduleTypes.InstallInfo{
 		Ctx: ctx,
@@ -58,8 +56,8 @@ func prepareInstallInfo(ctx context.Context, chartPath, releaseName string, rest
 			},
 		},
 		ClusterInfo: &moduleTypes.ClusterInfo{
-			Client: restClient,
-			Config: restConfig,
+			Client: clnt,
+			Config: clnt.Config(),
 		},
 	}
 }

--- a/pkg/remote/client.go
+++ b/pkg/remote/client.go
@@ -1,45 +1,24 @@
 package remote
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
-
-	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const KubeConfigKey = "config"
-
-type ClusterClient struct {
-	logr.Logger
-	DefaultClient client.Client
+type Client interface {
+	client.Client
+	Config() *rest.Config
 }
 
-func (cc *ClusterClient) GetRestConfigFromSecret(ctx context.Context, name, namespace string) (*rest.Config, error) {
-	kubeConfigSecretList := &v1.SecretList{}
-	if err := cc.DefaultClient.List(ctx, kubeConfigSecretList, &client.ListOptions{
-		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{v1alpha1.KymaName: name}), Namespace: namespace,
-	}); err != nil {
-		return nil, err
-	} else if len(kubeConfigSecretList.Items) < 1 {
-		gr := v1.SchemeGroupVersion.WithResource(fmt.Sprintf("secret with label %s", v1alpha1.KymaName)).GroupResource()
+type ConfigAndClient struct {
+	client.Client
+	cfg *rest.Config
+}
 
-		return nil, errors.NewNotFound(gr, name)
-	}
+func (c *ConfigAndClient) Config() *rest.Config {
+	return c.cfg
+}
 
-	kubeConfigSecret := kubeConfigSecretList.Items[0]
-
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigSecret.Data[KubeConfigKey])
-	if err != nil {
-		return nil, err
-	}
-
-	return restConfig, err
+func NewClientWithConfig(clnt client.Client, cfg *rest.Config) *ConfigAndClient {
+	return &ConfigAndClient{Client: clnt, cfg: cfg}
 }

--- a/pkg/remote/client_cache.go
+++ b/pkg/remote/client_cache.go
@@ -25,16 +25,16 @@ type ClientCache struct {
 	internal *sync.Map
 }
 
-func (cache *ClientCache) Get(key ClientCacheID) client.Client {
+func (cache *ClientCache) Get(key ClientCacheID) Client {
 	value, ok := cache.internal.Load(key)
 	if !ok {
 		return nil
 	}
 
-	return value.(client.Client)
+	return value.(Client)
 }
 
-func (cache *ClientCache) Set(key ClientCacheID, value client.Client) {
+func (cache *ClientCache) Set(key ClientCacheID, value Client) {
 	cache.internal.Store(key, value)
 }
 

--- a/pkg/remote/client_lookup.go
+++ b/pkg/remote/client_lookup.go
@@ -1,0 +1,76 @@
+package remote
+
+import (
+	"context"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type ClientLookup struct {
+	kcp   Client
+	cache *ClientCache
+
+	strategy v1alpha1.SyncStrategy
+}
+
+func NewClientLookup(kcp Client, cache *ClientCache, strategy v1alpha1.SyncStrategy) *ClientLookup {
+	return &ClientLookup{kcp: kcp, cache: cache, strategy: strategy}
+}
+
+func (l *ClientLookup) Lookup(ctx context.Context, key client.ObjectKey) (Client, error) {
+	remoteClient := l.cache.Get(ClientCacheID(key))
+	if remoteClient != nil {
+		return remoteClient, nil
+	}
+
+	cfg, err := l.restConfigFromStrategy(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	clnt, err := client.New(cfg, client.Options{Scheme: l.kcp.Scheme()})
+	if err != nil {
+		return nil, err
+	}
+
+	skr := NewClientWithConfig(clnt, cfg)
+
+	l.cache.Set(ClientCacheID(key), skr)
+
+	return skr, nil
+}
+
+func (l *ClientLookup) restConfigFromStrategy(ctx context.Context, key client.ObjectKey) (*rest.Config, error) {
+	var err error
+	var restConfig *rest.Config
+
+	clusterClient := ClusterClient{
+		DefaultClient: l.kcp,
+		Logger:        log.FromContext(ctx),
+	}
+	switch l.strategy {
+	case v1alpha1.SyncStrategyLocalClient:
+		if LocalClient != nil {
+			restConfig = LocalClient()
+		} else {
+			err = ErrNoLocalClientDefined
+		}
+	case v1alpha1.SyncStrategyLocalSecret:
+		fallthrough
+	default:
+		restConfig, err = clusterClient.GetRestConfigFromSecret(ctx, key.Name, key.Namespace)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Overrides the default rate-limiting as we want unified flow control settings in KCP and SKR clusters.
+	restConfig.QPS = l.kcp.Config().QPS
+	restConfig.Burst = l.kcp.Config().Burst
+
+	return restConfig, err
+}

--- a/pkg/remote/cluster_client.go
+++ b/pkg/remote/cluster_client.go
@@ -1,0 +1,44 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const KubeConfigKey = "config"
+
+type ClusterClient struct {
+	logr.Logger
+	DefaultClient client.Client
+}
+
+func (cc *ClusterClient) GetRestConfigFromSecret(ctx context.Context, name, namespace string) (*rest.Config, error) {
+	kubeConfigSecretList := &v1.SecretList{}
+	if err := cc.DefaultClient.List(ctx, kubeConfigSecretList, &client.ListOptions{
+		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{v1alpha1.KymaName: name}), Namespace: namespace,
+	}); err != nil {
+		return nil, err
+	} else if len(kubeConfigSecretList.Items) < 1 {
+		gr := v1.SchemeGroupVersion.WithResource(fmt.Sprintf("secret with label %s", v1alpha1.KymaName)).GroupResource()
+
+		return nil, errors.NewNotFound(gr, name)
+	}
+
+	kubeConfigSecret := kubeConfigSecretList.Items[0]
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigSecret.Data[KubeConfigKey])
+	if err != nil {
+		return nil, err
+	}
+
+	return restConfig, err
+}

--- a/pkg/remote/context.go
+++ b/pkg/remote/context.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // syncContextKey is a singleton key.
@@ -14,9 +13,9 @@ type syncContextKey = struct{}
 var ErrIsNoSyncContext = errors.New("the given value is not a pointer to a kyma synchronization context")
 
 func InitializeSyncContext(
-	ctx context.Context, kyma *v1alpha1.Kyma, controlPlaneClient client.Client, cache *ClientCache,
+	ctx context.Context, kyma *v1alpha1.Kyma, kcp Client, cache *ClientCache,
 ) (context.Context, error) {
-	syncContext, err := InitializeKymaSynchronizationContext(ctx, kyma, controlPlaneClient, cache)
+	syncContext, err := InitializeKymaSynchronizationContext(ctx, kcp, cache, kyma)
 	if err != nil {
 		return ctx, err
 	}

--- a/pkg/remote/kyma_synchronization_context.go
+++ b/pkg/remote/kyma_synchronization_context.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
+	"github.com/kyma-project/lifecycle-manager/pkg/adapter"
 	corev1 "k8s.io/api/core/v1"
 	v1extensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,10 +19,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/kyma-project/lifecycle-manager/api/v1alpha1"
-	"github.com/kyma-project/lifecycle-manager/pkg/adapter"
 )
 
 type ClientFunc func() *rest.Config
@@ -31,76 +29,24 @@ var (
 )
 
 type KymaSynchronizationContext struct {
-	ControlPlaneClient client.Client
-	RuntimeClient      client.Client
-}
-
-func NewRemoteClient(ctx context.Context, controlPlaneClient client.Client, key client.ObjectKey,
-	strategy v1alpha1.SyncStrategy, cache *ClientCache,
-) (client.Client, error) {
-	remoteClient := cache.Get(ClientCacheID(key))
-	if remoteClient != nil {
-		return remoteClient, nil
-	}
-
-	restConfig, err := GetRemoteRestConfig(ctx, controlPlaneClient, key, strategy)
-	if err != nil {
-		return nil, err
-	}
-
-	remoteClient, err = client.New(restConfig, client.Options{Scheme: controlPlaneClient.Scheme()})
-	if err != nil {
-		return nil, err
-	}
-	cache.Set(ClientCacheID(key), remoteClient)
-
-	return remoteClient, nil
-}
-
-func GetRemoteRestConfig(ctx context.Context, controlPlaneClient client.Client, key client.ObjectKey,
-	strategy v1alpha1.SyncStrategy,
-) (*rest.Config, error) {
-	var err error
-	var restConfig *rest.Config
-
-	clusterClient := ClusterClient{
-		DefaultClient: controlPlaneClient,
-		Logger:        log.FromContext(ctx),
-	}
-	switch strategy {
-	case v1alpha1.SyncStrategyLocalClient:
-		if LocalClient != nil {
-			restConfig = LocalClient()
-		} else {
-			err = ErrNoLocalClientDefined
-		}
-	case v1alpha1.SyncStrategyLocalSecret:
-		fallthrough
-	default:
-		restConfig, err = clusterClient.GetRestConfigFromSecret(ctx, key.Name, key.Namespace)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	return restConfig, err
+	ControlPlaneClient Client
+	RuntimeClient      Client
 }
 
 func InitializeKymaSynchronizationContext(
-	ctx context.Context, controlPlaneKyma *v1alpha1.Kyma, controlPlaneClient client.Client, cache *ClientCache,
+	ctx context.Context, kcp Client, cache *ClientCache, kyma *v1alpha1.Kyma,
 ) (*KymaSynchronizationContext, error) {
-	runtimeClient, err := NewRemoteClient(ctx, controlPlaneClient, client.ObjectKeyFromObject(controlPlaneKyma),
-		controlPlaneKyma.Spec.Sync.Strategy, cache)
+	skr, err := NewClientLookup(kcp, cache, kyma.Spec.Sync.Strategy).Lookup(ctx, client.ObjectKeyFromObject(kyma))
 	if err != nil {
 		return nil, err
 	}
 
 	sync := &KymaSynchronizationContext{
-		ControlPlaneClient: controlPlaneClient,
-		RuntimeClient:      runtimeClient,
+		ControlPlaneClient: kcp,
+		RuntimeClient:      skr,
 	}
 
-	if err := sync.ensureRemoteNamespaceExists(ctx, controlPlaneKyma); err != nil {
+	if err := sync.ensureRemoteNamespaceExists(ctx, kyma); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Introduces a new Client Abstraction that includes rest config. Also fixes Webhook lookup of SKR clients as it was skipping the cache for the chart installation and removal (was looking up the secret explicitly). Also overrides SKR Rate Limiting Config with KCP values to avoid rate limiting on catalog sync if configured properly.