### PR TITLE
increase cpu limit to 4000 for control plane

### DIFF
--- a/config/control-plane/patches/adjust_resources_in_deployment.yaml
+++ b/config/control-plane/patches/adjust_resources_in_deployment.yaml
@@ -12,7 +12,7 @@ spec:
         - name: manager
           resources:
             limits:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4000Mi
             requests:
               cpu: 1000m


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Atm, LM in KCP DEV always reach 2000m CPU limit, bring CPU throttling. After run pprof, most CPU time spent on the conversion webhook, which we can't avoid.

This PR increased the CPU limit to 4000m, to see if it can be sufficient for LM to handle for CR conversion.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
