### PR TITLE
fix: remove bad naming scheme from `operator.kyma-project.io/owned-by`

### DIFF
--- a/api/v1beta1/operator_labels.go
+++ b/api/v1beta1/operator_labels.go
@@ -21,8 +21,7 @@ const (
 	OperatorName         = "lifecycle-manager"
 	// OwnedByLabel defines the resource managing the resource. Differing from ManagedBy in that it does not reference
 	// controllers.
-	OwnedByLabel  = OperatorPrefix + Separator + "owned-by"
-	OwnedByFormat = "%s__%s"
+	OwnedByLabel = OperatorPrefix + Separator + "owned-by"
 	// WatchedByLabel defines a redirect to a controller that should be getting a notification
 	// if this resource is changed.
 	WatchedByLabel = OperatorPrefix + Separator + "watched-by"

--- a/pkg/declarative/v2/default_transforms.go
+++ b/pkg/declarative/v2/default_transforms.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kyma-project/lifecycle-manager/pkg/labels"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -62,7 +61,7 @@ func watchedByOwnedBy(_ context.Context, obj Object, resources []*unstructured.U
 		}
 		// legacy managed by value
 		lbls[labels.WatchedByLabel] = labels.OperatorName
-		lbls[labels.OwnedByLabel] = fmt.Sprintf(labels.OwnedByFormat, obj.GetNamespace(), obj.GetName())
+		lbls[labels.OwnedByLabel] = obj.GetName()
 		resource.SetLabels(lbls)
 	}
 	return nil

--- a/pkg/labels/component_labels.go
+++ b/pkg/labels/component_labels.go
@@ -8,6 +8,5 @@ const (
 	LifecycleManager = "lifecycle-manager"
 	OperatorName     = "module-manager"
 	OwnedByLabel     = OperatorPrefix + Separator + "owned-by"
-	OwnedByFormat    = "%s__%s"
 	WatchedByLabel   = OperatorPrefix + Separator + "watched-by"
 )


### PR DESCRIPTION
The naming scheme of `operator.kyma-project.io/owned-by` causes errors during SSA as the naming can get too long:

```
Warning  ServerSideApply  4m1s  declarative.kyma-project.io/events  ServerSideApply failed (after 34.811534ms): patch for clusterrolebindings/istio-manager-rolebinding failed: ClusterRoleBinding.rbac.authorization.k8s.io "istio-manager-rolebinding" is invalid: metadata.labels: Invalid value: "kcp-system__226094f5-ac2a-4ffc-bfd2-1d7d41185286-istio-4034478325": must be no more than 63 characters
```