### PR TITLE
Improve private oci registry document

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -121,12 +121,6 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	controlPlaneClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(controlPlaneClient).NotTo(BeNil())
-
-	runtimeClient, runtimeEnv = NewSKRCluster(controlPlaneClient.Scheme())
-
 	k8sManager, err = ctrl.NewManager(
 		cfg, ctrl.Options{
 			MetricsBindAddress: UseRandomPort,
@@ -152,6 +146,10 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())
+
+	controlPlaneClient = k8sManager.GetClient()
+
+	runtimeClient, runtimeEnv = NewSKRCluster(controlPlaneClient.Scheme())
 
 	go func() {
 		defer GinkgoRecover()

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -133,12 +133,6 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	controlPlaneClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(controlPlaneClient).NotTo(BeNil())
-
-	runtimeClient, runtimeEnv = NewSKRCluster(controlPlaneClient.Scheme())
-
 	metricsBindAddress, found := os.LookupEnv("metrics-bind-address")
 	if !found {
 		metricsBindAddress = ":0"
@@ -151,6 +145,9 @@ var _ = BeforeSuite(func() {
 			NewCache:           controllers.NewCacheFunc(),
 		})
 	Expect(err).ToNot(HaveOccurred())
+
+	controlPlaneClient = k8sManager.GetClient()
+	runtimeClient, runtimeEnv = NewSKRCluster(controlPlaneClient.Scheme())
 
 	intervals := controllers.RequeueIntervals{
 		Success: 3 * time.Second,

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -153,11 +153,16 @@ var _ = BeforeSuite(func() {
 		Success: 3 * time.Second,
 	}
 
-	Expect(createLoadBalancer(suiteCtx, controlPlaneClient)).To(Succeed())
+	// This k8sClient is used to install external resources
+	k8sClient, err := client.New(restCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	Expect(createLoadBalancer(suiteCtx, k8sClient)).To(Succeed())
 	istioResources, err = deserializeIstioResources()
 	Expect(err).NotTo(HaveOccurred())
 	for _, istioResource := range istioResources {
-		Expect(controlPlaneClient.Create(suiteCtx, istioResource)).To(Succeed())
+		Expect(k8sClient.Create(suiteCtx, istioResource)).To(Succeed())
 	}
 
 	remoteClientCache = remote.NewClientCache()

--- a/docs/user/tutorials/config-private-registry.md
+++ b/docs/user/tutorials/config-private-registry.md
@@ -26,14 +26,18 @@ _Notice, to compliance least privileges principle, make sure this credential onl
    ```yaml
    apiVersion: v1
    kind: Secret
-   labels:
-   "operator.kyma-project.io/oci-registry-cred": "test-operator"
-   
+   metadata:
+      labels:
+        "operator.kyma-project.io/managed-by": "lifecycle-manager"
+        "operator.kyma-project.io/oci-registry-cred": "test-operator"
+   ```   
+   Please be aware, the `"operator.kyma-project.io/managed-by": "lifecycle-manager"` is mandatory to have, it's for the Lifecycle Manager runtime controller to know which resources to cache.
+
 3. Deploy to the KCP cluster in each environment.
 
 ### Generate Module Template with `oci-registry-cred` label
 
-`oci-registry-cred` label in module template allows lifecycle manager parsing the secret label selector and propagate to manifest CR so that module manager knows which credential secret to lookup.
+`oci-registry-cred` label in module template allows lifecycle manager parsing the secret label selector and propagate to manifest CR so that Lifecycle Manager knows which credential secret to lookup.
 
 The most convenient way to support module template with `oci-registry-cred` label is using Kyma CLI with `registry-cred-selector`flag for create module command.
 
@@ -54,4 +58,4 @@ Verify in each component descriptor resources layer, it should contains `oci-reg
           value:
             operator.kyma-project.io/oci-registry-cred: test-operator
    ```
-With this module template, module manager should access private oci registry with no authentication problem.
+With this module template, Lifecycle Manager should access private oci registry with no authentication problem.

--- a/internal/manifest/v1beta1/suite_test.go
+++ b/internal/manifest/v1beta1/suite_test.go
@@ -139,9 +139,8 @@ var _ = BeforeSuite(
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(k8sClient).NotTo(BeNil())
+		k8sClient = k8sManager.GetClient()
+
 		kcp := &declarative.ClusterInfo{Config: cfg, Client: k8sClient}
 		reconciler = declarative.NewFromManager(
 			k8sManager, &v1beta1.Manifest{},


### PR DESCRIPTION
In this PR, it improved the document to mention the mandatory `operator.kyma-project.io/managed-by: lifecycle-manager` label, which is related to this [issue](https://github.com/kyma-project/lifecycle-manager/issues/440)

Also after revisiting our testing suite, the controlPlaneClient/KCPClient that we are initialized is not configured same as what is in the real controller, which will bring side effects, for example, the `cache.Options` will not be included. this PR also fixed this problem.