### PR TITLE
Add removed files which is needed for two cluster setups

### DIFF
--- a/config/samples/component-integration-installed/component-integration-installed/operator_v1alpha1_moduletemplate_skr-module.yaml
+++ b/config/samples/component-integration-installed/component-integration-installed/operator_v1alpha1_moduletemplate_skr-module.yaml
@@ -1,0 +1,75 @@
+apiVersion: operator.kyma-project.io/v1alpha1
+kind: ModuleTemplate
+metadata:
+  name: moduletemplate-sample-skr-module
+  namespace: default
+  labels:
+    "operator.kyma-project.io/managed-by": "lifecycle-manager"
+    "operator.kyma-project.io/controller-name": "manifest"
+    "operator.kyma-project.io/module-name": "skr-module"
+    "operator.kyma-project.io/profile": "production"
+  annotations:
+    "operator.kyma-project.io/module-version": "v0.0.48"
+    "operator.kyma-project.io/module-provider": "internal"
+    "operator.kyma-project.io/descriptor-schema-version": "v2"
+    "operator.kyma-project.io/generated-at": "2022-07-11T14:59:43Z"
+spec:
+  channel: regular
+  target: remote
+  data:
+    kind: SKRModule
+    resource: skrmodules
+    apiVersion: operator.kyma-project.io/v1alpha1
+    spec:
+      initKey: initValue
+  descriptor:
+    component:
+      componentReferences: []
+      name: kyma-project.io/module/manifest1
+      provider: internal
+      repositoryContexts:
+        - baseUrl: ghcr.io/ruanxin
+          componentNameMapping: urlPath
+          type: ociRegistry
+        - baseUrl: ghcr.io/ruanxin/signed
+          componentNameMapping: urlPath
+          type: ociRegistry
+      resources:
+        - access:
+            digest: sha256:9d37fb366e4371b44c94496f3db276bd6f3a1019c9d44077b689c68ec6486c1e
+            type: localOciBlob
+          digest:
+            hashAlgorithm: sha256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: 9d37fb366e4371b44c94496f3db276bd6f3a1019c9d44077b689c68ec6486c1e
+          name: config
+          relation: local
+          type: yaml
+          version: v0.0.53
+        - access:
+            digest: sha256:269dddc89f744812789673975a78e419177e5147dd2a55eeeb9154e6c827d830
+            type: localOciBlob
+          digest:
+            hashAlgorithm: sha256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: 269dddc89f744812789673975a78e419177e5147dd2a55eeeb9154e6c827d830
+          name: crds
+          relation: local
+          type: crds
+          version: v0.0.53
+        - access:
+            digest: sha256:8a179da0bb4d5b77896f6ef3d4ce853496f45551e44287daa1df3c3e69886bea
+            type: localOciBlob
+          digest:
+            hashAlgorithm: sha256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: 8a179da0bb4d5b77896f6ef3d4ce853496f45551e44287daa1df3c3e69886bea
+          name: kyma-load-test
+          relation: local
+          type: helm-chart
+          version: v0.0.53
+      sources: []
+      version: v0.0.53
+    meta:
+      schemaVersion: v2
+    signatures: []


### PR DESCRIPTION
Files was removed with https://github.com/kyma-project/lifecycle-manager/pull/348/files#diff-35bb8ee4aeb31abc92bd1be598b3b94833be5a5acdf7388d015e52f888f3507d

This file is needed for local two cluster setups.