### PR TITLE
manifest reconciler can't handle different target module managed by same kyma

### DIFF
--- a/controllers/manifest_controller.go
+++ b/controllers/manifest_controller.go
@@ -87,7 +87,7 @@ func ManifestReconciler(
 				Config: mgr.GetConfig(),
 			}}).ConfigResolver,
 		),
-		declarative.WithClientCacheKeyFromLabelOrResource(v1beta1.KymaName),
+		internalv1beta1.WithClientCacheKey(),
 		declarative.WithPostRun{internalv1beta1.PostRunCreateCR},
 		declarative.WithPreDelete{internalv1beta1.PreDeleteDeleteCR},
 		declarative.WithPeriodicConsistencyCheck(checkInterval),

--- a/internal/manifest/v1beta1/client.go
+++ b/internal/manifest/v1beta1/client.go
@@ -5,12 +5,19 @@ import (
 	"errors"
 	"fmt"
 
+	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"
+	"github.com/kyma-project/lifecycle-manager/internal"
+	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
+	"github.com/kyma-project/lifecycle-manager/pkg/types"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strconv"
+	"strings"
 )
 
 var ErrKubeconfigFetchFailed = errors.New("could not fetch kubeconfig")
@@ -53,4 +60,37 @@ func (cc *ClusterClient) GetRESTConfig(
 		return nil, err
 	}
 	return restConfig, err
+}
+
+func WithClientCacheKey() declarative.WithClientCacheKeyOption {
+	cacheKey := func(ctx context.Context, resource declarative.Object) (any, bool) {
+		logger := log.FromContext(ctx)
+
+		if resource == nil {
+			return nil, false
+		}
+		manifest := resource.(*manifestv1beta1.Manifest)
+		labelValue, err := internal.GetResourceLabel(resource, manifestv1beta1.KymaName)
+		objectKey := client.ObjectKeyFromObject(resource)
+		var labelErr *types.LabelNotFoundError
+		if errors.As(err, &labelErr) {
+			return nil, false
+		}
+		cacheKey := generateCacheKey(labelValue, strconv.FormatBool(manifest.Spec.Remote), manifest.GetNamespace())
+		logger.V(internal.DebugLogLevel).Info(
+			"resource will be cached",
+			"resource", objectKey,
+			"cachekey", cacheKey,
+		)
+		return cacheKey, true
+	}
+	return declarative.WithClientCacheKeyOption{ClientCacheKeyFn: cacheKey}
+}
+
+func generateCacheKey(values ...string) string {
+	var sb strings.Builder
+	for _, value := range values {
+		sb.WriteString(value)
+	}
+	return sb.String()
 }

--- a/internal/manifest/v1beta1/manifest_controller_test.go
+++ b/internal/manifest/v1beta1/manifest_controller_test.go
@@ -20,7 +20,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	internalV1beta1 "github.com/kyma-project/lifecycle-manager/internal/manifest/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"strconv"
 )
 
 const ManifestDir = "manifest"
