### PR TITLE
Get credSecretSelector from install layer instead of optional config layer

### DIFF
--- a/internal/manifest/v1beta1/spec_resolver.go
+++ b/internal/manifest/v1beta1/spec_resolver.go
@@ -59,12 +59,7 @@ func (m *ManifestSpecResolver) Spec(ctx context.Context, obj declarative.Object)
 		return nil, err
 	}
 
-	keyChain, err := m.lookupKeyChain(ctx, manifest.Spec.Config)
-	if err != nil {
-		return nil, err
-	}
-
-	rawManifestInfo, err := m.getRawManifestForInstall(ctx, manifest.Spec.Install, specType, keyChain)
+	rawManifestInfo, err := m.getRawManifestForInstall(ctx, manifest.Spec.Install, specType)
 	if err != nil {
 		return nil, err
 	}
@@ -95,13 +90,17 @@ func (m *ManifestSpecResolver) getRawManifestForInstall(
 	ctx context.Context,
 	install v1beta2.InstallInfo,
 	specType v1beta2.RefTypeMetadata,
-	keyChain authn.Keychain,
 ) (*RawManifestInfo, error) {
 	var err error
 	switch specType {
 	case v1beta2.OciRefType:
 		var imageSpec v1beta2.ImageSpec
 		if err = m.Codec.Decode(install.Source.Raw, &imageSpec, specType); err != nil {
+			return nil, err
+		}
+
+		keyChain, err := m.lookupKeyChain(ctx, imageSpec)
+		if err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
With current implementation, the credSecretSelector for private oci registry access secret are coming from config layer (which is not used anymore), if the module template doesn't contains config layer, it will failed to get the secret and use default keychain. This PR fixed it by changes to get the credSecretSelector from install layer.