### PR TITLE
reduce kyma workers

### DIFF
--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -58,7 +58,7 @@ patches:
         value: --max-concurrent-manifest-reconciles=25
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --max-concurrent-kyma-reconciles=50
+        value: --max-concurrent-kyma-reconciles=25
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --failure-max-delay=30s


### PR DESCRIPTION
at the moment, with 50 kyma, it's not increase the perfomance (reducing processing latency) too much, in stead increased the CPU usage, lower to 25 can reduce CPU stress.