### PR TITLE
Fix: skr-webhook sidecar alpine image from internal registry that is signed

### DIFF
--- a/skr-webhook/resources.yaml
+++ b/skr-webhook/resources.yaml
@@ -124,7 +124,7 @@ spec:
             - containerPort: 8443
               name: watcher-port
         - name: request-sidecar
-          image: alpine
+          image: europe-docker.pkg.dev/kyma-project/prod/external/alpine:3.17.4
           command:
             - /bin/sh
             - "-c"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Warden validation webhook is rejecting images that are not signed from us on skr cluster, so we need to pick a verified image from our registry for the skr-webhook sidecar

**Related issue(s)**
* https://github.com/kyma-project/lifecycle-manager/issues/704
