### PR TITLE
stop upgrade ubuntu every time for e2e test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,8 +40,6 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt update -y
-          sudo apt upgrade -y
           sudo apt install git curl wget make bash golang-go -y
       - name: Install Istio CLI
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
+          sudo add-apt-repository ppa:longsleep/golang-backports -y
           sudo apt update -y
           sudo apt install git curl wget make bash golang-go -y
       - name: Install Istio CLI

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
+          sudo apt update -y
           sudo apt install git curl wget make bash golang-go -y
       - name: Install Istio CLI
         run: |


### PR DESCRIPTION
We don't need to do upgrade this one time ubuntu system every time

```
Get:101 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 netstandard-targeting-pack-2.1 amd64 6.0.120-0ubuntu1~22.04.1 [1398 kB]
Preconfiguring packages ...
Fetched 529 MB in 12min 3s (732 kB/s)
```