### PR TITLE
introduce component descriptor cache

### DIFF
--- a/api/v1beta2/moduletemplate_types.go
+++ b/api/v1beta2/moduletemplate_types.go
@@ -120,7 +120,7 @@ func (m *ModuleTemplate) GetDescriptor() (*Descriptor, error) {
 	descriptor := m.GetDescFromCache()
 	if descriptor == nil {
 		desc, err := compdesc.Decode(
-			m.Spec.Descriptor.Raw, append([]compdesc.DecodeOption{compdesc.DisableValidation(true)})...,
+			m.Spec.Descriptor.Raw, []compdesc.DecodeOption{compdesc.DisableValidation(true)}...,
 		)
 		if err != nil {
 			return nil, err

--- a/api/v1beta2/moduletemplate_webhook.go
+++ b/api/v1beta2/moduletemplate_webhook.go
@@ -45,7 +45,7 @@ var _ webhook.Validator = &ModuleTemplate{}
 func (m *ModuleTemplate) ValidateCreate() error {
 	logf.Log.WithName("moduletemplate-resource").
 		Info("validate create", "name", m.Name)
-	newDescriptor, err := m.Spec.GetDescriptor()
+	newDescriptor, err := m.GetDescriptor()
 	if err != nil {
 		return err
 	}
@@ -56,12 +56,12 @@ func (m *ModuleTemplate) ValidateCreate() error {
 func (m *ModuleTemplate) ValidateUpdate(old runtime.Object) error {
 	logf.Log.WithName("moduletemplate-resource").
 		Info("validate update", "name", m.Name)
-	newDescriptor, err := m.Spec.GetDescriptor()
+	newDescriptor, err := m.GetDescriptor()
 	if err != nil {
 		return err
 	}
 	oldTemplate := old.(*ModuleTemplate)
-	oldDescriptor, err := oldTemplate.Spec.GetDescriptor()
+	oldDescriptor, err := oldTemplate.GetDescriptor()
 	if err != nil {
 		return err
 	}

--- a/api/v1beta2/webhook_moduletemplate_crd_validation_test.go
+++ b/api/v1beta2/webhook_moduletemplate_crd_validation_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Webhook ValidationCreate Strict", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(k8sClient.Create(webhookServerContext, template)).Should(Succeed())
 
-		descriptor, err := template.Spec.GetDescriptor()
+		descriptor, err := template.GetDescriptor()
 		Expect(err).ToNot(HaveOccurred())
 		version, err := semver.NewVersion(descriptor.Version)
 		Expect(err).ToNot(HaveOccurred())

--- a/config/load_test/kustomization.yaml
+++ b/config/load_test/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - metrics_role.yaml
   - metrics_role_binding.yaml
   - ../manager
+  - ../certmanager
+
 generatorOptions:
   disableNameSuffixHash: true
 
@@ -36,39 +38,87 @@ patchesJson6902:
 
 patchesStrategicMerge:
   - patches/adjust_resources_in_deployment.yaml
+  # Mount the controller config file for loading manager configurations
+  # through a ComponentConfig type
+  #  - manager_config_patch.yaml
+  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+  # crd/kustomization.yaml
+  - manager_webhook_patch.yaml
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+  # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+  # 'CERTMANAGER' needs to be enabled to use ca injection
+  - webhookcainjection_patch.yaml
+# the following config is for teaching kustomize how to do var substitution
+vars:
+  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+    objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert # this name should match the one in certificate.yaml
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: CERTIFICATE_NAME
+    objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: serving-cert # this name should match the one in certificate.yaml
+  - name: SERVICE_NAMESPACE # namespace of the service
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: SERVICE_NAME
+    objref:
+      kind: Service
+      version: v1
+      name: webhook-service
 
 patches:
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --max-concurrent-reconciles=10
+        value: --pprof=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --in-kcp-mode
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --log-level=9
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --rate-limiter-burst=2000
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --rate-limiter-frequency=2000           
+        value: --rate-limiter-frequency=1000
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-webhook-memory-limits=2000Mi      
+        value: --max-concurrent-manifest-reconciles=25
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-webhook-cpu-limits=1000m
+        value: --max-concurrent-kyma-reconciles=50
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --pprof=true      
+        value: --cache-sync-timeout=60m
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --cache-sync-timeout=60m      
+        value: --failure-max-delay=30s
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --failure-max-delay=30s    
+        value: --kyma-requeue-success-interval=1m
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --failure-base-delay=5ms      
+        value: --manifest-requeue-success-interval=1m
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --kyma-requeue-success-interval=5m
+        value: --watcher-requeue-success-interval=1m
     target:
       kind: Deployment
 
@@ -81,9 +131,7 @@ components:
 #  - ../istio
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
   # crd/kustomization.yaml
-  #- ../webhook
-  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-  #- ../certmanager
+  - ../webhook
   # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
   - ../prometheus
   # [GRAFANA] To generate configmap for provision grafana dashboard

--- a/config/load_test/manager_webhook_patch.yaml
+++ b/config/load_test/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/load_test/webhookcainjection_patch.yaml
+++ b/config/load_test/webhookcainjection_patch.yaml
@@ -1,0 +1,18 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+
+# No MutatingWebhookConfiguration needed, uncomment follow when necessary
+
+#apiVersion: admissionregistration.k8s.io/v1
+#kind: MutatingWebhookConfiguration
+#metadata:
+#  name: mutating-webhook-configuration
+#  annotations:
+#    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+#---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/controllers/kyma_controller_helper_test.go
+++ b/controllers/kyma_controller_helper_test.go
@@ -145,7 +145,7 @@ func CreateModuleTemplateSetsForKyma(modules []v1beta2.Module, modifiedVersion, 
 			return err
 		}
 
-		descriptor, err := template.Spec.GetDescriptor()
+		descriptor, err := template.GetDescriptor()
 		if err != nil {
 			return err
 		}

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -95,7 +95,6 @@ func (r *KymaReconciler) SetupWithManager(mgr ctrl.Manager,
 func (r *KymaReconciler) watchEventChannel(controllerBuilder *builder.Builder, eventChannel *source.Channel) {
 	controllerBuilder.Watches(eventChannel, &handler.Funcs{
 		GenericFunc: func(event event.GenericEvent, queue workqueue.RateLimitingInterface) {
-
 			logger := ctrl.Log.WithName("listener")
 			unstructWatcherEvt, conversionOk := event.Object.(*unstructured.Unstructured)
 			if !conversionOk {

--- a/internal/manifest/v1beta1/manifest_controller_test.go
+++ b/internal/manifest/v1beta1/manifest_controller_test.go
@@ -110,7 +110,6 @@ var _ = Describe(
 
 var _ = Describe(
 	"Given manifest with private registry", func() {
-		Skip("refactor this test to not use external oci registry")
 		manifest := &v1beta2.Manifest{}
 		manifestPath := filepath.Join("../../../pkg/test_samples/oci", "private-registry-manifest.yaml")
 		manifestFile, err := os.ReadFile(manifestPath)
@@ -125,10 +124,13 @@ var _ = Describe(
 		Expect(err).ToNot(HaveOccurred())
 
 		It("Should create Manifest", func() {
+			Skip("refactor this test to not use external oci registry")
 			Expect(k8sClient.Create(ctx, manifest)).To(Succeed())
 		})
 
 		It("Manifest should be in Error state with no auth secret found error message", func() {
+			Skip("refactor this test to not use external oci registry")
+
 			Eventually(func() error {
 				status, err := getManifestStatus(manifest.GetName())
 				if err != nil {

--- a/internal/manifest/v1beta1/manifest_controller_test.go
+++ b/internal/manifest/v1beta1/manifest_controller_test.go
@@ -110,6 +110,7 @@ var _ = Describe(
 
 var _ = Describe(
 	"Given manifest with private registry", func() {
+		Skip("refactor this test to not use external oci registry")
 		manifest := &v1beta2.Manifest{}
 		manifestPath := filepath.Join("../../../pkg/test_samples/oci", "private-registry-manifest.yaml")
 		manifestFile, err := os.ReadFile(manifestPath)

--- a/internal/manifest/v1beta1/spec_resolver.go
+++ b/internal/manifest/v1beta1/spec_resolver.go
@@ -47,7 +47,8 @@ var (
 )
 
 func (m *ManifestSpecResolver) Spec(ctx context.Context, obj declarative.Object,
-	remoteClient client.Client) (*declarative.Spec, error) {
+	remoteClient client.Client,
+) (*declarative.Spec, error) {
 	manifest, ok := obj.(*v1beta2.Manifest)
 	if !ok {
 		return nil, fmt.Errorf(

--- a/pkg/channel/lookup.go
+++ b/pkg/channel/lookup.go
@@ -126,7 +126,7 @@ func CheckValidTemplateUpdate(
 	if moduleTemplate.Spec.Channel != moduleStatus.Channel {
 		checkLog.Info("outdated ModuleTemplate: channel skew")
 
-		descriptor, err := moduleTemplate.Spec.GetDescriptor()
+		descriptor, err := moduleTemplate.GetDescriptor()
 		if err != nil {
 			msg := "could not handle channel skew as descriptor from template cannot be fetched"
 			checkLog.Error(err, msg)
@@ -289,7 +289,7 @@ func (c *TemplateLookup) getTemplate(ctx context.Context, desiredChannel string)
 			filteredTemplates = append(filteredTemplates, template)
 			continue
 		}
-		descriptor, err := template.Spec.GetDescriptor()
+		descriptor, err := template.GetDescriptor()
 		if err != nil {
 			return nil, fmt.Errorf("invalid ModuleTemplate descriptor: %w", err)
 		}

--- a/pkg/module/parse/template_to_module.go
+++ b/pkg/module/parse/template_to_module.go
@@ -63,7 +63,7 @@ func (p *Parser) GenerateModulesFromTemplates(ctx context.Context,
 			})
 			continue
 		}
-		descriptor, err := template.Spec.GetDescriptor()
+		descriptor, err := template.GetDescriptor()
 		if err != nil {
 			template.Err = err
 			modules = append(modules, &common.Module{
@@ -137,7 +137,7 @@ func (p *Parser) newManifestFromTemplate(
 
 	var layers img.Layers
 	var err error
-	descriptor, err := template.Spec.GetDescriptor()
+	descriptor, err := template.GetDescriptor()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -222,7 +222,7 @@ func GetManifest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	descriptor, err := template.Spec.GetDescriptor()
+	descriptor, err := template.GetDescriptor()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR improved the performance to cache the component descriptor, to avoid repeatly doing heavy CPU intensive yaml unmarshal in  `compdesc.Decode`

check the pprof for detail (click below)
![pprof001](https://github.com/kyma-project/lifecycle-manager/assets/2189071/17dd8112-bf02-4129-b6b6-10f593ea95c4)
