### PR TITLE
fix: change backoff max reconcile delay from 1000s to 5s

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -17,7 +17,7 @@ const (
 	rateLimiterBurstDefault               = 200
 	rateLimiterFrequencyDefault           = 30
 	failureBaseDelayDefault               = 100 * time.Millisecond
-	failureMaxDelayDefault                = 1000 * time.Second
+	failureMaxDelayDefault                = 5 * time.Second
 	defaultCacheSyncTimeout               = 2 * time.Minute
 	defaultListenerPort                   = 9080
 	defaultLogLevel                       = log.WarnLevel


### PR DESCRIPTION
reduces overall max delay settings for reconcile backoffs as this setting was optimised for 10000 cluster setup which is rarely used in open source and local setup with cli thus reducing reactivity of the system unnecessarily