### PR TITLE
Add global flag for target sync namespace

### DIFF
--- a/controllers/control-plane/control_plane_suite_test.go
+++ b/controllers/control-plane/control_plane_suite_test.go
@@ -137,9 +137,10 @@ var _ = BeforeSuite(func() {
 		VerificationSettings: signature.VerificationSettings{
 			EnableVerification: false,
 		},
-		RemoteClientCache: remoteClientCache,
-		KcpRestConfig:     k8sManager.GetConfig(),
-		InKCPMode:         true,
+		RemoteClientCache:   remoteClientCache,
+		KcpRestConfig:       k8sManager.GetConfig(),
+		InKCPMode:           true,
+		RemoteSyncNamespace: "kyma-system",
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/control-plane/control_plane_suite_test.go
+++ b/controllers/control-plane/control_plane_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		RemoteClientCache:   remoteClientCache,
 		KcpRestConfig:       k8sManager.GetConfig(),
 		InKCPMode:           true,
-		RemoteSyncNamespace: "kyma-system",
+		RemoteSyncNamespace: controllers.DefaultRemoteSyncNamespace,
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -52,9 +52,10 @@ import (
 type EventErrorType string
 
 const (
-	ModuleReconciliationError EventErrorType = "ModuleReconciliationError"
-	SyncContextError          EventErrorType = "SyncContextError"
-	DeletionError             EventErrorType = "DeletionError"
+	ModuleReconciliationError  EventErrorType = "ModuleReconciliationError"
+	SyncContextError           EventErrorType = "SyncContextError"
+	DeletionError              EventErrorType = "DeletionError"
+	DefaultRemoteSyncNamespace string         = "kyma-system"
 )
 
 type RequeueIntervals struct {

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -72,6 +72,7 @@ type KymaReconciler struct {
 	RemoteClientCache        *remote.ClientCache
 	ComponentDescriptorCache *ocmextensions.ComponentDescriptorCache
 	InKCPMode                bool
+	RemoteSyncNamespace      string
 }
 
 //nolint:lll
@@ -117,7 +118,7 @@ func (r *KymaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	if kyma.SyncEnabled() {
 		var err error
-		if ctx, err = remote.InitializeSyncContext(ctx, kyma,
+		if ctx, err = remote.InitializeSyncContext(ctx, kyma, r.RemoteSyncNamespace,
 			remote.NewClientWithConfig(r.Client, r.KcpRestConfig), r.RemoteClientCache); err != nil {
 			err := fmt.Errorf("initializing sync context failed: %w", err)
 			r.Event(kyma, "Warning", string(SyncContextError), err.Error())
@@ -177,7 +178,7 @@ func (r *KymaReconciler) syncRemoteKymaSpecAndStatus(
 ) error {
 	syncContext := remote.SyncContextFromContext(ctx)
 
-	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx, controlPlaneKyma)
+	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx, controlPlaneKyma, r.RemoteSyncNamespace)
 	if err != nil {
 		if errors.Is(err, remote.ErrNotFoundAndKCPKymaUnderDeleting) {
 			//remote kyma not found because it's deleted, should not continue
@@ -206,7 +207,7 @@ func (r *KymaReconciler) syncModuleCatalog(ctx context.Context, kyma *v1beta2.Ky
 		}
 	}
 
-	if err := remote.NewRemoteCatalogFromKyma(kyma).CreateOrUpdate(ctx, modulesToSync); err != nil {
+	if err := remote.NewRemoteCatalogFromKyma(r.RemoteSyncNamespace).CreateOrUpdate(ctx, modulesToSync); err != nil {
 		return fmt.Errorf("could not synchronize remote module catalog: %w", err)
 	}
 
@@ -329,14 +330,14 @@ func (r *KymaReconciler) handleDeletingState(ctx context.Context, kyma *v1beta2.
 	}
 
 	if kyma.SyncEnabled() {
-		if err := remote.NewRemoteCatalogFromKyma(kyma).Delete(ctx); err != nil {
+		if err := remote.NewRemoteCatalogFromKyma(r.RemoteSyncNamespace).Delete(ctx); err != nil {
 			err := fmt.Errorf("could not delete remote module catalog: %w", err)
 			r.Event(kyma, "Warning", string(DeletionError), err.Error())
 			return false, err
 		}
 
 		r.RemoteClientCache.Del(client.ObjectKeyFromObject(kyma))
-		if err := remote.RemoveFinalizerFromRemoteKyma(ctx, kyma); client.IgnoreNotFound(err) != nil {
+		if err := remote.RemoveFinalizerFromRemoteKyma(ctx, kyma, r.RemoteSyncNamespace); client.IgnoreNotFound(err) != nil {
 			err := fmt.Errorf("error while trying to remove finalizer from remote: %w", err)
 			r.Event(kyma, "Warning", string(DeletionError), err.Error())
 			return false, err
@@ -359,7 +360,7 @@ func (r *KymaReconciler) handleDeletingState(ctx context.Context, kyma *v1beta2.
 func (r *KymaReconciler) TriggerKymaDeletion(ctx context.Context, kyma *v1beta2.Kyma) error {
 	logger := ctrlLog.FromContext(ctx).V(log.InfoLevel)
 	if kyma.SyncEnabled() {
-		if err := remote.DeleteRemotelySyncedKyma(ctx, kyma); client.IgnoreNotFound(err) != nil {
+		if err := remote.DeleteRemotelySyncedKyma(ctx, kyma, r.RemoteSyncNamespace); client.IgnoreNotFound(err) != nil {
 			logger.Error(err, "Failed to be deleted remotely!")
 			return fmt.Errorf("error occurred while trying to delete remotely synced kyma: %w", err)
 		}
@@ -409,7 +410,7 @@ func (r *KymaReconciler) GenerateModulesFromTemplate(ctx context.Context, kyma *
 	if err != nil {
 		return nil, err
 	}
-	parser := parse.NewParser(r.Client, r.ComponentDescriptorCache, r.InKCPMode)
+	parser := parse.NewParser(r.Client, r.ComponentDescriptorCache, r.InKCPMode, r.RemoteSyncNamespace)
 	return parser.GenerateModulesFromTemplates(ctx, kyma, templates, verification), nil
 }
 

--- a/controllers/kyma_controller_helper_test.go
+++ b/controllers/kyma_controller_helper_test.go
@@ -101,10 +101,11 @@ func UpdateRemoteModule(
 	ctx context.Context,
 	client client.Client,
 	kyma *v1beta2.Kyma,
+	remoteNamespace string,
 	modules []v1beta2.Module,
 ) func() error {
 	return func() error {
-		kyma, err := GetKyma(ctx, client, kyma.Name, kyma.Namespace)
+		kyma, err := GetKyma(ctx, client, kyma.Name, remoteNamespace)
 		if err != nil {
 			return err
 		}
@@ -179,10 +180,10 @@ func ModuleTemplateExists(client client.Client, name, namespace string) error {
 	return nil
 }
 
-func ModuleTemplatesExist(clnt client.Client, kyma *v1beta2.Kyma) func() error {
+func ModuleTemplatesExist(clnt client.Client, kyma *v1beta2.Kyma, remoteSyncNamespace string) func() error {
 	return func() error {
 		for _, module := range kyma.Spec.Modules {
-			if err := ModuleTemplateExists(clnt, module.Name, kyma.GetNamespace()); err != nil {
+			if err := ModuleTemplateExists(clnt, module.Name, remoteSyncNamespace); err != nil {
 				return err
 			}
 		}
@@ -191,8 +192,8 @@ func ModuleTemplatesExist(clnt client.Client, kyma *v1beta2.Kyma) func() error {
 	}
 }
 
-func WatcherLabelsAnnotationsExist(clnt client.Client, kyma *v1beta2.Kyma) error {
-	remoteKyma, err := GetKyma(ctx, clnt, kyma.GetName(), kyma.GetNamespace())
+func WatcherLabelsAnnotationsExist(clnt client.Client, kyma *v1beta2.Kyma, remoteSyncNamespace string) error {
+	remoteKyma, err := GetKyma(ctx, clnt, kyma.GetName(), remoteSyncNamespace)
 	if err != nil {
 		return err
 	}
@@ -200,6 +201,7 @@ func WatcherLabelsAnnotationsExist(clnt client.Client, kyma *v1beta2.Kyma) error
 		return ErrWatcherLabelMissing
 	}
 	if remoteKyma.Annotations[v1beta2.OwnedByAnnotation] != fmt.Sprintf(v1beta2.OwnedByFormat,
+		//TODO: Is it OK?
 		kyma.GetNamespace(), kyma.GetName()) {
 		return ErrWatcherAnnotationMissing
 	}

--- a/controllers/kyma_controller_helper_test.go
+++ b/controllers/kyma_controller_helper_test.go
@@ -101,11 +101,11 @@ func UpdateRemoteModule(
 	ctx context.Context,
 	client client.Client,
 	kyma *v1beta2.Kyma,
-	remoteNamespace string,
+	remoteSyncNamespace string,
 	modules []v1beta2.Module,
 ) func() error {
 	return func() error {
-		kyma, err := GetKyma(ctx, client, kyma.Name, remoteNamespace)
+		kyma, err := GetKyma(ctx, client, kyma.Name, remoteSyncNamespace)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,6 @@ func WatcherLabelsAnnotationsExist(clnt client.Client, kyma *v1beta2.Kyma, remot
 		return ErrWatcherLabelMissing
 	}
 	if remoteKyma.Annotations[v1beta2.OwnedByAnnotation] != fmt.Sprintf(v1beta2.OwnedByFormat,
-		//TODO: Is it OK?
 		kyma.GetNamespace(), kyma.GetName()) {
 		return ErrWatcherAnnotationMissing
 	}

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/controllers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,11 +49,11 @@ var _ = Describe("Kyma with multiple module CRs in remote sync mode", Ordered, f
 	It("CR add from client should be synced in both clusters", func() {
 		By("Remote Kyma created")
 		Eventually(KymaExists, Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetName(), "kyma-system").
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
 
 		By("add skr-module-client to remoteKyma.spec.modules")
-		Eventually(UpdateRemoteModule(ctx, runtimeClient, kyma, "kyma-system", []v1beta2.Module{
+		Eventually(UpdateRemoteModule(ctx, runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace, []v1beta2.Module{
 			skrModuleFromClient,
 		}), Timeout, Interval).Should(Succeed())
 
@@ -158,7 +159,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 	It("Kyma CR should be synchronized in both clusters", func() {
 		By("Remote Kyma created")
 		Eventually(KymaExists, Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetName(), "kyma-system").
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
 
 		By("CR created in kcp")
@@ -179,7 +180,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 		}, Timeout, Interval)
 
 		By("Remote Module Catalog created")
-		Eventually(ModuleTemplatesExist(runtimeClient, kyma, "kyma-system"), Timeout, Interval).Should(Succeed())
+		Eventually(ModuleTemplatesExist(runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace), Timeout, Interval).Should(Succeed())
 		Eventually(func() error {
 			remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.GetNamespace())
 			if err != nil {
@@ -193,18 +194,18 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 		By("Remote Kyma should contain Watcher labels and annotations")
 		Eventually(WatcherLabelsAnnotationsExist, Timeout, Interval).
-			WithArguments(runtimeClient, kyma, "kyma-system").
+			WithArguments(runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
 		moduleToBeUpdated := kyma.Spec.Modules[0].Name
 
 		By("Update SKR Module Template spec.data.spec field")
 		Eventually(updateModuleTemplateSpec,
 			Timeout, Interval).
-			WithArguments(runtimeClient, "kyma-system", moduleToBeUpdated, "valueUpdated").
+			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace, moduleToBeUpdated, "valueUpdated").
 			Should(Succeed())
 
 		By("Expect SKR Module Template spec.data.spec field get reset")
 		Eventually(expectModuleTemplateSpecGetReset, Timeout, Interval).
-			WithArguments(runtimeClient, "kyma-system", moduleToBeUpdated, "initValue").Should(Succeed())
+			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace, moduleToBeUpdated, "initValue").Should(Succeed())
 	})
 })

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -180,7 +180,9 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 		}, Timeout, Interval)
 
 		By("Remote Module Catalog created")
-		Eventually(ModuleTemplatesExist(runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace), Timeout, Interval).Should(Succeed())
+		Eventually(ModuleTemplatesExist(runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace),
+			Timeout, Interval).
+			Should(Succeed())
 		Eventually(func() error {
 			remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.GetNamespace())
 			if err != nil {
@@ -206,6 +208,8 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 		By("Expect SKR Module Template spec.data.spec field get reset")
 		Eventually(expectModuleTemplateSpecGetReset, Timeout, Interval).
-			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace, moduleToBeUpdated, "initValue").Should(Succeed())
+			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace,
+				moduleToBeUpdated, "initValue").
+			Should(Succeed())
 	})
 })

--- a/controllers/kyma_controller_remote_sync_test.go
+++ b/controllers/kyma_controller_remote_sync_test.go
@@ -48,11 +48,11 @@ var _ = Describe("Kyma with multiple module CRs in remote sync mode", Ordered, f
 	It("CR add from client should be synced in both clusters", func() {
 		By("Remote Kyma created")
 		Eventually(KymaExists, Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetName(), kyma.GetNamespace()).
+			WithArguments(runtimeClient, kyma.GetName(), "kyma-system").
 			Should(Succeed())
 
 		By("add skr-module-client to remoteKyma.spec.modules")
-		Eventually(UpdateRemoteModule(ctx, runtimeClient, kyma, []v1beta2.Module{
+		Eventually(UpdateRemoteModule(ctx, runtimeClient, kyma, "kyma-system", []v1beta2.Module{
 			skrModuleFromClient,
 		}), Timeout, Interval).Should(Succeed())
 
@@ -158,7 +158,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 	It("Kyma CR should be synchronized in both clusters", func() {
 		By("Remote Kyma created")
 		Eventually(KymaExists, Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetName(), kyma.GetNamespace()).
+			WithArguments(runtimeClient, kyma.GetName(), "kyma-system").
 			Should(Succeed())
 
 		By("CR created in kcp")
@@ -179,7 +179,7 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 		}, Timeout, Interval)
 
 		By("Remote Module Catalog created")
-		Eventually(ModuleTemplatesExist(runtimeClient, kyma), Timeout, Interval).Should(Succeed())
+		Eventually(ModuleTemplatesExist(runtimeClient, kyma, "kyma-system"), Timeout, Interval).Should(Succeed())
 		Eventually(func() error {
 			remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.GetNamespace())
 			if err != nil {
@@ -193,18 +193,18 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 
 		By("Remote Kyma should contain Watcher labels and annotations")
 		Eventually(WatcherLabelsAnnotationsExist, Timeout, Interval).
-			WithArguments(runtimeClient, kyma).
+			WithArguments(runtimeClient, kyma, "kyma-system").
 			Should(Succeed())
 		moduleToBeUpdated := kyma.Spec.Modules[0].Name
 
 		By("Update SKR Module Template spec.data.spec field")
 		Eventually(updateModuleTemplateSpec,
 			Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetNamespace(), moduleToBeUpdated, "valueUpdated").
+			WithArguments(runtimeClient, "kyma-system", moduleToBeUpdated, "valueUpdated").
 			Should(Succeed())
 
 		By("Expect SKR Module Template spec.data.spec field get reset")
 		Eventually(expectModuleTemplateSpecGetReset, Timeout, Interval).
-			WithArguments(runtimeClient, kyma.GetNamespace(), moduleToBeUpdated, "initValue").Should(Succeed())
+			WithArguments(runtimeClient, "kyma-system", moduleToBeUpdated, "initValue").Should(Succeed())
 	})
 })

--- a/controllers/kyma_controller_test.go
+++ b/controllers/kyma_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Kyma with empty ModuleTemplate", Ordered, func() {
 		Expect(
 			kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModuleCatalog, metav1.ConditionTrue)).To(BeTrue())
 		By("Module Catalog created")
-		Eventually(ModuleTemplatesExist(controlPlaneClient, kyma),
+		Eventually(ModuleTemplatesExist(controlPlaneClient, kyma, kyma.GetNamespace()),
 			Timeout, Interval).Should(Succeed())
 	})
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -140,6 +140,7 @@ var _ = BeforeSuite(func() {
 		ComponentDescriptorCache: componentDescriptorCache,
 		KcpRestConfig:            k8sManager.GetConfig(),
 		InKCPMode:                false,
+		RemoteSyncNamespace:      "kyma-system",
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		ComponentDescriptorCache: componentDescriptorCache,
 		KcpRestConfig:            k8sManager.GetConfig(),
 		InKCPMode:                false,
-		RemoteSyncNamespace:      "kyma-system",
+		RemoteSyncNamespace:      controllers.DefaultRemoteSyncNamespace,
 	}).SetupWithManager(k8sManager, controller.Options{},
 		controllers.SetupUpSetting{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -165,7 +165,7 @@ var _ = BeforeSuite(func() {
 		SkrWebhookMemoryLimits: "200Mi",
 		SkrWebhookCPULimits:    "1",
 		IstioNamespace:         metav1.NamespaceDefault,
-		RemoteSyncNamespace:    "kyma-system",
+		RemoteSyncNamespace:    controllers.DefaultRemoteSyncNamespace,
 	}
 
 	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(restCfg, skrChartCfg)
@@ -181,7 +181,7 @@ var _ = BeforeSuite(func() {
 		RemoteClientCache:        remoteClientCache,
 		ComponentDescriptorCache: componentDescriptorCache,
 		KcpRestConfig:            k8sManager.GetConfig(),
-		RemoteSyncNamespace:      "kyma-system",
+		RemoteSyncNamespace:      controllers.DefaultRemoteSyncNamespace,
 	}).SetupWithManager(k8sManager, controller.Options{}, controllers.SetupUpSetting{ListenerAddr: listenerAddr})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -165,7 +165,9 @@ var _ = BeforeSuite(func() {
 		SkrWebhookMemoryLimits: "200Mi",
 		SkrWebhookCPULimits:    "1",
 		IstioNamespace:         metav1.NamespaceDefault,
+		RemoteSyncNamespace:    "kyma-system",
 	}
+
 	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(restCfg, skrChartCfg)
 	Expect(err).ToNot(HaveOccurred())
 	err = (&controllers.KymaReconciler{
@@ -179,6 +181,7 @@ var _ = BeforeSuite(func() {
 		RemoteClientCache:        remoteClientCache,
 		ComponentDescriptorCache: componentDescriptorCache,
 		KcpRestConfig:            k8sManager.GetConfig(),
+		RemoteSyncNamespace:      "kyma-system",
 	}).SetupWithManager(k8sManager, controller.Options{}, controllers.SetupUpSetting{ListenerAddr: listenerAddr})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/flags.go
+++ b/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/kyma-project/lifecycle-manager/controllers"
 	"github.com/kyma-project/lifecycle-manager/pkg/log"
 )
 
@@ -108,7 +109,7 @@ func defineFlagVar() *FlagVar {
 		"Indicates the SKR Purge Finalizers execution delay in seconds")
 	flag.StringVar(&flagVar.skipPurgingFor, "skip-finalizer-purging-for", "", "Exclude the passed CRDs"+
 		" from finalizer removal. Example: 'ingressroutetcps.traefik.containo.us,*.helm.cattle.io'.")
-	flag.StringVar(&flagVar.remoteSyncNamespace, "sync-namespace", "kyma-system",
+	flag.StringVar(&flagVar.remoteSyncNamespace, "sync-namespace", controllers.DefaultRemoteSyncNamespace,
 		"Name of the namespace for syncing remote Kyma and module catalog")
 	return flagVar
 }

--- a/flags.go
+++ b/flags.go
@@ -108,8 +108,8 @@ func defineFlagVar() *FlagVar {
 		"Indicates the SKR Purge Finalizers execution delay in seconds")
 	flag.StringVar(&flagVar.skipPurgingFor, "skip-finalizer-purging-for", "", "Exclude the passed CRDs"+
 		" from finalizer removal. Example: 'ingressroutetcps.traefik.containo.us,*.helm.cattle.io'.")
-	flag.StringVar(&flagVar.remoteKymaNamespace, "sync-namespace", "kyma-system",
-		"Name of the namespace for syncing remote Kyma objects")
+	flag.StringVar(&flagVar.remoteSyncNamespace, "sync-namespace", "kyma-system",
+		"Name of the namespace for syncing remote Kyma and module catalog")
 	return flagVar
 }
 
@@ -152,5 +152,5 @@ type FlagVar struct {
 	enablePurgeFinalizer                   bool
 	purgeFinalizerTimeout                  time.Duration
 	skipPurgingFor                         string
-	remoteKymaNamespace                    string
+	remoteSyncNamespace                    string
 }

--- a/flags.go
+++ b/flags.go
@@ -101,13 +101,15 @@ func defineFlagVar() *FlagVar {
 		"indicates the current log-level, enter negative values to increase verbosity (e.g. 9)",
 	)
 	flag.BoolVar(&flagVar.inKCPMode, "in-kcp-mode", false,
-		"indicates lifecycle manager is deployed in control-plane mode")
+		"Indicates lifecycle manager is deployed in control-plane mode")
 	flag.BoolVar(&flagVar.enablePurgeFinalizer, "enable-purge-finalizer", false,
 		"Enabling purge finalizer")
 	flag.DurationVar(&flagVar.purgeFinalizerTimeout, "purge-finalizer-timeout", defaultPurgeFinalizerTimeout,
 		"Indicates the SKR Purge Finalizers execution delay in seconds")
 	flag.StringVar(&flagVar.skipPurgingFor, "skip-finalizer-purging-for", "", "Exclude the passed CRDs"+
 		" from finalizer removal. Example: 'ingressroutetcps.traefik.containo.us,*.helm.cattle.io'.")
+	flag.StringVar(&flagVar.remoteKymaNamespace, "sync-namespace", "kyma-system",
+		"Name of the namespace for syncing remote Kyma objects")
 	return flagVar
 }
 
@@ -150,4 +152,5 @@ type FlagVar struct {
 	enablePurgeFinalizer                   bool
 	purgeFinalizerTimeout                  time.Duration
 	skipPurgingFor                         string
+	remoteKymaNamespace                    string
 }

--- a/main.go
+++ b/main.go
@@ -234,8 +234,7 @@ func NewClient(
 func setupKymaReconciler(mgr ctrl.Manager,
 	remoteClientCache *remote.ClientCache,
 	componentDescriptorCache *ocmextensions.ComponentDescriptorCache,
-	flagVar *FlagVar,
-	options controller.Options,
+	flagVar *FlagVar, options controller.Options,
 ) {
 	options.MaxConcurrentReconciles = flagVar.maxConcurrentKymaReconciles
 

--- a/main.go
+++ b/main.go
@@ -253,6 +253,7 @@ func setupKymaReconciler(mgr ctrl.Manager,
 			WatcherLocalTestingEnabled: flagVar.enableWatcherLocalTesting,
 			GatewayHTTPPortMapping:     flagVar.listenerHTTPPortLocalMapping,
 			IstioNamespace:             flagVar.istioNamespace,
+			RemoteSyncNamespace:        flagVar.remoteSyncNamespace,
 		}
 		skrWebhookManager, err = watcher.NewSKRWebhookManifestManager(kcpRestConfig, skrWebhookConfig)
 		if err != nil {
@@ -274,7 +275,8 @@ func setupKymaReconciler(mgr ctrl.Manager,
 			PublicKeyFilePath:   flagVar.moduleVerificationKeyFilePath,
 			ValidSignatureNames: strings.Split(flagVar.moduleVerificationSignatureNames, ":"),
 		},
-		InKCPMode: flagVar.inKCPMode,
+		InKCPMode:           flagVar.inKCPMode,
+		RemoteSyncNamespace: flagVar.remoteSyncNamespace,
 	}).SetupWithManager(
 		mgr, options, controllers.SetupUpSetting{
 			ListenerAddr:                 flagVar.kymaListenerAddr,

--- a/pkg/module/parse/template_to_module.go
+++ b/pkg/module/parse/template_to_module.go
@@ -29,7 +29,8 @@ var (
 
 type Parser struct {
 	client.Client
-	InKCPMode bool
+	InKCPMode           bool
+	remoteSyncNamespace string
 	*ocmextensions.ComponentDescriptorCache
 }
 
@@ -37,11 +38,13 @@ func NewParser(
 	clnt client.Client,
 	descriptorCache *ocmextensions.ComponentDescriptorCache,
 	inKCPMode bool,
+	remoteSyncNamespace string,
 ) *Parser {
 	return &Parser{
 		Client:                   clnt,
 		ComponentDescriptorCache: descriptorCache,
 		InKCPMode:                inKCPMode,
+		remoteSyncNamespace:      remoteSyncNamespace,
 	}
 }
 
@@ -75,7 +78,7 @@ func (p *Parser) GenerateModulesFromTemplates(ctx context.Context,
 		fqdn := descriptor.GetName()
 		version := descriptor.GetVersion()
 		name := common.CreateModuleName(fqdn, kyma.Name, module.Name)
-		overwriteNameAndNamespace(&template, name, kyma.Namespace)
+		overwriteNameAndNamespace(&template, name, p.remoteSyncNamespace)
 		var obj client.Object
 		if obj, err = p.newManifestFromTemplate(ctx, module,
 			template.ModuleTemplate,
@@ -108,7 +111,7 @@ func overwriteNameAndNamespace(template *channel.ModuleTemplateTO, name, namespa
 	if template.ModuleTemplate.Spec.Data.GetName() == "" {
 		template.ModuleTemplate.Spec.Data.SetName(name)
 	}
-	// if the default data does not contain a namespace, default it to the kyma namespace
+	// if the default data does not contain a namespace, default it to the provided namespace
 	if template.ModuleTemplate.Spec.Data.GetNamespace() == "" {
 		template.ModuleTemplate.Spec.Data.SetNamespace(namespace)
 	}

--- a/pkg/remote/context.go
+++ b/pkg/remote/context.go
@@ -13,9 +13,9 @@ type syncContextKey = struct{}
 var ErrIsNoSyncContext = errors.New("the given value is not a pointer to a kyma synchronization context")
 
 func InitializeSyncContext(
-	ctx context.Context, kyma *v1beta2.Kyma, kcp Client, cache *ClientCache,
+	ctx context.Context, kyma *v1beta2.Kyma, syncNamespace string, kcp Client, cache *ClientCache,
 ) (context.Context, error) {
-	syncContext, err := InitializeKymaSynchronizationContext(ctx, kcp, cache, kyma)
+	syncContext, err := InitializeKymaSynchronizationContext(ctx, kcp, cache, kyma, syncNamespace)
 	if err != nil {
 		return ctx, err
 	}

--- a/pkg/remote/kyma_synchronization_context.go
+++ b/pkg/remote/kyma_synchronization_context.go
@@ -35,7 +35,7 @@ type KymaSynchronizationContext struct {
 }
 
 func InitializeKymaSynchronizationContext(
-	ctx context.Context, kcp Client, cache *ClientCache, kyma *v1beta2.Kyma,
+	ctx context.Context, kcp Client, cache *ClientCache, kyma *v1beta2.Kyma, syncNamespace string,
 ) (*KymaSynchronizationContext, error) {
 	strategyValue, found := kyma.Annotations[v1beta2.SyncStrategyAnnotation]
 	syncStrategy := v1beta2.SyncStrategyLocalSecret
@@ -53,7 +53,7 @@ func InitializeKymaSynchronizationContext(
 		RuntimeClient:      skr,
 	}
 
-	if err := sync.ensureRemoteNamespaceExists(ctx, kyma); err != nil {
+	if err := sync.ensureRemoteNamespaceExists(ctx, syncNamespace); err != nil {
 		return nil, err
 	}
 
@@ -61,10 +61,10 @@ func InitializeKymaSynchronizationContext(
 }
 
 func (c *KymaSynchronizationContext) GetRemotelySyncedKyma(
-	ctx context.Context, controlPlaneKyma *v1beta2.Kyma,
+	ctx context.Context, controlPlaneKyma *v1beta2.Kyma, remoteSyncNamespace string,
 ) (*v1beta2.Kyma, error) {
 	remoteKyma := &v1beta2.Kyma{}
-	if err := c.RuntimeClient.Get(ctx, GetRemoteObjectKey(controlPlaneKyma), remoteKyma); err != nil {
+	if err := c.RuntimeClient.Get(ctx, GetRemoteObjectKey(controlPlaneKyma, remoteSyncNamespace), remoteKyma); err != nil {
 		return nil, err
 	}
 
@@ -72,11 +72,11 @@ func (c *KymaSynchronizationContext) GetRemotelySyncedKyma(
 }
 
 func RemoveFinalizerFromRemoteKyma(
-	ctx context.Context, kyma *v1beta2.Kyma,
+	ctx context.Context, kyma *v1beta2.Kyma, remoteSyncNamespace string,
 ) error {
 	syncContext := SyncContextFromContext(ctx)
 
-	remoteKyma, err := syncContext.GetRemotelySyncedKyma(ctx, kyma)
+	remoteKyma, err := syncContext.GetRemotelySyncedKyma(ctx, kyma, remoteSyncNamespace)
 	if err != nil {
 		return err
 	}
@@ -87,10 +87,10 @@ func RemoveFinalizerFromRemoteKyma(
 }
 
 func DeleteRemotelySyncedKyma(
-	ctx context.Context, kyma *v1beta2.Kyma,
+	ctx context.Context, kyma *v1beta2.Kyma, remoteSyncNamespace string,
 ) error {
 	syncContext := SyncContextFromContext(ctx)
-	remoteKyma, err := syncContext.GetRemotelySyncedKyma(ctx, kyma)
+	remoteKyma, err := syncContext.GetRemotelySyncedKyma(ctx, kyma, remoteSyncNamespace)
 	if err != nil {
 		return err
 	}
@@ -100,10 +100,10 @@ func DeleteRemotelySyncedKyma(
 
 // ensureRemoteNamespaceExists tries to ensure existence of a namespace for synchronization based on
 // name of controlPlaneKyma.namespace in this order.
-func (c *KymaSynchronizationContext) ensureRemoteNamespaceExists(ctx context.Context, kyma *v1beta2.Kyma) error {
+func (c *KymaSynchronizationContext) ensureRemoteNamespaceExists(ctx context.Context, syncNamespace string) error {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   kyma.GetNamespace(),
+			Name:   syncNamespace,
 			Labels: map[string]string{v1beta2.ManagedBy: v1beta2.OperatorName},
 		},
 		// setting explicit type meta is required for SSA on Namespaces
@@ -162,13 +162,13 @@ func (c *KymaSynchronizationContext) CreateOrUpdateCRD(ctx context.Context, plur
 }
 
 func (c *KymaSynchronizationContext) CreateOrFetchRemoteKyma(
-	ctx context.Context, kyma *v1beta2.Kyma,
+	ctx context.Context, kyma *v1beta2.Kyma, remoteSyncNamespace string,
 ) (*v1beta2.Kyma, error) {
 	recorder := adapter.RecorderFromContext(ctx)
 	remoteKyma := &v1beta2.Kyma{}
 
 	remoteKyma.Name = kyma.Name
-	remoteKyma.Namespace = kyma.Namespace
+	remoteKyma.Namespace = remoteSyncNamespace
 
 	err := c.RuntimeClient.Get(ctx, client.ObjectKeyFromObject(remoteKyma), remoteKyma)
 
@@ -260,9 +260,9 @@ func (c *KymaSynchronizationContext) ReplaceWithVirtualKyma(
 	}
 }
 
-func GetRemoteObjectKey(kyma *v1beta2.Kyma) client.ObjectKey {
+func GetRemoteObjectKey(kyma *v1beta2.Kyma, remoteSyncNamespace string) client.ObjectKey {
 	name := kyma.Name
-	namespace := kyma.Namespace
+	namespace := remoteSyncNamespace
 	return client.ObjectKey{Namespace: namespace, Name: name}
 }
 

--- a/pkg/remote/remote_catalog.go
+++ b/pkg/remote/remote_catalog.go
@@ -35,12 +35,12 @@ type Catalog interface {
 	Delete(ctx context.Context) error
 }
 
-func NewRemoteCatalogFromKyma(kyma *v1beta2.Kyma) *RemoteCatalog {
+func NewRemoteCatalogFromKyma(remoteSyncNamespace string) *RemoteCatalog {
 	force := true
 	return NewRemoteCatalog(
 		Settings{
 			SSAPatchOptions: &client.PatchOptions{FieldManager: moduleCatalogSyncFieldManager, Force: &force},
-			Namespace:       kyma.Namespace,
+			Namespace:       remoteSyncNamespace,
 		},
 	)
 }

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -83,7 +83,8 @@ func (m *SKRWebhookManifestManager) Install(ctx context.Context, kyma *v1beta2.K
 	}
 	logger.V(log.DebugLevel).Info("Successfully created Certificate", "kyma", kymaObjKey)
 
-	resources, err := m.getSKRClientObjectsForInstall(ctx, syncContext.ControlPlaneClient, kymaObjKey, m.config.RemoteSyncNamespace, logger)
+	resources, err := m.getSKRClientObjectsForInstall(
+		ctx, syncContext.ControlPlaneClient, kymaObjKey, m.config.RemoteSyncNamespace, logger)
 	if err != nil {
 		return err
 	}
@@ -116,7 +117,8 @@ func (m *SKRWebhookManifestManager) Remove(ctx context.Context, kyma *v1beta2.Ky
 	}
 
 	skrClientObjects := m.getBaseClientObjects()
-	genClientObjects := getGeneratedClientObjects(&unstructuredResourcesConfig{}, map[string]WatchableConfig{}, m.config.RemoteSyncNamespace)
+	genClientObjects := getGeneratedClientObjects(
+		&unstructuredResourcesConfig{}, map[string]WatchableConfig{}, m.config.RemoteSyncNamespace)
 	skrClientObjects = append(skrClientObjects, genClientObjects...)
 	err = runResourceOperationWithGroupedErrors(ctx, syncContext.RuntimeClient, skrClientObjects,
 		func(ctx context.Context, clt client.Client, resource client.Object) error {

--- a/pkg/watcher/webhook_chart.go
+++ b/pkg/watcher/webhook_chart.go
@@ -100,10 +100,6 @@ func resolveKcpAddr(kcpConfig *rest.Config, managerConfig *SkrWebhookManagerConf
 	return net.JoinHostPort(externalIP, strconv.Itoa(int(port))), nil
 }
 
-func resolveRemoteNamespace(kyma *v1beta2.Kyma) string {
-	return kyma.Namespace
-}
-
 func ResolveTLSCertName(kymaName string) string {
 	return fmt.Sprintf(webhookTLSCfgNameTpl, kymaName)
 }


### PR DESCRIPTION
**Description**

Introduce a global `sync-namespace` flag that configures target namespace for Kyma and module catalog sync.
This changes previous behavior of taking this namespace from the Kyma object itself.
The `v1beta1` behavior for this was the (now removed) Spec.Sync.Namespace attribute.

Changes proposed in this pull request:

- introduce the `sync-namespace` flag
- adjust the logic and tests

**Related issue(s)**
