### PR TITLE
Remove admission webhook

### DIFF
--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -80,7 +80,7 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-  - patches/webhook_configuration_cainjection.yaml
+#  - patches/webhook_configuration_cainjection.yaml
   # We override the certificate name to ensure that Cert-Manager uses a unique cert in conjunction with other
   # kubebuilder operators.
   - patches/unique_certificate_name.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -57,7 +57,7 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-  - webhookcainjection_patch.yaml
+#  - webhookcainjection_patch.yaml
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - manifests.yaml
+#  - manifests.yaml
   - service.yaml
 
 configurations:


### PR DESCRIPTION
To prepare for next API upgrade, the admission webhook needs to be updated, `Mutatingwebhookconfigurations` is useless, and we only need `Validatingwebhookconfigurations` for moduletemplate, however, kustomize can't remove those two existing resources automatically. 

In this PR, it removes all admission webhooks, so that in next API upgrade, we can create new resources from scratch to avoid handle deprecated webhook endpoint.