### PR TITLE
kyma_controller: Add Channel Whitelisting Logic

### DIFF
--- a/api/v1beta1/operator_labels.go
+++ b/api/v1beta1/operator_labels.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
 )
 
 const (
@@ -27,6 +28,10 @@ const (
 	CertManager  = "klm-watcher-cert-manager"
 	// SkipReconcileLabel indicates this specific resource will be skipped during reconciliation.
 	SkipReconcileLabel = OperatorPrefix + Separator + "skip-reconciliation"
+
+	// ChannelWhitelistPrefix is used to identify labels for whitelisting a channel
+	ChannelWhitelistPrefix  = OperatorPrefix + Separator + "whitelist-channel-"
+	ChannelWhitelistEnabled = "true"
 )
 
 func ModuleTemplatesByLabel(module *Module) client.MatchingLabels {
@@ -59,4 +64,18 @@ func (kyma *Kyma) CheckLabelsAndFinalizers() bool {
 		updateRequired = true
 	}
 	return updateRequired
+}
+
+func (kyma *Kyma) GetWhitelistedChannels() []string {
+	var whitelistChannels []string
+
+	for label, value := range kyma.ObjectMeta.Labels {
+		if channelName, prefixFound := strings.CutPrefix(label, ChannelWhitelistPrefix); prefixFound {
+			if value == ChannelWhitelistEnabled {
+				whitelistChannels = append(whitelistChannels, channelName)
+			}
+		}
+	}
+
+	return whitelistChannels
 }

--- a/controllers/README.md
+++ b/controllers/README.md
@@ -36,7 +36,7 @@ On top of this, based on the  `.spec.sync.moduleCatalog` flag, the `syncModuleCa
 ## Manifest Controller
 
 The [Manifest controller](manifest_controller.go) is dealing with the reconciliation and installation of data desired through a `Manifest`, a representation of a single module desired in a cluster.
-Since it mainly is a delegation to the [declarative reconciliation library](../pkg/declarative/README.md) with certain [internal implementation additions](../internal/manifest/README.md) please look at the respective documentation for these parts to understand them more.
+Since it mainly is a delegation to the [declarative reconciliation library](../internal/declarative/README.md) with certain [internal implementation additions](../internal/manifest/README.md) please look at the respective documentation for these parts to understand them more.
 
 ## Watcher Controller
 

--- a/controllers/kyma_module_channel_test.go
+++ b/controllers/kyma_module_channel_test.go
@@ -141,6 +141,7 @@ func givenKymaSpecModulesWithInvalidChannel(channel string) func() error {
 
 var _ = Describe("Switching of a Channel with higher version leading to an Upgrade", Ordered, func() {
 	kyma := NewTestKyma("empty-module-kyma")
+	kyma.ObjectMeta.Labels[v1beta1.ChannelWhitelistPrefix+FastChannel] = "true"
 
 	kyma.Spec.Modules = append(
 		kyma.Spec.Modules, v1beta1.Module{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -53,6 +53,8 @@ func NewTestKyma(name string) *v1beta1.Kyma {
 			Name:        fmt.Sprintf("%s-%s", name, randString(randomStringLength)),
 			Namespace:   v1.NamespaceDefault,
 			Annotations: map[string]string{watcher.DomainAnnotation: "example.domain.com"},
+			Labels: map[string]string{
+				v1beta1.ChannelWhitelistPrefix + v1beta1.DefaultChannel: v1beta1.ChannelWhitelistEnabled},
 		},
 		Spec: v1beta1.KymaSpec{
 			Modules: []v1beta1.Module{},


### PR DESCRIPTION
### ♻️ Changes:
* Label-based channel whitelisting:
    * The following label must be set for a channel to whitelist it-> operator.kyma-project.io/whitelist-channel-{channelName}: "true"
    * This label is not synced in SKR Kyma copy.
    * Only a value of "true" whitelists a channel.
    * ModuleTemplates from non-whitelisted channels are not synced to the SKR.
    * Manifests are not created for modules with non-whitelisted channels as templates.
 
### ⚠️ Note:
* AFAIK, labels longer than 64 characters cause problems. This approach will limit the length of a channel name.

Closes #455 