### PR TITLE
fix missing synchronization context for local testing

### DIFF
--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -23,6 +23,7 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --enable-watcher-local-testing
+      value: --in-kcp-mode=true
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --listener-http-local-mapping=9443

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -449,7 +449,7 @@ func (r *KymaReconciler) RecordKymaStatusMetrics(ctx context.Context, kyma *v1be
 }
 
 func (r *KymaReconciler) WatcherEnabled(kyma *v1beta2.Kyma) bool {
-	return kyma.HasSyncLabelEnabled() && r.SKRWebhookManager != nil
+	return r.SyncKymaEnabled(kyma) && r.SKRWebhookManager != nil
 }
 
 func (r *KymaReconciler) IsKymaManaged() bool {

--- a/flags.go
+++ b/flags.go
@@ -99,7 +99,7 @@ func defineFlagVar() *FlagVar {
 		"indicates the current log-level, enter negative values to increase verbosity (e.g. 9)",
 	)
 	flag.BoolVar(&flagVar.inKCPMode, "in-kcp-mode", false,
-		"Indicates lifecycle manager is deployed in control-plane mode")
+		"Indicates lifecycle manager is deployed in control-plane mode (multiple clusters mode)")
 	flag.BoolVar(&flagVar.enablePurgeFinalizer, "enable-purge-finalizer", false,
 		"Enabling purge finalizer")
 	flag.DurationVar(&flagVar.purgeFinalizerTimeout, "purge-finalizer-timeout", defaultPurgeFinalizerTimeout,


### PR DESCRIPTION
**Description**

Fixes panic in local testing introduced in #607 
Changes proposed in this pull request:

- Watcher is enabled only if Kyma Sync is enabled
- add missing "in-kcp-mode" flag to local testing Makefile target

**Related issue(s)**
#623 