### PR TITLE
Fix remote Kyma spec synced back to KCP Kyma

### DIFF
--- a/controllers/control-plane/kcp_controller_remote_sync_test.go
+++ b/controllers/control-plane/kcp_controller_remote_sync_test.go
@@ -144,17 +144,15 @@ var _ = Describe("Kyma with remote module templates", Ordered, func() {
 	})
 })
 
-var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
+var _ = FDescribe("Kyma sync into Remote Cluster", Ordered, func() {
 	kyma := NewTestKyma("kyma-test-remote-skr")
 	kyma.Labels[v1beta2.SyncLabel] = v1beta2.EnableLabelValue
-
-	kyma.Spec.Modules = append(
-		kyma.Spec.Modules, v1beta2.Module{
-			ControllerName: "manifest",
-			Name:           "skr-remote-module",
-			Channel:        v1beta2.DefaultChannel,
-		})
-
+	moduleInSkr := v1beta2.Module{
+		Name:    "skr-remote-module",
+		Channel: v1beta2.DefaultChannel,
+	}
+	template, err := ModuleTemplateFactory(moduleInSkr, unstructured.Unstructured{}, false)
+	Expect(err).ShouldNot(HaveOccurred())
 	registerControlPlaneLifecycleForKyma(kyma)
 
 	It("Kyma CR should be synchronized in both clusters", func() {
@@ -163,55 +161,64 @@ var _ = Describe("Kyma sync into Remote Cluster", Ordered, func() {
 			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
 
-		By("CR created in kcp")
-		for _, activeModule := range kyma.Spec.Modules {
-			Eventually(ManifestExists, Timeout, Interval).WithArguments(
-				ctx, kyma, activeModule, controlPlaneClient).Should(Succeed())
-		}
+		By("Module Template created")
+		Eventually(DeployModuleTemplate, Timeout, Interval).WithContext(ctx).
+			WithArguments(controlPlaneClient, moduleInSkr, false, false, false).
+			Should(Succeed())
+		Eventually(ModuleTemplateExists, Timeout, Interval).
+			WithArguments(ctx, controlPlaneClient, template.Name, template.Namespace).
+			Should(Succeed())
 
-		By("No spec.module in remote Kyma")
-		Eventually(func() error {
-			remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.GetNamespace())
-			if err != nil {
-				return err
-			}
-			if len(remoteKyma.Spec.Modules) != 0 {
-				return ErrContainsUnexpectedModules
-			}
-			return nil
-		}, Timeout, Interval)
+		By("No module synced to remote Kyma")
+		Eventually(containsNoModulesInSpec, Timeout, Interval).
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
+			Should(Succeed())
 
 		By("Remote Module Catalog created")
-		Eventually(ModuleTemplatesExist(ctx, runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace),
-			Timeout, Interval).
+		Eventually(ModuleTemplateExists, Timeout, Interval).
+			WithArguments(ctx, runtimeClient, template.Name, controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
-		Eventually(func() error {
-			remoteKyma, err := GetKyma(ctx, runtimeClient, kyma.GetName(), kyma.GetNamespace())
-			if err != nil {
-				return err
-			}
-			if !remoteKyma.ContainsCondition(v1beta2.ConditionTypeModuleCatalog) {
-				return ErrNotContainsExpectedCondition
-			}
-			return nil
-		}, Timeout, Interval)
+		Eventually(containsModuleTemplateCondition, Timeout, Interval).
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace).
+			Should(Succeed())
+		Eventually(containsModuleTemplateCondition, Timeout, Interval).
+			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace()).
+			Should(Succeed())
 
 		By("Remote Kyma should contain Watcher labels and annotations")
 		Eventually(watcherLabelsAnnotationsExist, Timeout, Interval).
 			WithArguments(runtimeClient, kyma, controllers.DefaultRemoteSyncNamespace).
 			Should(Succeed())
-		moduleToBeUpdated := kyma.Spec.Modules[0].Name
+	})
 
+	It("Enable module in SKR Kyma CR", func() {
+		By("add module to remote Kyma")
+		Eventually(addModuleToKyma, Timeout, Interval).
+			WithArguments(runtimeClient, kyma.GetName(), controllers.DefaultRemoteSyncNamespace, moduleInSkr).
+			Should(Succeed())
+
+		By("SKR module not sync back to KCP Kyma")
+		Consistently(containsNoModulesInSpec, Timeout, Interval).
+			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace()).
+			Should(Succeed())
+
+		By("Manifest CR created in KCP")
+		Eventually(ManifestExists, Timeout, Interval).
+			WithArguments(ctx, kyma, moduleInSkr, controlPlaneClient).
+			Should(Succeed())
+	})
+
+	It("Synced Module Template should get reset after changed", func() {
 		By("Update SKR Module Template spec.data.spec field")
 		Eventually(updateModuleTemplateSpec,
 			Timeout, Interval).
-			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace, moduleToBeUpdated, "valueUpdated").
+			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace, moduleInSkr.Name, "valueUpdated").
 			Should(Succeed())
 
 		By("Expect SKR Module Template spec.data.spec field get reset")
 		Eventually(expectModuleTemplateSpecGetReset, Timeout, Interval).
 			WithArguments(runtimeClient, controllers.DefaultRemoteSyncNamespace,
-				moduleToBeUpdated, "initValue").
+				moduleInSkr.Name, "initValue").
 			Should(Succeed())
 	})
 })

