### PR TITLE
Unregister histogram metrics with high cardinality

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - interfacer # deprecated (since v1.38.0)
     - ireturn # TODO enable and fix
     - maligned # deprecated (since v1.38.0)
+    - mnd # TODO temporary disabled
     - nlreturn # too strict and mostly code is not more readable
     - nosnakecase  # deprecated (since v1.48.1) and replaced by 'revive'
     - scopelint # deprecated (since v1.39.0) and replaced by 'exportloopref'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,6 @@ linters:
     - interfacer # deprecated (since v1.38.0)
     - ireturn # TODO enable and fix
     - maligned # deprecated (since v1.38.0)
-    - mnd # TODO temporary disabled
     - nlreturn # too strict and mostly code is not more readable
     - nosnakecase  # deprecated (since v1.48.1) and replaced by 'revive'
     - scopelint # deprecated (since v1.39.0) and replaced by 'exportloopref'

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,7 +33,6 @@ var (
 )
 
 func Initialize() {
-
 	requestLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: "rest_client",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,6 +32,7 @@ var (
 	}, []string{moduleNameLabel, kymaNameLabel, stateLabel, shootIDLabel, instanceIDLabel})
 )
 
+//nolint:gomnd
 func Initialize() {
 	requestLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -34,6 +34,8 @@ var (
 
 //nolint:gomnd
 func Initialize() {
+	// TODO this is a temporary fix
+	// we need to conclude the controller-runtime upgrade to 0.15+ and remove this
 	requestLatency := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: "rest_client",
@@ -68,6 +70,8 @@ func Initialize() {
 		[]string{"verb", "host"},
 	)
 
+	// TODO unregistering these metrics is a temporary fix
+	// we need to conclude the controller-runtime upgrade to 0.15+ and remove
 	ctrlMetrics.Registry.Unregister(requestLatency)
 	ctrlMetrics.Registry.Unregister(requestDuration)
 	ctrlMetrics.Registry.Unregister(requestSize)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,6 +33,46 @@ var (
 )
 
 func Initialize() {
+
+	requestLatency := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: "rest_client",
+			Name:      "request_latency_seconds",
+			Help:      "Request latency in seconds. Broken down by verb and URL.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 10),
+		},
+		[]string{"verb", "url"},
+	)
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_request_duration_seconds",
+			Help:    "Request latency in seconds. Broken down by verb, and host.",
+			Buckets: []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
+		},
+		[]string{"verb", "host"},
+	)
+	requestSize := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_request_size_bytes",
+			Help:    "Request size in bytes. Broken down by verb and host.",
+			Buckets: []float64{64, 256, 512, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216},
+		},
+		[]string{"verb", "host"},
+	)
+	responseSize := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_response_size_bytes",
+			Help:    "Response size in bytes. Broken down by verb and host.",
+			Buckets: []float64{64, 256, 512, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216},
+		},
+		[]string{"verb", "host"},
+	)
+
+	ctrlMetrics.Registry.Unregister(requestLatency)
+	ctrlMetrics.Registry.Unregister(requestDuration)
+	ctrlMetrics.Registry.Unregister(requestSize)
+	ctrlMetrics.Registry.Unregister(responseSize)
+
 	ctrlMetrics.Registry.MustRegister(kymaStateGauge)
 	ctrlMetrics.Registry.MustRegister(moduleStateGauge)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove the generation of unused metrics since the cardinality is too high on productive environments

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
