### PR TITLE
Refactor SynchronizeRemoteKyma; add Spec and Labels-AnnotationSync

### DIFF
--- a/controllers/kyma_controller_helper_test.go
+++ b/controllers/kyma_controller_helper_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 var (
-	ErrKymaNotFound          = errors.New("kyma not exists")
-	ErrExpectedLabelNotReset = errors.New("expected label not reset")
+	ErrKymaNotFound             = errors.New("kyma not exists")
+	ErrExpectedLabelNotReset    = errors.New("expected label not reset")
+	ErrWatcherLabelMissing      = errors.New("watcher label missing")
+	ErrWatcherAnnotationMissing = errors.New("watcher annotation missing")
 )
 
 func RegisterDefaultLifecycleForKyma(kyma *v1beta1.Kyma) {
@@ -233,6 +235,23 @@ func ModuleTemplatesExist(clnt client.Client, kyma *v1beta1.Kyma, remote bool) f
 			}
 		}
 
+		return nil
+	}
+}
+
+func WatcherLabelsAnnotationsExist(clnt client.Client, kyma *v1beta1.Kyma) func() error {
+	return func() error {
+		remoteKyma, err := GetKyma(ctx, clnt, kyma.GetName(), kyma.Spec.Sync.Namespace)
+		if err != nil {
+			return err
+		}
+		if remoteKyma.Labels[v1beta1.WatchedByLabel] != v1beta1.OperatorName {
+			return ErrWatcherLabelMissing
+		}
+		if remoteKyma.Annotations[v1beta1.OwnedByAnnotation] != fmt.Sprintf(v1beta1.OwnedByFormat,
+			kyma.GetNamespace(), kyma.GetName()) {
+			return ErrWatcherAnnotationMissing
+		}
 		return nil
 	}
 }

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -121,6 +121,8 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 			}
 			return nil
 		}, Timeout, Interval)
+		By("Remote Kyma should contain Watcher labels and annotations")
+		Eventually(WatcherLabelsAnnotationsExist(runtimeClient, kyma), Timeout, Interval).Should(Succeed())
 		moduleToBeUpdated := kyma.Spec.Modules[0].Name
 		By("Update SKR Module Template spec.data.spec field")
 		Eventually(updateModuleTemplateSpec,

--- a/pkg/remote/kyma_synchronization_context.go
+++ b/pkg/remote/kyma_synchronization_context.go
@@ -214,13 +214,12 @@ func (c *KymaSynchronizationContext) SynchronizeRemoteKyma(
 	if !remoteKyma.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
-
 	recorder := adapter.RecorderFromContext(ctx)
 
 	c.SyncWatcherLabelsAnnotations(controlPlaneKyma, remoteKyma)
 	if err := c.RuntimeClient.Update(ctx, remoteKyma); err != nil {
-		recorder.Event(controlPlaneKyma, "Warning", err.Error(), "could not update runtime kyma "+
-			"watcher labels and annotations")
+		recorder.Event(controlPlaneKyma, "Warning", err.Error(), "could not synchronise runtime kyma "+
+			"spec, watcher labels and annotations")
 		return err
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We introduced a bug by removing an update call in the `SynchronizeRemoteKyma` function, thus the spec, labels and annotations have not been synced anymore. This PR introduced it again and refactors the sequence of the sync process.


Changes proposed in this pull request:

- Renamed InsertWatcherLabelsAnnotations to SyncWatcherLabelsAnnotations
- Refactored the sequence of the sync calls
    - First check if the Kyma is being deleted, if yes nothing needs to be done
    - Sync Watcher Labels and annotations
    - Call update to update labels, annoations and sync spec
    - Update Status
- Introduce new testcase to check for Watcher Labels and Annotations