--- a/controllers/kyma_controller.go
+++ b/controllers/kyma_controller.go
@@ -49,8 +49,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type EventReasonError string
-type EventReasonInfo string
+type (
+	EventReasonError string
+	EventReasonInfo  string
+)
 
 const (
 	moduleReconciliationError  EventReasonError = "ModuleReconciliationError"
@@ -149,9 +151,6 @@ func (r *KymaReconciler) reconcile(ctx context.Context, kyma *v1beta2.Kyma) (ctr
 	}
 
 	if r.SyncKymaEnabled(kyma) { //nolint:nestif
-		if err := r.syncRemoteKyma(ctx, kyma); err != nil {
-			return r.requeueWithError(ctx, kyma, fmt.Errorf("could not synchronize remote kyma: %w", err))
-		}
 		updateKymaRequired, err := r.syncCrdsAndUpdateKymaAnnotations(ctx, kyma)
 		if err != nil {
 			return r.requeueWithError(ctx, kyma, fmt.Errorf("could not sync CRDs: %w", err))
@@ -161,6 +160,9 @@ func (r *KymaReconciler) reconcile(ctx context.Context, kyma *v1beta2.Kyma) (ctr
 				return r.requeueWithError(ctx, kyma, fmt.Errorf("could not update kyma annotations: %w", err))
 			}
 			return ctrl.Result{}, nil
+		}
+		if err := r.syncRemoteKyma(ctx, kyma); err != nil {
+			return r.requeueWithError(ctx, kyma, fmt.Errorf("could not synchronize remote kyma: %w", err))
 		}
 	}
 

--- a/controllers/kyma_controller_test.go
+++ b/controllers/kyma_controller_test.go
@@ -67,8 +67,9 @@ var _ = Describe("Kyma with empty ModuleTemplate", Ordered, func() {
 		Expect(
 			kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModuleCatalog, metav1.ConditionTrue)).To(BeFalse())
 		By("Module Catalog created")
-		Eventually(ModuleTemplatesExist(ctx, controlPlaneClient, kyma, kyma.GetNamespace()),
-			Timeout, Interval).Should(Succeed())
+		Eventually(AllModuleTemplatesExists, Timeout, Interval).
+			WithArguments(ctx, controlPlaneClient, kyma, kyma.GetNamespace()).
+			Should(Succeed())
 	})
 })
 

