### PR TITLE
set deleted kyma log to debug level

### DIFF
--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -184,7 +184,7 @@ func (r *KymaReconciler) syncRemoteKymaSpecAndStatus(
 	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx, controlPlaneKyma, r.RemoteSyncNamespace)
 	if err != nil {
 		if errors.Is(err, remote.ErrNotFoundAndKCPKymaUnderDeleting) {
-
+			// remote kyma not found because it's deleted, should not continue
 			return nil
 		}
 		return fmt.Errorf("could not create or fetch remote kyma: %w", err)

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -104,7 +104,9 @@ func (r *KymaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		// requeue (we'll need to wait for a new notification), and we can get them
 		// on deleted requests.
 		if apierrors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("can not found Kyma %s, assume deleted successfully", req.NamespacedName))
+			// TODO: revisit this after runtime-controller get upgraded to newer version
+			// Related issue: https://github.com/kyma-project/lifecycle-manager/issues/579
+			logger.V(log.DebugLevel).Info(fmt.Sprintf("can not found Kyma %s, assume deleted", req.NamespacedName))
 		}
 
 		return ctrl.Result{}, client.IgnoreNotFound(err) //nolint:wrapcheck
@@ -182,7 +184,6 @@ func (r *KymaReconciler) syncRemoteKymaSpecAndStatus(
 	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx, controlPlaneKyma, r.RemoteSyncNamespace)
 	if err != nil {
 		if errors.Is(err, remote.ErrNotFoundAndKCPKymaUnderDeleting) {
-			//remote kyma not found because it's deleted, should not continue
 			return nil
 		}
 		return fmt.Errorf("could not create or fetch remote kyma: %w", err)

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -184,6 +184,7 @@ func (r *KymaReconciler) syncRemoteKymaSpecAndStatus(
 	remoteKyma, err := syncContext.CreateOrFetchRemoteKyma(ctx, controlPlaneKyma, r.RemoteSyncNamespace)
 	if err != nil {
 		if errors.Is(err, remote.ErrNotFoundAndKCPKymaUnderDeleting) {
+
 			return nil
 		}
 		return fmt.Errorf("could not create or fetch remote kyma: %w", err)


### PR DESCRIPTION
Atm, this info log constantly report unexisting kyma get reconciled, assume it's a bug from controller-runtime or could figure out the root cause at the moment, the current decision is temporarily downgrading to debug level to prevent it flooding log. At least those non exists kyma get into reconciling loop will not process further, hiding this log doesn't bring side effects.


**Related issue(s)**
https://github.com/kyma-project/lifecycle-manager/issues/579