### PR TITLE
Replace warning events when setting metrics by info log

### DIFF
--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -439,7 +439,8 @@ func (r *KymaReconciler) RecordKymaStatusMetrics(ctx context.Context, kyma *v1be
 	shootFQDN, keyExists := kyma.Annotations[v1beta1.SKRDomainAnnotation]
 	if keyExists {
 		parts := strings.Split(shootFQDN, ".")
-		if len(parts) > 2 {
+		minFqdnParts := 2
+		if len(parts) > minFqdnParts {
 			shoot = parts[0] // hostname
 		}
 	} else {

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -433,30 +433,22 @@ func (r *KymaReconciler) deleteModule(ctx context.Context, moduleStatus *v1beta1
 }
 
 // RecordKymaStatusMetrics updates prometheus metrics defined to track changes to the Kyma status.
-func (r *KymaReconciler) RecordKymaStatusMetrics(kyma *v1beta1.Kyma) {
+func (r *KymaReconciler) RecordKymaStatusMetrics(ctx context.Context, kyma *v1beta1.Kyma) {
+	logger := ctrlLog.FromContext(ctx).V(log.InfoLevel)
 	shoot := ""
 	shootFQDN, keyExists := kyma.Annotations[v1beta1.SKRDomainAnnotation]
 	if keyExists {
 		parts := strings.Split(shootFQDN, ".")
-		// at least three labels in any real deployment.
-		if len(parts) > 2 { //nolint:gomnd
+		if len(parts) > 2 {
 			shoot = parts[0] // hostname
 		}
 	} else {
-		r.EventRecorder.Eventf(
-			kyma, "Warning", "AnnotationNotDefined",
-			"Expected annotation: %s not found.",
-			v1beta1.SKRDomainAnnotation,
-		)
+		logger.Info(fmt.Sprintf("expected annotation: %s not found when setting metric", v1beta1.SKRDomainAnnotation))
 	}
 
 	instanceID, keyExists := kyma.Labels[v1beta1.InstanceIDLabel]
 	if !keyExists {
-		r.EventRecorder.Eventf(
-			kyma, "Warning", "LabelNotDefined",
-			"Expected label: %s not found.",
-			v1beta1.InstanceIDLabel,
-		)
+		logger.Info(fmt.Sprintf("expected label: %s not found when setting metric", v1beta1.InstanceIDLabel))
 	}
 
 	metrics.RecordKymaStatus(kyma.Name, kyma.Status.State, shoot, instanceID)

--- a/controllers/kyma_controller_helper_test.go
+++ b/controllers/kyma_controller_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"

--- a/internal/declarative/v2/renderer_raw_test.go
+++ b/internal/declarative/v2/renderer_raw_test.go
@@ -2,12 +2,13 @@ package v2_test
 
 import (
 	"context"
-	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
-	mockV2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/mock"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
+	mockV2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/mock"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/internal/declarative/v2/renderer_with_cache_test.go
+++ b/internal/declarative/v2/renderer_with_cache_test.go
@@ -3,9 +3,10 @@ package v2_test
 import (
 	"context"
 	"errors"
+	"testing"
+
 	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	mockV2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/mock"
-	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/internal/declarative/v2/ssa_test.go
+++ b/internal/declarative/v2/ssa_test.go
@@ -2,8 +2,9 @@ package v2_test
 
 import (
 	"context"
-	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"testing"
+
+	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/internal/declarative/v2/test/v1/api.go
+++ b/internal/declarative/v2/test/v1/api.go
@@ -4,6 +4,7 @@ package v1
 
 import (
 	"fmt"
+
 	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/declarative/v2/test/v1/declarative_test.go
+++ b/internal/declarative/v2/test/v1/declarative_test.go
@@ -3,11 +3,12 @@ package v1_test
 import (
 	"context"
 	"fmt"
-	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
-	testv1 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/test/v1"
 	"path/filepath"
 	"testing"
 	"time"
+
+	. "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
+	testv1 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/test/v1"
 
 	"golang.org/x/time/rate"
 	v1 "k8s.io/api/core/v1"

--- a/internal/declarative/v2/test/v1/helper_test.go
+++ b/internal/declarative/v2/test/v1/helper_test.go
@@ -3,6 +3,7 @@ package v1_test
 import (
 	"context"
 	"fmt"
+
 	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	testv1 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/test/v1"
 	. "github.com/onsi/gomega"

--- a/internal/declarative/v2/test/v1/suite_test.go
+++ b/internal/declarative/v2/test/v1/suite_test.go
@@ -2,10 +2,11 @@ package v1_test
 
 import (
 	"context"
-	testv1 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/test/v1"
 	"os"
 	"path/filepath"
 	"time"
+
+	testv1 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2/test/v1"
 
 	apiExtensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/internal/manifest/v1beta1/client.go
+++ b/internal/manifest/v1beta1/client.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"strconv"
 	"strings"
+
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	"github.com/kyma-project/lifecycle-manager/internal"

--- a/internal/manifest/v1beta1/custom_resource.go
+++ b/internal/manifest/v1beta1/custom_resource.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"context"
 	"errors"
+
 	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"

--- a/internal/manifest/v1beta1/manifest_controller_test.go
+++ b/internal/manifest/v1beta1/manifest_controller_test.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
+
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/manifest/v1beta1/ready_check.go
+++ b/internal/manifest/v1beta1/ready_check.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"strings"
+
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/manifest/v1beta1/ready_check.go
+++ b/internal/manifest/v1beta1/ready_check.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"strings"
 
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	manifestv1beta1 "github.com/kyma-project/lifecycle-manager/api/v1beta1"
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
 	deploymentutil "k8s.io/kubectl/pkg/util/deployment"

--- a/internal/manifest/v1beta1/ready_check_test.go
+++ b/internal/manifest/v1beta1/ready_check_test.go
@@ -2,10 +2,11 @@ package v1beta1_test
 
 import (
 	"encoding/json"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	internalV1beta1 "github.com/kyma-project/lifecycle-manager/internal/manifest/v1beta1"

--- a/internal/manifest/v1beta1/skr_client_lookup.go
+++ b/internal/manifest/v1beta1/skr_client_lookup.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+
 	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"

--- a/internal/manifest/v1beta1/spec_resolver.go
+++ b/internal/manifest/v1beta1/spec_resolver.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta1"

--- a/internal/manifest/v1beta1/suite_test.go
+++ b/internal/manifest/v1beta1/suite_test.go
@@ -18,12 +18,13 @@ package v1beta1_test
 
 import (
 	"context"
-	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	declarative "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 
 	"k8s.io/apimachinery/pkg/labels"
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	kymaNameLabel   = "kyma_name"
-	moduleNameLabel = "module_name"
 	stateLabel      = "state"
 	shootLabel      = "shoot"
 	instanceIDLabel = "instance_id"

--- a/pkg/status/kyma_helper.go
+++ b/pkg/status/kyma_helper.go
@@ -13,12 +13,12 @@ import (
 
 type KymaHelper struct {
 	client.StatusWriter
-	recordKymaStatusMetrics func(kyma *v1beta1.Kyma)
+	recordKymaStatusMetrics func(ctx context.Context, kyma *v1beta1.Kyma)
 }
 
 type HelperClient interface {
 	Status() client.StatusWriter
-	RecordKymaStatusMetrics(kyma *v1beta1.Kyma)
+	RecordKymaStatusMetrics(ctx context.Context, kyma *v1beta1.Kyma)
 }
 
 func Helper(handler HelperClient) *KymaHelper {
@@ -53,7 +53,7 @@ func (k *KymaHelper) UpdateStatusForExistingModules(ctx context.Context,
 	}
 
 	if k.recordKymaStatusMetrics != nil {
-		k.recordKymaStatusMetrics(kyma)
+		k.recordKymaStatusMetrics(ctx, kyma)
 	}
 
 	return nil


### PR DESCRIPTION
Description:
* Whenever the expected `skr-domain` annotation or `kyma-project.io/instance-id` label on a Kyma are missing when setting kyma status metric it should not create a warning event rather than just log that