### PR TITLE
fix watcher e2e

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -117,18 +117,20 @@ jobs:
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
       - name: Deploy LM local testing kustomize
         run: |
-          if make local-deploy-with-watcher IMG=europe-docker.pkg.dev/kyma-project/$KLM_IMAGE_REPO/lifecycle-manager:$KLM_VERSION_TAG; then
-            echo "KLM deployed successfully"
-          else
-            echo "Deploy encountered some error, will retry after 1 minute"
-            sleep 60
+          maxRetry=5
+          for i in $(seq 1 $maxRetry)
+          do
             if make local-deploy-with-watcher IMG=europe-docker.pkg.dev/kyma-project/$KLM_IMAGE_REPO/lifecycle-manager:$KLM_VERSION_TAG; then
-                echo "KLM deployed successfully"
+              echo "KLM deployed successfully"
+              exit 0
+            elif [[ $retry -lt $maxRetry ]]; then
+              echo "Deploy encountered some error, will retry after 20 seconds"
+              sleep 20
             else
               echo "KLM deployment failed"
               exit 1
             fi
-          fi
+          done
       - name: Run Watcher E2E Tests
         run: |
           make -C tests/e2e_test test

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,6 @@ jobs:
       CM_VERSION: v1.12.0
       KLM_VERSION_TAG: latest
       KLM_IMAGE_REPO: prod
-      DIND: false
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -132,8 +132,5 @@ jobs:
             fi
           done
       - name: Run Watcher E2E Tests
-        continue-on-error: true
         run: |
           make -C tests/e2e_test test
-      - name: Debugging with ssh
-        uses: lhotari/action-upterm@v1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -132,5 +132,8 @@ jobs:
             fi
           done
       - name: Run Watcher E2E Tests
+        continue-on-error: true
         run: |
           make -C tests/e2e_test test
+      - name: Debugging with ssh
+        uses: lhotari/action-upterm@v1

--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -32,16 +32,22 @@ patches:
       value: --enable-watcher-local-testing
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --in-kcp-mode=true
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
       value: --listener-http-local-mapping=9443
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --enable-domain-name-pinning=true
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --kyma-requeue-success-interval=30s
+      value: --kyma-requeue-success-interval=2m
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --manifest-requeue-success-interval=30s
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --log-level=9
+    - op: replace
+      path: /spec/template/spec/containers/0/imagePullPolicy
+      value: Always
   target:
     kind: Deployment
 - patch: |-

--- a/controllers/kyma_test.go
+++ b/controllers/kyma_test.go
@@ -63,7 +63,6 @@ var _ = Describe("Kyma with no Module", Ordered, func() {
 			return nil
 		}, Timeout, Interval).
 			Should(Succeed())
