### PR TITLE
Increase workqueue workers for KCP

### DIFF
--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -46,10 +46,10 @@ patches:
         value: --is-kyma-managed  
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: max-concurrent-manifest-reconciles=10
+        value: --max-concurrent-manifest-reconciles=10
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: max-concurrent-kyma-reconciles=10
+        value: --max-concurrent-kyma-reconciles=10
     target:
       kind: Deployment
 

--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -39,6 +39,17 @@ components:
   # [GRAFANA] To enable prometheus monitor, uncomment all sections with 'GRAFANA'.
   - ../grafana
 
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: max-concurrent-manifest-reconciles=10
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: max-concurrent-kyma-reconciles=10
+    target:
+      kind: Deployment
+
 patchesJson6902:
   # We patch the Metrics JSONs here as we expect KCP to be watching for grafana dashboards in kyma-system,
   # not kcp-system as we configure it above for the rest of the kustomization

--- a/flags.go
+++ b/flags.go
@@ -36,8 +36,12 @@ func defineFlagVar() *FlagVar {
 		"The address the skr listener endpoint binds to.")
 	flag.StringVar(&flagVar.pprofAddr, "pprof-bind-address", ":8084",
 		"The address the pprof endpoint binds to.")
-	flag.IntVar(&flagVar.maxConcurrentReconciles, "max-concurrent-reconciles", 1,
-		"The maximum number of concurrent Reconciles which can be run.")
+	flag.IntVar(&flagVar.maxConcurrentKymaReconciles, "max-concurrent-kyma-reconciles", 1,
+		"The maximum number of concurrent Kyma Reconciles which can be run.")
+	flag.IntVar(&flagVar.maxConcurrentManifestReconciles, "max-concurrent-manifest-reconciles", 1,
+		"The maximum number of concurrent Manifest Reconciles which can be run.")
+	flag.IntVar(&flagVar.maxConcurrentWatcherReconciles, "max-concurrent-watcher-reconciles", 1,
+		"The maximum number of concurrent Watcher Reconciles which can be run.")
 	flag.BoolVar(&flagVar.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -103,7 +107,9 @@ type FlagVar struct {
 	enableLeaderElection                                            bool
 	probeAddr                                                       string
 	kymaListenerAddr, manifestListenerAddr                          string
-	maxConcurrentReconciles                                         int
+	maxConcurrentKymaReconciles                                     int
+	maxConcurrentManifestReconciles                                 int
+	maxConcurrentWatcherReconciles                                  int
 	kymaRequeueSuccessInterval                                      time.Duration
 	manifestRequeueSuccessInterval                                  time.Duration
 	watcherRequeueSuccessInterval                                   time.Duration

--- a/main.go
+++ b/main.go
@@ -303,11 +303,6 @@ func setupManifestReconciler(
 }
 
 func setupKcpWatcherReconciler(mgr ctrl.Manager, options controller.Options, flagVar *FlagVar) {
-	// Set MaxConcurrentReconciles to 1 to avoid concurrent writes on
-	// the Istio virtual service resource the WatcherReconciler is managing.
-	// In total, we probably only have 20 watcher CRs, one worker can sufficiently handle it,
-	// and we don't have to deal with concurrent write to virtual service.
-	// although eventually the write operation will succeed.
 	options.MaxConcurrentReconciles = flagVar.maxConcurrentWatcherReconciles
 
 	istioConfig := istio.NewConfig(flagVar.virtualServiceName, flagVar.enableWatcherLocalTesting)


### PR DESCRIPTION
- Added `max-concurrent-kyma-reconciles` flag for the Kyma controller, with value for control-plane: 10
- Added `max-concurrent-manifest-reconciles` flag for the Manifest controller, with value for control-plane: 10
- Added `max-concurrent-watcher-reconciles` flag for the Manifest controller, with default value of 1

Closes #515 