@@ -142,7 +144,8 @@ var _ = Describe(
 				Eventually(expectManifestState, standardTimeout, standardInterval).
 					WithArguments(manifest.GetName()).Should(Succeed())
 				Eventually(expectedHelmClientCache, standardTimeout, standardInterval).
-					WithArguments(manifest.GetLabels()[v1beta1.KymaName]).Should(BeTrue())
+					WithArguments(internalV1beta1.GenerateCacheKey(manifest.GetLabels()[v1beta1.KymaName],
+						strconv.FormatBool(manifest.Spec.Remote), manifest.GetNamespace())).Should(BeTrue())
 				Eventually(deleteManifestAndVerify(manifest), standardTimeout, standardInterval).Should(Succeed())
 			},
 			Entry(
@@ -227,7 +230,9 @@ var _ = Describe(
 					WithArguments(manifestWithInstall).Should(Succeed())
 				validImageSpec := createOCIImageSpec(installName, server.Listener.Addr().String(), layerInstalls)
 				Eventually(expectHelmClientCacheExist(true), standardTimeout, standardInterval).
-					WithArguments(manifestWithInstall.GetLabels()[v1beta1.KymaName]).Should(BeTrue())
+					WithArguments(internalV1beta1.GenerateCacheKey(manifestWithInstall.GetLabels()[v1beta1.KymaName],
+						strconv.FormatBool(manifestWithInstall.Spec.Remote), manifestWithInstall.GetNamespace())).
+					Should(BeTrue())
 				// this will ensure only manifest.yaml remains
 				deleteHelmChartResources(validImageSpec)
 				manifest2WithInstall := NewTestManifest("multi-oci2")
@@ -255,10 +260,9 @@ func skipExpect() func() bool {
 	}
 }
 
-func expectHelmClientCacheExist(expectExist bool) func(componentOwner string) bool {
-	return func(componentOwner string) bool {
-		key := client.ObjectKey{Name: componentOwner, Namespace: metav1.NamespaceDefault}
-		clnt := reconciler.ClientCache.GetClientFromCache(key)
+func expectHelmClientCacheExist(expectExist bool) func(cacheKey string) bool {
+	return func(cacheKey string) bool {
+		clnt := reconciler.ClientCache.GetClientFromCache(cacheKey)
 		if expectExist {
 			return clnt != nil
 		}

--- a/internal/manifest/v1beta1/ready_check_test.go
+++ b/internal/manifest/v1beta1/ready_check_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
-	internalv1beta1 "github.com/kyma-project/lifecycle-manager/internal/manifest/v1beta1"
+	internalV1beta1 "github.com/kyma-project/lifecycle-manager/internal/manifest/v1beta1"
 	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +21,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
 )
 
 var _ = Describe("Custom Manifest consistency check", Ordered, func() {
@@ -49,11 +50,12 @@ var _ = Describe("Custom Manifest consistency check", Ordered, func() {
 		Eventually(expectManifestStateIn(declarative.StateReady), standardTimeout, standardInterval).
 			WithArguments(manifestName).Should(Succeed())
 		Eventually(expectHelmClientCacheExist(true), standardTimeout, standardInterval).
-			WithArguments(manifest.GetLabels()[v1beta1.KymaName]).Should(BeTrue())
-		cachedClient := reconciler.ClientCache.GetClientFromCache(client.ObjectKey{
-			Name:      manifest.GetLabels()[v1beta1.KymaName],
-			Namespace: metav1.NamespaceDefault,
-		})
+			WithArguments(internalV1beta1.GenerateCacheKey(manifest.GetLabels()[v1beta1.KymaName],
+				strconv.FormatBool(manifest.Spec.Remote), manifest.GetNamespace())).Should(BeTrue())
+		cacheKey := internalV1beta1.GenerateCacheKey(manifest.GetLabels()[v1beta1.KymaName],
+			strconv.FormatBool(manifest.Spec.Remote), manifest.GetNamespace())
+
+		cachedClient := reconciler.ClientCache.GetClientFromCache(cacheKey)
 
 		By("Verifying that deployment and Sample CR are deployed and ready")
 		deploy := &appsv1.Deployment{}
@@ -77,7 +79,7 @@ var _ = Describe("Custom Manifest consistency check", Ordered, func() {
 		Expect(deployInfo).ToNot(BeNil())
 		resources = append(resources, deployInfo)
 		By("Executing the custom readiness check")
-		customReadyCheck := internalv1beta1.NewManifestCustomResourceReadyCheck()
+		customReadyCheck := internalV1beta1.NewManifestCustomResourceReadyCheck()
 		Expect(customReadyCheck.Run(ctx, cachedClient, manifest, resources)).To(Succeed())
 	})
 })

--- a/internal/manifest/v1beta1/suite_test.go
+++ b/internal/manifest/v1beta1/suite_test.go
@@ -149,7 +149,7 @@ var _ = BeforeSuite(
 					return &declarative.ClusterInfo{Config: authUser.Config()}, nil
 				},
 			),
-			declarative.WithClientCacheKeyFromLabelOrResource(v1beta1.KymaName),
+			internalv1beta1.WithClientCacheKey(),
 			declarative.WithPostRun{internalv1beta1.PostRunCreateCR},
 			declarative.WithPreDelete{internalv1beta1.PreDeleteDeleteCR},
 			declarative.WithCustomReadyCheck(declarative.NewExistsReadyCheck()),

--- a/internal/util.go
+++ b/internal/util.go
@@ -129,14 +129,14 @@ func WriteToFile(filePath string, bytes []byte) error {
 
 func GetResourceLabel(resource client.Object, labelName string) (string, error) {
 	labels := resource.GetLabels()
-	label, ok := labels[labelName]
+	labelValue, ok := labels[labelName]
 	if !ok {
 		return "", &types.LabelNotFoundError{
 			Resource:  resource,
-			LabelName: label,
+			LabelName: labelValue,
 		}
 	}
-	return label, nil
+	return labelValue, nil
 }
 
 func GetStringifiedYamlFromFilePath(filePath string) (string, error) {

--- a/pkg/declarative/v2/reconciler.go
+++ b/pkg/declarative/v2/reconciler.go
@@ -396,10 +396,11 @@ func (r *Reconciler) getTargetClient(
 	ctx context.Context, obj Object, spec *Spec,
 ) (Client, error) {
 	var err error
-
-	clientsCacheKey := r.ClientCacheKeyFn(ctx, obj)
-
-	clnt := r.GetClientFromCache(clientsCacheKey)
+	var clnt Client
+	clientsCacheKey, found := r.ClientCacheKeyFn(ctx, obj)
+	if found {
+		clnt = r.GetClientFromCache(clientsCacheKey)
+	}
 
 	if clnt == nil {
 		cluster := &ClusterInfo{

--- a/pkg/declarative/v2/reconciler.go
+++ b/pkg/declarative/v2/reconciler.go
@@ -397,39 +397,20 @@ func (r *Reconciler) getTargetClient(
 ) (Client, error) {
 	var err error
 	var clnt Client
+	if r.ClientCacheKeyFn == nil {
+		return r.configClient(ctx, obj, spec.ManifestName)
+	}
+
 	clientsCacheKey, found := r.ClientCacheKeyFn(ctx, obj)
 	if found {
 		clnt = r.GetClientFromCache(clientsCacheKey)
 	}
 
 	if clnt == nil {
-		cluster := &ClusterInfo{
-			Config: r.Config,
-			Client: r.Client,
-		}
-		if r.TargetCluster != nil {
-			cluster, err = r.TargetCluster(ctx, obj)
-		}
+		clnt, err = r.configClient(ctx, obj, spec.ManifestName)
 		if err != nil {
 			return nil, err
 		}
-		clnt, err = NewSingletonClients(cluster, log.FromContext(ctx))
-		if err != nil {
-			return nil, err
-		}
-		clnt.Install().Atomic = false
-		clnt.Install().Replace = true
-		clnt.Install().DryRun = true
-		clnt.Install().IncludeCRDs = false
-		clnt.Install().CreateNamespace = r.CreateNamespace
-		clnt.Install().UseReleaseName = false
-		clnt.Install().IsUpgrade = true
-		clnt.Install().DisableHooks = true
-		clnt.Install().DisableOpenAPIValidation = true
-		if clnt.Install().Version == "" && clnt.Install().Devel {
-			clnt.Install().Version = ">0.0.0-0"
-		}
-		clnt.Install().ReleaseName = spec.ManifestName
 		r.SetClientInCache(clientsCacheKey, clnt)
 	}
 
@@ -449,6 +430,41 @@ func (r *Reconciler) getTargetClient(
 		}
 	}
 
+	return clnt, nil
+}
+
+func (r *Reconciler) configClient(ctx context.Context, obj Object, releaseName string) (Client, error) {
+	var err error
+
+	cluster := &ClusterInfo{
+		Config: r.Config,
+		Client: r.Client,
+	}
+
+	if r.TargetCluster != nil {
+		cluster, err = r.TargetCluster(ctx, obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	clnt, err := NewSingletonClients(cluster, log.FromContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	clnt.Install().Atomic = false
+	clnt.Install().Replace = true
+	clnt.Install().DryRun = true
+	clnt.Install().IncludeCRDs = false
+	clnt.Install().CreateNamespace = r.CreateNamespace
+	clnt.Install().UseReleaseName = false
+	clnt.Install().IsUpgrade = true
+	clnt.Install().DisableHooks = true
+	clnt.Install().DisableOpenAPIValidation = true
+	if clnt.Install().Version == "" && clnt.Install().Devel {
+		clnt.Install().Version = ">0.0.0-0"
+	}
+	clnt.Install().ReleaseName = releaseName
 	return clnt, nil
 }
 

--- a/pkg/declarative/v2/test/v1/declarative_test.go
+++ b/pkg/declarative/v2/test/v1/declarative_test.go
@@ -310,6 +310,7 @@ func StartDeclarativeReconcilerForRun(
 			// readiness check will not work without dedicated control loops in envtest. E.g. by default
 			// deployments are not started or set to ready. However we can check if the resource was created by
 			// the reconciler.
+			WithClientCacheKey(),
 			WithCustomReadyCheck(NewExistsReadyCheck()),
 			WithCustomResourceLabels(labels.Set{testRunLabel: runID}),
 			WithPeriodicConsistencyCheck(2*time.Second),
@@ -366,4 +367,11 @@ func expectResourceRecreated(ctx context.Context, obj *testv1.TestAPI) error {
 	}
 
 	return nil
+}
+
+func WithClientCacheKey() WithClientCacheKeyOption {
+	cacheKey := func(ctx context.Context, resource Object) (any, bool) {
+		return client.ObjectKeyFromObject(resource), true
+	}
+	return WithClientCacheKeyOption{ClientCacheKeyFn: cacheKey}
 }


### PR DESCRIPTION
At the moment, for the performance perspective, we cached remote cluster client, and the cache key is using kyma name, so each module defined under same kyma will shared same cluster client. 

However, if modules target are different, for example, some of them defined in control-plane, some in remote (although in practice, we don't have this scenario), then the client should be different.

The PR fixes this bug by providing a different cache key generation logic.