### PR TITLE
retry parsing raw ymal before saving into cache

### DIFF
--- a/internal/declarative/v2/inmemory_rendered.go
+++ b/internal/declarative/v2/inmemory_rendered.go
@@ -57,7 +57,7 @@ func (c *InMemoryManifestCache) Parse(
 		return nil, err
 	}
 
-	resources, err := internal.ParseManifestStringToObjects(string(rendered))
+	resources, err := internal.ConsistencyParseManifest(string(rendered))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util.go
+++ b/internal/util.go
@@ -75,11 +75,11 @@ func ConsistencyParseManifest(manifest string) (*ManifestResources, error) {
 		return nil, err
 	}
 	for i := 0; i < ParseRetries; i++ {
-		temp, err := ParseManifestStringToObjects(manifest)
+		tempResources, err := ParseManifestStringToObjects(manifest)
 		if err != nil {
 			return nil, err
 		}
-		if len(temp.Items) != len(resources.Items) {
+		if len(tempResources.Items) != len(resources.Items) {
 			return nil, ErrParseInconsistent
 		}
 	}


### PR DESCRIPTION
At the moment, it seems `ParseManifestStringToObjects` logic is not consistency, we got the internal incident that the resources saved in cache has diff compared to raw yaml, this PR introduced `ConsistencyParseManifest` by introduce parsing retry to reduce the chance that inconsistency happens before save into cache. 
