### PR TITLE
Improve manifest resource cache

### DIFF
--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -248,6 +248,7 @@ func (r *Reconciler) syncResources(
 	status.Synced = newSynced
 
 	if len(ResourcesDiff(oldSynced, newSynced)) > 0 {
+		r.Event(obj, "Warning", "SyncTarget", ErrResourceSyncStateDiff.Error())
 		obj.SetStatus(status.WithState(StateProcessing).WithOperation(ErrResourceSyncStateDiff.Error()))
 		return ErrResourceSyncStateDiff
 	}

--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -248,13 +248,14 @@ func (r *Reconciler) syncResources(
 
 	oldSynced := status.Synced
 	newSynced := NewInfoToResourceConverter().InfosToResources(target)
-	status.Synced = newSynced
 
 	if len(ResourcesDiff(oldSynced, newSynced)) > 0 {
 		r.Event(obj, "Warning", "SyncTarget", ErrResourceSyncStateDiff.Error())
 		obj.SetStatus(status.WithState(StateProcessing).WithOperation(ErrResourceSyncStateDiff.Error()))
 		return ErrResourceSyncStateDiff
 	}
+
+	status.Synced = newSynced
 
 	for i := range r.PostRuns {
 		if err := r.PostRuns[i](ctx, clnt, r.Client, obj); err != nil {


### PR DESCRIPTION
This PR tries to enhance the error handling by evict the cache when the ErrResourceSyncStateDiff is detected, it might be because the resources cached are different than the synced resources. It's worth recreate the cache by rendering raw manifest.