### PR TITLE
Fix Private OCI registry authentication crashed Lifecycle-Manager

### DIFF
--- a/internal/manifest/v1beta1/client.go
+++ b/internal/manifest/v1beta1/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	"github.com/kyma-project/lifecycle-manager/internal"
@@ -16,8 +18,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strconv"
-	"strings"
 )
 
 var ErrKubeconfigFetchFailed = errors.New("could not fetch kubeconfig")

--- a/internal/manifest/v1beta1/manifest_controller_test.go
+++ b/internal/manifest/v1beta1/manifest_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	declarative "github.com/kyma-project/lifecycle-manager/pkg/declarative/v2"
@@ -22,7 +23,6 @@ import (
 
 	internalV1beta1 "github.com/kyma-project/lifecycle-manager/internal/manifest/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"strconv"
 )
 
 const ManifestDir = "manifest"

--- a/internal/manifest/v1beta1/parse.go
+++ b/internal/manifest/v1beta1/parse.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"regexp"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
@@ -19,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"regexp"
 	yaml2 "sigs.k8s.io/yaml"
 )
 

--- a/internal/manifest/v1beta1/ready_check.go
+++ b/internal/manifest/v1beta1/ready_check.go
@@ -27,9 +27,7 @@ func NewManifestCustomResourceReadyCheck() *ManifestCustomResourceReadyCheck {
 
 type ManifestCustomResourceReadyCheck struct{}
 
-var (
-	ErrNoDeterminedState = errors.New("could not determine state")
-)
+var ErrNoDeterminedState = errors.New("could not determine state")
 
 func (c *ManifestCustomResourceReadyCheck) Run(
 	ctx context.Context, clnt declarative.Client, obj declarative.Object, resources []*resource.Info,

--- a/internal/manifest/v1beta1/ready_check_test.go
+++ b/internal/manifest/v1beta1/ready_check_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,7 +22,6 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 var _ = Describe("Custom Manifest consistency check", Ordered, func() {

--- a/internal/manifest/v1beta1/spec_resolver.go
+++ b/internal/manifest/v1beta1/spec_resolver.go
@@ -40,9 +40,9 @@ type ManifestSpecResolver struct {
 	cachedCharts map[string]string
 }
 
-func NewManifestSpecResolver(KCP *declarative.ClusterInfo, codec *v1beta1.Codec) *ManifestSpecResolver {
+func NewManifestSpecResolver(kcp *declarative.ClusterInfo, codec *v1beta1.Codec) *ManifestSpecResolver {
 	return &ManifestSpecResolver{
-		KCP:          KCP,
+		KCP:          kcp,
 		Codec:        codec,
 		ChartCache:   os.TempDir(),
 		cachedCharts: make(map[string]string),

--- a/internal/manifest/v1beta1/spec_resolver.go
+++ b/internal/manifest/v1beta1/spec_resolver.go
@@ -32,7 +32,7 @@ type ChartInfo struct {
 var ErrNoAuthSecretFound = errors.New("no auth secret found")
 
 type ManifestSpecResolver struct {
-	KCP client.Client
+	KCP *declarative.ClusterInfo
 
 	*v1beta1.Codec
 
@@ -40,8 +40,9 @@ type ManifestSpecResolver struct {
 	cachedCharts map[string]string
 }
 
-func NewManifestSpecResolver(codec *v1beta1.Codec) *ManifestSpecResolver {
+func NewManifestSpecResolver(KCP *declarative.ClusterInfo, codec *v1beta1.Codec) *ManifestSpecResolver {
 	return &ManifestSpecResolver{
+		KCP:          KCP,
 		Codec:        codec,
 		ChartCache:   os.TempDir(),
 		cachedCharts: make(map[string]string),
@@ -309,7 +310,7 @@ func (m *ManifestSpecResolver) lookupKeyChain(
 	var keyChain authn.Keychain
 	var err error
 	if imageSpec.CredSecretSelector != nil {
-		if keyChain, err = GetAuthnKeychain(ctx, imageSpec, m.KCP); err != nil {
+		if keyChain, err = GetAuthnKeychain(ctx, imageSpec, m.KCP.Client); err != nil {
 			return nil, err
 		}
 	} else {

--- a/internal/manifest/v1beta1/suite_test.go
+++ b/internal/manifest/v1beta1/suite_test.go
@@ -138,10 +138,14 @@ var _ = BeforeSuite(
 		)
 		Expect(err).NotTo(HaveOccurred())
 
+		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient).NotTo(BeNil())
+		kcp := &declarative.ClusterInfo{Config: cfg, Client: k8sClient}
 		reconciler = declarative.NewFromManager(
 			k8sManager, &v1beta1.Manifest{},
 			declarative.WithSpecResolver(
-				internalv1beta1.NewManifestSpecResolver(codec),
+				internalv1beta1.NewManifestSpecResolver(kcp, codec),
 			),
 			declarative.WithPermanentConsistencyCheck(true),
 			declarative.WithRemoteTargetCluster(
@@ -168,10 +172,6 @@ var _ = BeforeSuite(
 				},
 			).Complete(reconciler)
 		Expect(err).ToNot(HaveOccurred())
-
-		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(k8sClient).NotTo(BeNil())
 
 		go func() {
 			defer GinkgoRecover()


### PR DESCRIPTION
Related issue: https://github.com/kyma-project/lifecycle-manager/issues/440

The nil point error is due to the KCP in ManifestSpecResolver not being initialized.