### PR TITLE
Introduce ociRegistry access support for module-templates

### DIFF
--- a/config/samples/component-integration-installed/operator_v1beta1_moduletemplate_kcp-module.yaml
+++ b/config/samples/component-integration-installed/operator_v1beta1_moduletemplate_kcp-module.yaml
@@ -24,6 +24,10 @@ spec:
   descriptor:
     component:
       componentReferences: []
+      labels:
+      - name: scan.security.kyma-project.io
+        value:
+          scan: enabled
       name: kyma.project.io/module/loadtest
       provider: internal
       repositoryContexts:
@@ -37,6 +41,17 @@ spec:
           name: loadtest-operator
           relation: local
           type: helm-chart
+          version: 0.0.4
+        - access:
+            imageReference: artifact.registry.hostname/path/to/the/registry/k8s-tools:v20221213-1840f45a
+            type: ociRegistry
+          labels:
+          - name: type.scan.security.kyma-project.io
+            value:
+              type: third-party-image
+          name: k8s-tools
+          relation: external
+          type: ociImage
           version: 0.0.4
       sources: []
       version: 0.0.4

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -105,13 +105,18 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 				v1beta1.ConditionReasonModuleCatalogIsReady)).To(BeTrue())
 		}, Timeout, Interval)
 
+		By("getting the label count of module templates in the remote cluster before updating the labels")
+		Expect(kyma.Spec.Modules).NotTo(BeEmpty())
+		count, err := GetModuleTemplatesLabelCount(runtimeClient, kyma, true)
+		Expect(err).ShouldNot(HaveOccurred())
+
 		By("updating a module template in the remote cluster to simulate unwanted modification")
 		Eventually(ModifyModuleTemplateSpecThroughLabels(runtimeClient, kyma,
 			ocm.Labels{ocm.Label{Name: "test", Value: json.RawMessage(`{"foo":"bar"}`)}},
 			true), Timeout, Interval).Should(Succeed())
 
-		By("verifying the discovered override and checking the resetted label")
+		By("verifying the discovered override and checking the reset label")
 		Eventually(ModuleTemplatesLabelsCountMatch(
-			runtimeClient, kyma, 0, true), 20*time.Second, Interval).Should(Succeed())
+			runtimeClient, kyma, count, true), 20*time.Second, Interval).Should(Succeed())
 	})
 })

--- a/pkg/img/parse.go
+++ b/pkg/img/parse.go
@@ -81,6 +81,9 @@ func parseLayersByName(repo *ocm.OCIRegistryRepository, descriptor *ocm.Componen
 				Version:   helmChartAccess.HelmChartVersion,
 				Type:      HelmRepresentationType,
 			}
+		// this resource type is not relevant for module rendering but for security scanning only
+		case ocm.OCIRegistryType:
+			continue
 		default:
 			return nil, fmt.Errorf("error while parsing access type %s: %w",
 				access.GetType(), ErrAccessTypeNotSupported,


### PR DESCRIPTION
**Proposed change(s):**

- Ignore parsing access layers with type `ociRegistry`