### PR TITLE
fix: atomic module set as only one controller should manage active modules

### DIFF
--- a/api/v1beta1/kyma_types.go
+++ b/api/v1beta1/kyma_types.go
@@ -129,6 +129,7 @@ type KymaSpec struct {
 	Channel string `json:"channel"`
 
 	// Modules specifies the list of modules to be installed
+	//+listType:=atomic
 	Modules []Module `json:"modules,omitempty"`
 
 	// Active Synchronization Settings

--- a/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -94,6 +94,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               sync:
                 description: Active Synchronization Settings
                 properties:
@@ -443,6 +444,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               sync:
                 description: Active Synchronization Settings
                 properties:


### PR DESCRIPTION
this also allows CLI to disable Modules via SSA