--- a/pkg/remote/crd_upgrade.go
+++ b/pkg/remote/crd_upgrade.go
@@ -32,7 +32,8 @@ const (
 )
 
 func updateRemoteCRD(ctx context.Context, kyma *v1beta2.Kyma, runtimeClient Client,
-	crdFromRuntime *v1extensions.CustomResourceDefinition, kcpCrd *v1extensions.CustomResourceDefinition) (bool, error) {
+	crdFromRuntime *v1extensions.CustomResourceDefinition, kcpCrd *v1extensions.CustomResourceDefinition,
+) (bool, error) {
 	if ShouldPatchRemoteCRD(crdFromRuntime, kcpCrd, kyma) {
 		err := PatchCRD(ctx, runtimeClient, kcpCrd)
 		if err != nil {
@@ -47,7 +48,8 @@ func updateRemoteCRD(ctx context.Context, kyma *v1beta2.Kyma, runtimeClient Clie
 
 func ShouldPatchRemoteCRD(
 	runtimeCrd *v1extensions.CustomResourceDefinition, kcpCrd *v1extensions.CustomResourceDefinition,
-	kyma *v1beta2.Kyma) bool {
+	kyma *v1beta2.Kyma,
+) bool {
 	kcpAnnotation := getAnnotation(kcpCrd, KCP)
 	skrAnnotation := getAnnotation(runtimeCrd, SKR)
 
@@ -70,7 +72,8 @@ func getAnnotation(crd *v1extensions.CustomResourceDefinition, crdType CrdType) 
 }
 
 func SyncCrdsAndUpdateKymaAnnotations(ctx context.Context, kyma *v1beta2.Kyma,
-	runtimeClient Client, controlPlaneClient Client) (bool, error) {
+	runtimeClient Client, controlPlaneClient Client,
+) (bool, error) {
 	kymaCrdUpdated, err := fetchCrdsAndUpdateKymaAnnotations(ctx, controlPlaneClient,
 		runtimeClient, kyma, v1beta2.KymaKind.Plural())
 	if err != nil {
@@ -87,7 +90,8 @@ func SyncCrdsAndUpdateKymaAnnotations(ctx context.Context, kyma *v1beta2.Kyma,
 }
 
 func fetchCrdsAndUpdateKymaAnnotations(ctx context.Context, controlPlaneClient Client,
-	runtimeClient Client, kyma *v1beta2.Kyma, plural string) (bool, error) {
+	runtimeClient Client, kyma *v1beta2.Kyma, plural string,
+) (bool, error) {
 	kcpCrd, skrCrd, err := fetchCrds(ctx, controlPlaneClient, runtimeClient, plural)
 	if err != nil {
 		return false, err
@@ -113,7 +117,8 @@ func fetchCrdsAndUpdateKymaAnnotations(ctx context.Context, controlPlaneClient C
 }
 
 func fetchCrds(ctx context.Context, controlPlaneClient Client, runtimeClient Client, plural string) (
-	*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinition, error) {
+	*v1extensions.CustomResourceDefinition, *v1extensions.CustomResourceDefinition, error,
+) {
 	crd := &v1extensions.CustomResourceDefinition{}
 	crdFromRuntime := &v1extensions.CustomResourceDefinition{}
 	err := controlPlaneClient.Get(
@@ -123,7 +128,6 @@ func fetchCrds(ctx context.Context, controlPlaneClient Client, runtimeClient Cli
 			Name: fmt.Sprintf("%s.%s", plural, v1beta2.GroupVersion.Group),
 		}, crd,
 	)
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/remote/kyma_synchronization_context_test.go
+++ b/pkg/remote/kyma_synchronization_context_test.go
@@ -1,8 +1,9 @@
 package remote_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/pkg/remote"

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -413,7 +413,8 @@ func ExpectKymaManagerField(
 }
 
 func GetModuleTemplate(ctx context.Context,
-	clnt client.Client, name, namespace string) (*v1beta2.ModuleTemplate, error) {
+	clnt client.Client, name, namespace string,
+) (*v1beta2.ModuleTemplate, error) {
 	moduleTemplateInCluster := &v1beta2.ModuleTemplate{}
 	moduleTemplateInCluster.SetNamespace(namespace)
 	moduleTemplateInCluster.SetName(name)
@@ -425,7 +426,8 @@ func GetModuleTemplate(ctx context.Context,
 }
 
 func ManifestExists(ctx context.Context,
-	kyma *v1beta2.Kyma, module v1beta2.Module, controlPlaneClient client.Client) error {
+	kyma *v1beta2.Kyma, module v1beta2.Module, controlPlaneClient client.Client,
+) error {
 	_, err := GetManifest(ctx, controlPlaneClient, kyma, module)
 	if k8serrors.IsNotFound(err) {
 		return ErrNotFound
@@ -441,15 +443,14 @@ func ModuleTemplateExists(ctx context.Context, client client.Client, name, names
 	return nil
 }
 
-func ModuleTemplatesExist(ctx context.Context,
-	clnt client.Client, kyma *v1beta2.Kyma, remoteSyncNamespace string) func() error {
-	return func() error {
-		for _, module := range kyma.Spec.Modules {
-			if err := ModuleTemplateExists(ctx, clnt, module.Name, remoteSyncNamespace); err != nil {
-				return err
-			}
+func AllModuleTemplatesExists(ctx context.Context,
+	clnt client.Client, kyma *v1beta2.Kyma, remoteSyncNamespace string,
+) error {
+	for _, module := range kyma.Spec.Modules {
+		if err := ModuleTemplateExists(ctx, clnt, module.Name, remoteSyncNamespace); err != nil {
+			return err
 		}
-
-		return nil
 	}
+
+	return nil
 }


### PR DESCRIPTION
This PR fixed the problem the vitrual kyma get updated into KCP by relocate the syncRemoteKyma after kyma update, also add an integration test to make sure KCP kyma spec not changed after reconcilation.