### PR TITLE
Fix wrong naming of iterator

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Deploy LM local testing kustomize
         run: |
           maxRetry=5
-          for i in $(seq 1 $maxRetry)
+          for retry in $(seq 1 $maxRetry)
           do
             if make local-deploy-with-watcher IMG=europe-docker.pkg.dev/kyma-project/$KLM_IMAGE_REPO/lifecycle-manager:$KLM_VERSION_TAG; then
               echo "KLM deployed successfully"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The iterator was called `i` but used as `retry`, thus we never went to into the `else` since retry was always unset and thus lower than `maxRetry`
- Renamed the iterator to `retry` so it is actually counting up

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