-
 	})
 })
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -52,8 +52,10 @@ func ParseManifestToObjects(path string) (ManifestResources, error) {
 }
 
 func getID(item *unstructured.Unstructured) string {
-	return strings.Join([]string{item.GetNamespace(), item.GetName(),
-		item.GroupVersionKind().Group, item.GroupVersionKind().Version, item.GroupVersionKind().Kind}, "/")
+	return strings.Join([]string{
+		item.GetNamespace(), item.GetName(),
+		item.GroupVersionKind().Group, item.GroupVersionKind().Version, item.GroupVersionKind().Kind,
+	}, "/")
 }
 
 func GetResourceLabel(resource client.Object, labelName string) (string, error) {

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -46,6 +46,16 @@ const (
 var ErrNotFound = errors.New("resource not exists")
 
 func NewTestKyma(name string) *v1beta2.Kyma {
+	return newKCPKymaWithNamespace(name, v1.NamespaceDefault, v1beta2.DefaultChannel, v1beta2.SyncStrategyLocalClient)
+}
+
+func NewKymaForE2E(name, namespace, channel string) *v1beta2.Kyma {
+	kyma := newKCPKymaWithNamespace(name, namespace, channel, v1beta2.SyncStrategyLocalSecret)
+	kyma.Labels[v1beta2.SyncLabel] = v1beta2.EnableLabelValue
+	return kyma
+}
+
+func newKCPKymaWithNamespace(name, namespace, channel, syncStrategy string) *v1beta2.Kyma {
 	return &v1beta2.Kyma{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: v1beta2.GroupVersion.String(),
@@ -53,15 +63,18 @@ func NewTestKyma(name string) *v1beta2.Kyma {
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", name, randString(randomStringLength)),
-			Namespace: v1.NamespaceDefault,
+			Namespace: namespace,
 			Annotations: map[string]string{
 				watcher.DomainAnnotation:       "example.domain.com",
-				v1beta2.SyncStrategyAnnotation: v1beta2.SyncStrategyLocalClient,
+				v1beta2.SyncStrategyAnnotation: syncStrategy,
+			},
+			Labels: map[string]string{
+				v1beta2.InstanceIDLabel: "test-instance",
 			},
 		},
 		Spec: v1beta2.KymaSpec{
 			Modules: []v1beta2.Module{},
-			Channel: v1beta2.DefaultChannel,
+			Channel: channel,
 		},
 	}
 }

--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -38,4 +38,4 @@ test: test-watcher-e2e ## Runs the all E2E Tests
 
 .PHONY: test-watcher-e2e
 test-watcher-e2e: ## Runs the Watcher E2E Test
-	go test --tags=e2e -v
+	go test --tags=e2e -ginkgo.vv

--- a/tests/e2e_test/suite_test.go
+++ b/tests/e2e_test/suite_test.go
@@ -21,7 +21,6 @@ import (
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	yaml2 "k8s.io/apimachinery/pkg/util/yaml"
 
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -73,11 +72,6 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	externalCRDs := AppendExternalCRDs(
-		filepath.Join("../..", "config", "samples", "tests", "crds"),
-		"cert-manager-v1.10.1.crds.yaml",
-		"istio-v1.17.1.crds.yaml")
-
 	// kcpModule CRD
 	controlPlaneCrd := &v1.CustomResourceDefinition{}
 	modulePath := filepath.Join("../..", "config", "samples", "component-integration-installed",
@@ -107,11 +101,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	controlPlaneEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("../..", "config", "crd", "bases")},
-		CRDs:                  append([]*v1.CustomResourceDefinition{controlPlaneCrd}, externalCRDs...),
-		ErrorIfCRDPathMissing: true,
-		UseExistingCluster:    &existingCluster,
-		Config:                controlPlaneRESTConfig,
+		UseExistingCluster: &existingCluster,
+		Config:             controlPlaneRESTConfig,
 	}
 	controlPlaneClient, err = client.New(controlPlaneRESTConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e_test/suite_test.go
+++ b/tests/e2e_test/suite_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/kyma-project/lifecycle-manager/api"
@@ -57,7 +56,6 @@ var (
 
 	ctx    context.Context    //nolint:gochecknoglobals
 	cancel context.CancelFunc //nolint:gochecknoglobals
-	isDinD bool               //nolint:gochecknoglobals
 )
 
 func TestAPIs(t *testing.T) {
@@ -80,10 +78,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(moduleFile).ToNot(BeEmpty())
 	Expect(yaml2.Unmarshal(moduleFile, &controlPlaneCrd)).To(Succeed())
-
-	//dind
-	isDinD, err = getTestRuntimeEnvironment()
-	Expect(err).NotTo(HaveOccurred())
 
 	// k8s configs
 	controlPlaneConfig, runtimeConfig, err = getKubeConfigs()
@@ -145,14 +139,6 @@ var _ = AfterSuite(func() {
 	err = controlPlaneEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
-
-func getTestRuntimeEnvironment() (bool, error) {
-	dockerInDockerValue := os.Getenv(dockerInDocker)
-	if dockerInDockerValue == "" {
-		return false, fmt.Errorf("%w: %s", errEmptyEnvVar, dockerInDocker)
-	}
-	return strings.ToLower(dockerInDockerValue) == "true", nil
-}
 
 func getKubeConfigs() (*[]byte, *[]byte, error) {
 	controlPlaneConfigFile := os.Getenv(kcpConfigEnvVar)

--- a/tests/e2e_test/suite_test.go
+++ b/tests/e2e_test/suite_test.go
@@ -6,14 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kyma-project/lifecycle-manager/pkg/log"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kyma-project/lifecycle-manager/api"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/pkg/log"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/rest"
 
 	//nolint:gci

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -8,9 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/pkg/watcher"
@@ -28,7 +29,7 @@ import (
 
 const (
 	timeout      = 10 * time.Second
-	readyTimeout = 1 * time.Minute
+	readyTimeout = 2 * time.Minute
 	interval     = 1 * time.Second
 
 	watcherPodContainer = "server"
@@ -169,6 +170,7 @@ func checkKymaReady(ctx context.Context, kymaName, kymaNamespace string, k8sClie
 	if err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kyma); err != nil {
 		return err
 	}
+	GinkgoWriter.Printf("kyma %v\n", kyma)
 	if kyma.Status.State != v1beta2.StateReady {
 		return errKymaNotReady
 	}
@@ -199,6 +201,7 @@ func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, 
 
 func createKymaSecret(ctx context.Context, kymaName, kymaNamespace, channel string, k8sClient client.Client) error {
 	hostnameToBeReplaced := resolveHostToBeReplaced()
+	GinkgoWriter.Printf("hostnameToBeReplaced:  %s\n", hostnameToBeReplaced)
 	patchedRuntimeConfig := strings.ReplaceAll(string(*runtimeConfig), hostnameToBeReplaced, k3dHostname)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -297,7 +300,8 @@ func checkKLMLogs(ctx context.Context, logMsg string, controlPlaneConfig, runtim
 	if err != nil {
 		return err
 	}
-	return fmt.Errorf("%w\n Expected: %s\n Given KLM logs: %s Watcher-Server-Logs: %s", errLogNotFound, logMsg, logs, watcherLogs)
+	GinkgoWriter.Printf("watcher Logs:  %s\n", watcherLogs)
+	return errLogNotFound
 }
 
 func getPodLogs(ctx context.Context, config *rest.Config, k8sClient client.Client, namespace, podPrefix, container string) (string, error) {

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -199,16 +199,7 @@ func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, 
 			Modules: nil,
 		},
 	}
-	GinkgoWriter.Printf("kyma before create: %v\n", kyma)
-	if err := k8sClient.Create(ctx, kyma); err != nil {
-		return err
-	}
-	kymaInCluster := &v1beta2.Kyma{}
-	if err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kymaInCluster); err != nil {
-		return err
-	}
-	GinkgoWriter.Printf("kyma after create: %v\n", kymaInCluster)
-	return nil
+	return k8sClient.Create(ctx, kyma)
 }
 
 func createKymaSecret(ctx context.Context, kymaName, kymaNamespace, channel string, k8sClient client.Client) error {

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -199,7 +199,16 @@ func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, 
 			Modules: nil,
 		},
 	}
-	return k8sClient.Create(ctx, kyma)
+	GinkgoWriter.Printf("kyma before create: %v\n", kyma)
+	if err := k8sClient.Create(ctx, kyma); err != nil {
+		return err
+	}
+	kymaInCluster := &v1beta2.Kyma{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kymaInCluster); err != nil {
+		return err
+	}
+	GinkgoWriter.Printf("kyma after create: %v\n", kymaInCluster)
+	return nil
 }
 
 func createKymaSecret(ctx context.Context, kymaName, kymaNamespace, channel string, k8sClient client.Client) error {

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -179,7 +179,7 @@ func checkKymaReady(ctx context.Context, kymaName, kymaNamespace string, k8sClie
 
 func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, k8sClient client.Client) error {
 	kyma := &v1beta2.Kyma{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1beta2.GroupVersion.String(),
 			Kind:       string(v1beta2.KymaKind),
 		},

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -179,6 +179,10 @@ func checkKymaReady(ctx context.Context, kymaName, kymaNamespace string, k8sClie
 
 func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, k8sClient client.Client) error {
 	kyma := &v1beta2.Kyma{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1beta2.GroupVersion.String(),
+			Kind:       string(v1beta2.KymaKind),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kymaName,
 			Namespace: kymaNamespace,
@@ -187,8 +191,7 @@ func createKymaCR(ctx context.Context, kymaName, kymaNamespace, channel string, 
 				"operator.kyma-project.io/sync":       "true",
 			},
 			Annotations: map[string]string{
-				"operator.kyma-project.io/sync": "true",
-				"skr-domain":                    exampleSKRDomain,
+				"skr-domain": exampleSKRDomain,
 			},
 		},
 		Spec: v1beta2.KymaSpec{


### PR DESCRIPTION
This PR mainly fixed watcher e2e test by removing envTest CRD overwrites, which will remove the conversion webhook in CRD definition, which makes kyma CR not convert as expected.
It also refactoring exists test cases.