### PR TITLE
Fix invalid remote kyma status sync

### DIFF
--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -28,6 +28,9 @@ patches:
       value: --in-kcp-mode=true
     - op: add
       path: /spec/template/spec/containers/0/args/-
+      value: --in-kcp-mode=true
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
       value: --listener-http-local-mapping=9443
     - op: add
       path: /spec/template/spec/containers/0/args/-

--- a/controllers/control-plane/kcp_controller_remote_sync_test.go
+++ b/controllers/control-plane/kcp_controller_remote_sync_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/controllers"
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 var (
@@ -188,6 +188,14 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 			Should(Succeed())
 		Eventually(containsModuleTemplateCondition, Timeout, Interval).
 			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace()).
+			Should(Succeed())
+
+		By("Remote Kyma contains correct conditions for Modules and ModuleTemplates")
+		Eventually(kymaHasCondition(v1beta2.ConditionTypeModules, "Ready", metav1.ConditionTrue), Timeout, Interval).
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
+			Should(Succeed())
+		Eventually(kymaHasCondition(v1beta2.ConditionTypeModuleCatalog, "Ready", metav1.ConditionTrue), Timeout, Interval).
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
 
 		By("Remote Kyma should contain Watcher labels and annotations")

--- a/pkg/remote/kyma_synchronization_context.go
+++ b/pkg/remote/kyma_synchronization_context.go
@@ -231,13 +231,12 @@ func (c *KymaSynchronizationContext) SynchronizeRemoteKyma(
 	return nil
 }
 
-// ReplaceWithVirtualKyma creates a virtual kyma instance from a control plane Kyma and one Remote Kymas,
-// merging the module specification in the process.
-func ReplaceWithVirtualKyma(
-	kyma *v1beta2.Kyma,
+// MergeModules merges modules specification from a control plane Kyma and a Remote Kymas.
+func MergeModules(
+	controlPlaneKyma *v1beta2.Kyma,
 	remoteKyma *v1beta2.Kyma,
 ) {
-	totalModuleAmount := len(kyma.Spec.Modules)
+	totalModuleAmount := len(controlPlaneKyma.Spec.Modules)
 	totalModuleAmount += len(remoteKyma.Spec.Modules)
 	modules := make(map[string]v1beta2.Module, totalModuleAmount)
 
@@ -245,15 +244,15 @@ func ReplaceWithVirtualKyma(
 		modules[m.Name] = m
 	}
 
-	for _, m := range kyma.Spec.Modules {
+	for _, m := range controlPlaneKyma.Spec.Modules {
 		modules[m.Name] = m
 	}
 
-	kyma.Spec.Modules = []v1beta2.Module{}
+	controlPlaneKyma.Spec.Modules = []v1beta2.Module{}
 	for _, m := range modules {
-		kyma.Spec.Modules = append(kyma.Spec.Modules, m)
+		controlPlaneKyma.Spec.Modules = append(controlPlaneKyma.Spec.Modules, m)
 	}
-	kyma.Spec.Channel = remoteKyma.Spec.Channel
+	controlPlaneKyma.Spec.Channel = remoteKyma.Spec.Channel
 }
 
 func GetRemoteObjectKey(kyma *v1beta2.Kyma, remoteSyncNamespace string) client.ObjectKey {

--- a/pkg/remote/kyma_synchronization_context_test.go
+++ b/pkg/remote/kyma_synchronization_context_test.go
@@ -60,7 +60,7 @@ func TestReplaceWithVirtualKyma(t *testing.T) {
 			t.Parallel()
 			kcpKyma := createKyma(testCase.kcpKyma.channel, testCase.kcpKyma.modules)
 			remoteKyma := createKyma(testCase.remoteKyma.channel, testCase.remoteKyma.modules)
-			remote.ReplaceWithVirtualKyma(kcpKyma, remoteKyma)
+			remote.MergeModules(kcpKyma, remoteKyma)
 			assert.Equal(t, testCase.expectedKyma.channel, kcpKyma.Spec.Channel)
 			var virtualModules []string
 			for _, module := range kcpKyma.Spec.Modules {


### PR DESCRIPTION
**Description**

Fix invalid sync of the remote Kyma `status.conditions`

Changes proposed in this pull request:

- Fix invalid sync of the remote Kyma `status.conditions`
- minor renaming to more readable identifiers

**Related issue(s)**
#618 