### PR TITLE
fix: DNS1035 Label Key Compliance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         cli-stability: ["unstable"]
         target: ["default", "control-plane"]
-    needs: [kustomize]
+    needs: [kustomize,wait-for-img]
     name: "kyma (${{ matrix.cli-stability }}) alpha deploy -k config/${{ matrix.target }}"
     runs-on: ubuntu-latest
     env:

--- a/api/v1alpha1/manifest_conversion.go
+++ b/api/v1alpha1/manifest_conversion.go
@@ -45,7 +45,7 @@ func (src *Manifest) ConvertTo(dstRaw conversion.Hub) error {
 
 // ConvertFrom converts from the Hub version to this version.
 //
-//nolint:revive
+//nolint:revive,stylecheck
 func (dst *Manifest) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1beta1.Manifest)
 

--- a/api/v1alpha1/manifest_types.go
+++ b/api/v1alpha1/manifest_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,11 +81,6 @@ type Manifest struct {
 	// Status signifies the current status of the Manifest
 	// +kubebuilder:validation:Optional
 	Status ManifestStatus `json:"status,omitempty"`
-}
-
-//nolint:stylecheck
-func (m *Manifest) ComponentName() string {
-	return fmt.Sprintf("manifest-%s", m.Name)
 }
 
 func (m *Manifest) GetStatus() declarative.Status {

--- a/api/v1beta1/manifest_types.go
+++ b/api/v1beta1/manifest_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -75,10 +73,6 @@ type Manifest struct {
 
 	Spec   ManifestSpec   `json:"spec,omitempty"`
 	Status ManifestStatus `json:"status,omitempty"`
-}
-
-func (m *Manifest) ComponentName() string {
-	return fmt.Sprintf("manifest-%s", m.Name)
 }
 
 func (m *Manifest) GetStatus() declarative.Status {

--- a/internal/manifest/v1beta1/ready_check.go
+++ b/internal/manifest/v1beta1/ready_check.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 
 	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
@@ -81,7 +82,7 @@ func checkDeploymentState(clt declarative.Client, resources []*resource.Info) er
 		return ErrDeploymentResNotFound
 	}
 	availableCond := deploymentutil.GetDeploymentCondition(deploy.Status, appsv1.DeploymentAvailable)
-	if availableCond != nil && availableCond.Status == corev1.ConditionTrue{
+	if availableCond != nil && availableCond.Status == corev1.ConditionTrue {
 		return nil
 	}
 	if deploy.Spec.Replicas != nil && *deploy.Spec.Replicas == deploy.Status.ReadyReplicas {

--- a/pkg/declarative/v2/default_transforms.go
+++ b/pkg/declarative/v2/default_transforms.go
@@ -46,7 +46,7 @@ func kymaComponentTransform(_ context.Context, obj Object, resources []*unstruct
 		if lbls == nil {
 			lbls = make(map[string]string)
 		}
-		lbls["app.kubernetes.io/component"] = obj.ComponentName()
+		lbls["app.kubernetes.io/component"] = obj.GetName()
 		lbls["app.kubernetes.io/part-of"] = "Kyma"
 		resource.SetLabels(lbls)
 	}

--- a/pkg/declarative/v2/default_transforms_test.go
+++ b/pkg/declarative/v2/default_transforms_test.go
@@ -13,9 +13,8 @@ import (
 
 type testObj struct{ *unstructured.Unstructured }
 
-func (t testObj) ComponentName() string { return "test-object" }
-func (t testObj) GetStatus() Status     { panic("status not supported in test object") }
-func (t testObj) SetStatus(Status)      { panic("status not supported in test object") }
+func (t testObj) GetStatus() Status { panic("status not supported in test object") }
+func (t testObj) SetStatus(Status)  { panic("status not supported in test object") }
 
 //nolint:funlen
 func Test_defaultTransforms(t *testing.T) {
@@ -105,7 +104,9 @@ func Test_defaultTransforms(t *testing.T) {
 		t.Run(
 			testCase.name, func(t *testing.T) {
 				t.Parallel()
-				err := testCase.ObjectTransform(context.Background(), &testObj{}, testCase.resources)
+				obj := &testObj{Unstructured: &unstructured.Unstructured{}}
+				obj.SetName("test-object")
+				err := testCase.ObjectTransform(context.Background(), obj, testCase.resources)
 				testCase.wantErr(
 					t, err, testCase.resources,
 				)

--- a/pkg/declarative/v2/mock/object.go
+++ b/pkg/declarative/v2/mock/object.go
@@ -38,20 +38,6 @@ func (m *MockObject) EXPECT() *MockObjectMockRecorder {
 	return m.recorder
 }
 
-// ComponentName mocks base method.
-func (m *MockObject) ComponentName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComponentName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ComponentName indicates an expected call of ComponentName.
-func (mr *MockObjectMockRecorder) ComponentName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComponentName", reflect.TypeOf((*MockObject)(nil).ComponentName))
-}
-
 // DeepCopyObject mocks base method.
 func (m *MockObject) DeepCopyObject() runtime.Object {
 	m.ctrl.T.Helper()

--- a/pkg/declarative/v2/object.go
+++ b/pkg/declarative/v2/object.go
@@ -13,7 +13,6 @@ import (
 //go:generate mockgen -source object.go -destination mock/object.go Object
 type Object interface {
 	client.Object
-	ComponentName() string
 	GetStatus() Status
 	SetStatus(Status)
 }

--- a/pkg/declarative/v2/spec.go
+++ b/pkg/declarative/v2/spec.go
@@ -17,7 +17,7 @@ type Spec struct {
 
 func DefaultSpec(path string, values any, mode RenderMode) *CustomSpecFns {
 	return &CustomSpecFns{
-		ManifestNameFn: func(_ context.Context, obj Object) string { return obj.ComponentName() },
+		ManifestNameFn: func(_ context.Context, obj Object) string { return obj.GetName() },
 		PathFn:         func(_ context.Context, _ Object) string { return path },
 		ValuesFn:       func(_ context.Context, _ Object) any { return values },
 		ModeFn:         func(_ context.Context, _ Object) RenderMode { return mode },

--- a/pkg/declarative/v2/test/v1/declarative_test.go
+++ b/pkg/declarative/v2/test/v1/declarative_test.go
@@ -62,7 +62,7 @@ var _ = Describe(
 		var runID string
 		var ctx context.Context
 		var cancel context.CancelFunc
-		BeforeEach(func() { runID = rand.String(4) })
+		BeforeEach(func() { runID = fmt.Sprintf("run-%s", rand.String(4)) })
 		BeforeEach(func() { ctx, cancel = context.WithCancel(context.TODO()) })
 		AfterEach(func() { cancel() })
 

--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
@@ -78,7 +79,7 @@ func (m *Module) ContainsExpectedOwnerReference(ownerName string) bool {
 	return false
 }
 
-const maxModuleNameLength = 253
+const maxModuleNameLength = validation.DNS1035LabelMaxLength
 
 // CreateModuleName takes a FQDN and a prefix and generates a human-readable unique interpretation of
 // a name combination.


### PR DESCRIPTION
It can happen that the `app.kubernetes.io/component` label key that is added to every object reconciled by the manifest control-loop exceeds 63 characters since it prepends every object name with `manifest-`. Since object names can already be 63 characters long, I removed this prefix. This meant we can directly use the GetName() method and I could remove the method for the ComponentName in the declarative controller.

Additionally this PR adjusts the max Label Size of the CreateModuleName function to 63 (the value required for k8s object names and label keys) instead of 253 (label values) according to DNS1035, as we previously had the wrong validation length configured for module names.

I also noticed that integration tests are no longer waiting for the image build in the github action since the last change that was done in #403, so I added that back

Fix https://github.com/kyma-project/lifecycle-manager/issues/443