### PR TITLE
Introduce resourceversion to ComponentDescriptor cache key

### DIFF
--- a/api/v1beta2/moduletemplate_types.go
+++ b/api/v1beta2/moduletemplate_types.go
@@ -184,7 +184,7 @@ func init() {
 }
 
 func (m *ModuleTemplate) GetComponentDescriptorCacheKey() string {
-	return fmt.Sprintf("%s:%s:%d", m.Name, m.Spec.Channel, m.Generation)
+	return fmt.Sprintf("%s:%s:%d:%s", m.Name, m.Spec.Channel, m.Generation, m.ResourceVersion)
 }
 
 func (m *ModuleTemplate) SyncEnabled(betaEnabled, internalEnabled bool) bool {


### PR DESCRIPTION
At the moment, the module team test moduletemplate by maunaully upload in skr cluster, after verify everything works, they apply new version of moduletemplate in KCP. With current cache key, it may leads to the situation that old, new version use same cache key, since the generation id can be `1` in both case. 

This PR introduce ResourceVersion as another key to distinguish different moduletemplate.