### PR TITLE
Fix parallel file cache access

### DIFF
--- a/internal/manifest/v1beta1/parse.go
+++ b/internal/manifest/v1beta1/parse.go
@@ -23,8 +23,7 @@ const manifestFileName = "raw-manifest.yaml"
 
 var (
 	//nolint:gochecknoglobals
-	fileMutexMap                         = sync.Map{}
-	ErrUnknownTypeDuringHeaderExtraction = errors.New("unknown type encountered during header extraction")
+	fileMutexMap = sync.Map{}
 )
 
 func GetPathFromRawManifest(ctx context.Context,


### PR DESCRIPTION
**Description**

This PR introduces an in-memory locking mechanism to avoid parallel writes to the same file when handling raw manifests.
This also ensures there are no `reads` of the file when the `write` is still pending.
All of this is to ensure the read/write consistency of the data.

Changes proposed in this pull request:

For any specific file:

1) only a single goroutine may check if the file exists, all other writers/readers must wait
2) only a single goroutine may create the file and write data to it, all other writers/readers must wait

Operation 1) is very fast so though it's performed many times, the additional locking is not expected to impact performance (to be verified).
Operation 2) is slow, but it's executed only once per module version in the Lifecycle-Manager lifetime. It creates a local file with raw manifest data for a specific module template hash.

The file operations on different files (paths) are not mutually locked because these can be safely executed in parallel.

**Related issue(s)**
https://github.com/kyma-project/lifecycle-manager/issues/663