### PR TITLE
fix failed to create webhook chart manager

### DIFF
--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func() {
 		RemoteSyncNamespace:    controllers.DefaultRemoteSyncNamespace,
 	}
 
-	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(k8sClient, skrChartCfg)
+	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(restCfg, scheme.Scheme, skrChartCfg)
 	Expect(err).ToNot(HaveOccurred())
 	err = (&controllers.KymaReconciler{
 		Client:            k8sManager.GetClient(),

--- a/controllers/withwatcher/suite_with_watcher_test.go
+++ b/controllers/withwatcher/suite_with_watcher_test.go
@@ -176,7 +176,7 @@ var _ = BeforeSuite(func() {
 		RemoteSyncNamespace:    controllers.DefaultRemoteSyncNamespace,
 	}
 
-	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(restCfg, skrChartCfg)
+	skrWebhookChartManager, err := watcher.NewSKRWebhookManifestManager(k8sClient, skrChartCfg)
 	Expect(err).ToNot(HaveOccurred())
 	err = (&controllers.KymaReconciler{
 		Client:            k8sManager.GetClient(),

--- a/main.go
+++ b/main.go
@@ -277,7 +277,7 @@ func setupKymaReconciler(mgr ctrl.Manager,
 }
 
 func createSkrWebhookManager(mgr ctrl.Manager, flagVar *FlagVar) (watcher.SKRWebhookManager, error) {
-	return watcher.NewSKRWebhookManifestManager(mgr.GetClient(), &watcher.SkrWebhookManagerConfig{
+	return watcher.NewSKRWebhookManifestManager(mgr.GetConfig(), mgr.GetScheme(), &watcher.SkrWebhookManagerConfig{
 		SKRWatcherPath:              flagVar.skrWatcherPath,
 		SkrWatcherImage:             flagVar.skrWatcherImage,
 		SkrWebhookCPULimits:         flagVar.skrWebhookCPULimits,

--- a/main.go
+++ b/main.go
@@ -235,19 +235,8 @@ func setupKymaReconciler(mgr ctrl.Manager,
 			setupLog.Error(err, "failed to read local skr chart")
 			os.Exit(1)
 		}
-		skrWebhookManager, err = watcher.NewSKRWebhookManifestManager(mgr.GetClient(), &watcher.SkrWebhookManagerConfig{
-			SKRWatcherPath:              flagVar.skrWatcherPath,
-			SkrWatcherImage:             flagVar.skrWatcherImage,
-			SkrWebhookCPULimits:         flagVar.skrWebhookCPULimits,
-			SkrWebhookMemoryLimits:      flagVar.skrWebhookMemoryLimits,
-			WatcherLocalTestingEnabled:  flagVar.enableWatcherLocalTesting,
-			LocalGatewayHTTPPortMapping: flagVar.listenerHTTPSPortLocalMapping,
-			IstioNamespace:              flagVar.istioNamespace,
-			IstioGatewayName:            flagVar.istioGatewayName,
-			IstioGatewayNamespace:       flagVar.istioGatewayNamespace,
-			RemoteSyncNamespace:         flagVar.remoteSyncNamespace,
-		})
-		if err != nil {
+
+		if skrWebhookManager, err = createSkrWebhookManager(mgr, flagVar); err != nil {
 			setupLog.Error(err, "failed to create webhook chart manager")
 			os.Exit(1)
 		}
@@ -285,6 +274,21 @@ func setupKymaReconciler(mgr ctrl.Manager,
 		setupPurgeReconciler(mgr, remoteClientCache, flagVar, options, kcpRestConfig)
 	}
 	metrics.Initialize()
+}
+
+func createSkrWebhookManager(mgr ctrl.Manager, flagVar *FlagVar) (watcher.SKRWebhookManager, error) {
+	return watcher.NewSKRWebhookManifestManager(mgr.GetClient(), &watcher.SkrWebhookManagerConfig{
+		SKRWatcherPath:              flagVar.skrWatcherPath,
+		SkrWatcherImage:             flagVar.skrWatcherImage,
+		SkrWebhookCPULimits:         flagVar.skrWebhookCPULimits,
+		SkrWebhookMemoryLimits:      flagVar.skrWebhookMemoryLimits,
+		WatcherLocalTestingEnabled:  flagVar.enableWatcherLocalTesting,
+		LocalGatewayHTTPPortMapping: flagVar.listenerHTTPSPortLocalMapping,
+		IstioNamespace:              flagVar.istioNamespace,
+		IstioGatewayName:            flagVar.istioGatewayName,
+		IstioGatewayNamespace:       flagVar.istioGatewayNamespace,
+		RemoteSyncNamespace:         flagVar.remoteSyncNamespace,
+	})
 }
 
 func setupPurgeReconciler(

--- a/main.go
+++ b/main.go
@@ -233,6 +233,7 @@ func setupKymaReconciler(mgr ctrl.Manager,
 		watcherChartDirInfo, err := os.Stat(flagVar.skrWatcherPath)
 		if err != nil || !watcherChartDirInfo.IsDir() {
 			setupLog.Error(err, "failed to read local skr chart")
+			os.Exit(1)
 		}
 		skrWebhookManager, err = watcher.NewSKRWebhookManifestManager(mgr.GetClient(), &watcher.SkrWebhookManagerConfig{
 			SKRWatcherPath:              flagVar.skrWatcherPath,
@@ -248,6 +249,7 @@ func setupKymaReconciler(mgr ctrl.Manager,
 		})
 		if err != nil {
 			setupLog.Error(err, "failed to create webhook chart manager")
+			os.Exit(1)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func setupKymaReconciler(mgr ctrl.Manager,
 		if err != nil || !watcherChartDirInfo.IsDir() {
 			setupLog.Error(err, "failed to read local skr chart")
 		}
-		skrWebhookManager, err = watcher.NewSKRWebhookManifestManager(kcpRestConfig, &watcher.SkrWebhookManagerConfig{
+		skrWebhookManager, err = watcher.NewSKRWebhookManifestManager(mgr.GetClient(), &watcher.SkrWebhookManagerConfig{
 			SKRWatcherPath:              flagVar.skrWatcherPath,
 			SkrWatcherImage:             flagVar.skrWatcherImage,
 			SkrWebhookCPULimits:         flagVar.skrWebhookCPULimits,

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -67,7 +67,7 @@ func NewSKRWebhookManifestManager(kcpConfig *rest.Config,
 	}
 	kcpClient, err := client.New(kcpConfig, client.Options{Scheme: schema})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't create kcpClient: %w", err)
 	}
 	resolvedKcpAddr, err := resolveKcpAddr(kcpClient, managerConfig)
 	if err != nil {

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -48,7 +48,9 @@ type SkrWebhookManagerConfig struct {
 	LocalGatewayHTTPPortMapping int
 }
 
-func NewSKRWebhookManifestManager(kcpClient client.Client, managerConfig *SkrWebhookManagerConfig) (*SKRWebhookManifestManager, error) {
+func NewSKRWebhookManifestManager(kcpClient client.Client,
+	managerConfig *SkrWebhookManagerConfig,
+) (*SKRWebhookManifestManager, error) {
 	logger := logf.FromContext(context.TODO())
 	manifestFilePath := fmt.Sprintf(rawManifestFilePathTpl, managerConfig.SKRWatcherPath)
 	rawManifestFile, err := os.Open(manifestFilePath)

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -49,8 +48,7 @@ type SkrWebhookManagerConfig struct {
 	LocalGatewayHTTPPortMapping int
 }
 
-func NewSKRWebhookManifestManager(kcpRestConfig *rest.Config, managerConfig *SkrWebhookManagerConfig,
-) (*SKRWebhookManifestManager, error) {
+func NewSKRWebhookManifestManager(kcpClient client.Client, managerConfig *SkrWebhookManagerConfig) (*SKRWebhookManifestManager, error) {
 	logger := logf.FromContext(context.TODO())
 	manifestFilePath := fmt.Sprintf(rawManifestFilePathTpl, managerConfig.SKRWatcherPath)
 	rawManifestFile, err := os.Open(manifestFilePath)
@@ -62,7 +60,7 @@ func NewSKRWebhookManifestManager(kcpRestConfig *rest.Config, managerConfig *Skr
 	if err != nil {
 		return nil, err
 	}
-	resolvedKcpAddr, err := resolveKcpAddr(kcpRestConfig, managerConfig)
+	resolvedKcpAddr, err := resolveKcpAddr(kcpClient, managerConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
LM failed to start with

```
{"level":"ERROR","date":"2023-08-09T13:34:52.133656664Z","logger":"setup","caller":"workspace/main.go:240","msg":"failed to create webhook chart manager","context":{"error":"the cache is not started, can not read objects"},"stacktrace":"main.setupKymaReconciler\n\t/workspace/main.go:240\nmain.setupManager\n\t/workspace/main.go:160\nmain.main\n\t/workspace/main.go:111\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}

```