### PR TITLE
Fix propagate warning state

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -99,8 +99,6 @@ jobs:
           cmctl check api --wait=2m
       - name: Checkout repo
         uses: actions/checkout@v3
-        with:
-          path: ./lifecycle-manager/
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -112,8 +110,6 @@ jobs:
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
       - name: Deploy LM local testing kustomize
         run: |
-          pwd
-          ls
           maxRetry=5
           for retry in $(seq 1 $maxRetry)
           do
@@ -138,7 +134,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: github.com/kyma-project/template-operator
-          path: ./template-operator/
+          path: ../template-operator/
+      - name: Create Template Operator Module
+        run: |
+          pwd
+          ls
       - name: Run Status Propagation Tests
         run: |
           make -C tests/e2e_test test-status-propagation-e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,6 +153,7 @@ jobs:
           popd
           
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
+          sed 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000'
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -129,14 +129,14 @@ jobs:
               exit 1
             fi
           done
-      - name: Run Watcher E2E Tests
-        working-directory: ./lifecycle-manager
-        run: |
-          make -C tests/e2e_test test-watcher-e2e
-      - name: Run Kyma CR Deletion Test
-        working-directory: ./lifecycle-manager
-        run: |
-          make -C tests/e2e_test test-kyma-deletion-e2e
+#      - name: Run Watcher E2E Tests
+#        working-directory: ./lifecycle-manager
+#        run: |
+#          make -C tests/e2e_test test-watcher-e2e
+#      - name: Run Kyma CR Deletion Test
+#        working-directory: ./lifecycle-manager
+#        run: |
+#          make -C tests/e2e_test test-kyma-deletion-e2e
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -154,6 +154,7 @@ jobs:
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 0.0.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
+          kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests
         working-directory: ./lifecycle-manager

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -147,13 +147,12 @@ jobs:
           echo "- op: replace
             path: /spec/template/spec/containers/0/args/1
             value: --final-state=Warning" >> warning_patch.yaml
-           
           cat warning_patch.yaml
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
-          
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
           sed -i 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000/g' ./template.yaml
+          kubectl config use-context k3d-kcp
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           FILE=/etc/hosts
           if [ -f "$FILE" ]; then
-              sudo echo "127.0.0.1 k3d-kcp-registry.localhost" | sudo tee -a $FILE
+              sudo echo "127.0.0.1 k3d-kcp-registry" | sudo tee -a $FILE
           else
               echo "$FILE does not exist."
               exit 1
@@ -152,7 +152,7 @@ jobs:
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           
-          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry.localhost:5111 --insecure --module-archive-version-overwrite /
+          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,7 +153,8 @@ jobs:
           popd
           
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
-          sed 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000'
+          sed -i 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000/g' ./template.yaml
+          cat template.yaml
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       K3D_VERSION: v5.4.7
       ISTIO_VERSION: 1.17.1
-      CM_VERSION: v1.12.0
+      CM_VERSION: v1.12.3
       KLM_VERSION_TAG: latest
       KLM_IMAGE_REPO: prod
     steps:
@@ -82,7 +82,7 @@ jobs:
         run: |
           FILE=/etc/hosts
           if [ -f "$FILE" ]; then
-              sudo echo "127.0.0.1 k3d-kcp-registry" | sudo tee -a $FILE
+              sudo echo "127.0.0.1 k3d-kcp-registry.localhost" | sudo tee -a $FILE
           else
               echo "$FILE does not exist."
               exit 1
@@ -113,8 +113,6 @@ jobs:
       - name: Deploy LM local testing kustomize
         working-directory: ./lifecycle-manager
         run: |
-          pwd 
-          ls
           maxRetry=5
           for retry in $(seq 1 $maxRetry)
           do

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$CM_VERSION/cert-manager.yaml
           cmctl check api --wait=2m
-      - name: Checkout repo
+      - name: Checkout lifecycle-manager
         uses: actions/checkout@v3
         with:
           path: ./lifecycle-manager/
@@ -135,7 +135,7 @@ jobs:
         working-directory: ./lifecycle-manager
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
-      - name: Checkout repo
+      - name: Checkout template-operator
         uses: actions/checkout@v3
         with:
           repository: kyma-project/template-operator

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -99,6 +99,8 @@ jobs:
           cmctl check api --wait=2m
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          path: ./lifecycle-manager/
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -134,7 +136,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: kyma-project/template-operator
-          path: ../template-operator/
+          path: ./template-operator/
       - name: Create Template Operator Module
         run: |
           echo "- op: replace \

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -108,8 +108,11 @@ jobs:
         run: |
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Deploy LM local testing kustomize
         run: |
+          ls
           maxRetry=5
           for retry in $(seq 1 $maxRetry)
           do
@@ -130,3 +133,6 @@ jobs:
       - name: Run Kyma CR Deletion Test
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
+      - name: Run Status Propagation Tests
+        run: |
+          make -C tests/e2e_test test-status-propagation-e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -154,6 +154,7 @@ jobs:
           
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
           sed -i 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000/g' ./template.yaml
+          kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests
         working-directory: ./lifecycle-manager

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -113,11 +113,13 @@ jobs:
       - run: |
           pwd
           ls
-          pushd ./lifecycle-manager
+          pushd $GITHUB_WORKSPACE/lifecycle-manager
           pwd 
           ls
       - name: Deploy LM local testing kustomize
         run: |
+          pwd 
+          ls
           maxRetry=5
           for retry in $(seq 1 $maxRetry)
           do

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -153,7 +153,8 @@ jobs:
           cat warning_patch.yaml
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
-          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
+          
+          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kyma-registry.localhost:5111 --insecure --module-archive-version-overwrite /
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -154,6 +154,8 @@ jobs:
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 0.0.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
+          kubectl apply -f template.yaml
       - name: Run Status Propagation Tests
+        working-directory: ./lifecycle-manager
         run: |
           make -C tests/e2e_test test-status-propagation-e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -154,7 +154,7 @@ jobs:
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           
-          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kyma-registry.localhost:5111 --insecure --module-archive-version-overwrite /
+          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry.localhost:5111 --insecure --module-archive-version-overwrite /
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -99,6 +99,8 @@ jobs:
           cmctl check api --wait=2m
       - name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          path: ./lifecycle-manager/
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
@@ -108,10 +110,9 @@ jobs:
         run: |
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Deploy LM local testing kustomize
         run: |
+          pwd
           ls
           maxRetry=5
           for retry in $(seq 1 $maxRetry)
@@ -133,6 +134,11 @@ jobs:
       - name: Run Kyma CR Deletion Test
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: github.com/kyma-project/template-operator
+          path: ./template-operator/
       - name: Run Status Propagation Tests
         run: |
           make -C tests/e2e_test test-status-propagation-e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -127,14 +127,14 @@ jobs:
               exit 1
             fi
           done
-#      - name: Run Watcher E2E Tests
-#        working-directory: ./lifecycle-manager
-#        run: |
-#          make -C tests/e2e_test test-watcher-e2e
-#      - name: Run Kyma CR Deletion Test
-#        working-directory: ./lifecycle-manager
-#        run: |
-#          make -C tests/e2e_test test-kyma-deletion-e2e
+      - name: Run Watcher E2E Tests
+        working-directory: ./lifecycle-manager
+        run: |
+          make -C tests/e2e_test test-watcher-e2e
+      - name: Run Kyma CR Deletion Test
+        working-directory: ./lifecycle-manager
+        run: |
+          make -C tests/e2e_test test-kyma-deletion-e2e
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
@@ -154,8 +154,6 @@ jobs:
           
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-kcp-registry:5111 --insecure --module-archive-version-overwrite /
           sed -i 's/k3d-kcp-registry:5111/k3d-kcp-registry:5000/g' ./template.yaml
-          cat template.yaml
-          kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests
         working-directory: ./lifecycle-manager

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -151,9 +151,9 @@ jobs:
             value: --final-state=Warning" >> warning_patch.yaml
            
           cat warning_patch.yaml
-          kustomize edit add patch --path warning_patch.yaml --kind Deployment
+          
           popd
-          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 0.0.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
+          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
           kubectl get crds
           kubectl apply -f template.yaml
       - name: Run Status Propagation Tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -151,7 +151,7 @@ jobs:
             value: --final-state=Warning" >> warning_patch.yaml
            
           cat warning_patch.yaml
-          
+          kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 1.1.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
           kubectl get crds

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
+      - run: pushd ./lifecycle-manager
       - name: Deploy LM local testing kustomize
         run: |
           maxRetry=5
@@ -132,6 +133,7 @@ jobs:
       - name: Run Kyma CR Deletion Test
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
+      - run: popd
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -130,13 +130,13 @@ jobs:
           done
       - name: Checkout template-operator
         uses: actions/checkout@v3
-        if: ${{ matrix.e2e-test }} == 'test-status-propagation-e2e'
+        if: ${{ matrix.e2e-test == 'test-status-propagation-e2e' }}
         with:
           repository: kyma-project/template-operator
           path: ./template-operator/
       - name: Create Template Operator Module
         working-directory: ./template-operator
-        if: ${{ matrix.e2e-test }} == 'test-status-propagation-e2e'
+        if: ${{ matrix.e2e-test == 'test-status-propagation-e2e' }}
         run: |
           pushd config/default
           echo "- op: replace

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -110,14 +110,9 @@ jobs:
         run: |
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
-      - run: |
-          pwd
-          ls
-          pushd $GITHUB_WORKSPACE/lifecycle-manager
-          pwd 
-          ls
       - name: Deploy LM local testing kustomize
         run: |
+          pushd ./lifecycle-manager
           pwd 
           ls
           maxRetry=5
@@ -140,7 +135,7 @@ jobs:
       - name: Run Kyma CR Deletion Test
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
-      - run: popd
+          popd
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -111,8 +111,8 @@ jobs:
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
       - name: Deploy LM local testing kustomize
+        working-directory: ./lifecycle-manager
         run: |
-          pushd ./lifecycle-manager
           pwd 
           ls
           maxRetry=5
@@ -130,24 +130,26 @@ jobs:
             fi
           done
       - name: Run Watcher E2E Tests
+        working-directory: ./lifecycle-manager
         run: |
           make -C tests/e2e_test test-watcher-e2e
       - name: Run Kyma CR Deletion Test
+        working-directory: ./lifecycle-manager
         run: |
           make -C tests/e2e_test test-kyma-deletion-e2e
-          popd
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           repository: kyma-project/template-operator
           path: ./template-operator/
       - name: Create Template Operator Module
+        working-directory: ./template-operator
         run: |
+          pushd config/default
           echo "- op: replace \
             path: /spec/template/spec/containers/0/args/1 \
-            value: --final-state=Warning" >> config/default/warning_patch.yaml
-          
-          pushd config/default
+            value: --final-state=Warning" >> warning_patch.yaml
+          cat warning_patch.yaml
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd
           kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 0.0.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -110,7 +110,12 @@ jobs:
         run: |
           echo "KLM_VERSION_TAG=PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "KLM_IMAGE_REPO=dev" >> $GITHUB_ENV
-      - run: pushd ./lifecycle-manager
+      - run: |
+          pwd
+          ls
+          pushd ./lifecycle-manager
+          pwd 
+          ls
       - name: Deploy LM local testing kustomize
         run: |
           maxRetry=5

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -146,9 +146,10 @@ jobs:
         working-directory: ./template-operator
         run: |
           pushd config/default
-          echo "- op: replace \
-            path: /spec/template/spec/containers/0/args/1 \
+          echo "- op: replace
+            path: /spec/template/spec/containers/0/args/1
             value: --final-state=Warning" >> warning_patch.yaml
+           
           cat warning_patch.yaml
           kustomize edit add patch --path warning_patch.yaml --kind Deployment
           popd

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,8 +27,8 @@ jobs:
   e2e-integration:
     strategy:
       matrix:
-        cli-stability: [ "unstable" ]
         e2e-test: ["test-watcher-e2e", "test-kyma-deletion-e2e", "test-status-propagation-e2e"]
+        cli-stability: [ "unstable" ]
     name: "Run E2E tests"
     needs: [wait-for-img]
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       matrix:
         cli-stability: [ "unstable" ]
+        e2e-test: ["test-watcher-e2e", "test-kyma-deletion-e2e", "test-status-propagation-e2e"]
     name: "Run E2E tests"
     needs: [wait-for-img]
     runs-on: ubuntu-latest
@@ -127,21 +128,15 @@ jobs:
               exit 1
             fi
           done
-      - name: Run Watcher E2E Tests
-        working-directory: ./lifecycle-manager
-        run: |
-          make -C tests/e2e_test test-watcher-e2e
-      - name: Run Kyma CR Deletion Test
-        working-directory: ./lifecycle-manager
-        run: |
-          make -C tests/e2e_test test-kyma-deletion-e2e
       - name: Checkout template-operator
         uses: actions/checkout@v3
+        if: ${{ matrix.e2e-test }} == 'test-status-propagation-e2e'
         with:
           repository: kyma-project/template-operator
           path: ./template-operator/
       - name: Create Template Operator Module
         working-directory: ./template-operator
+        if: ${{ matrix.e2e-test }} == 'test-status-propagation-e2e'
         run: |
           pushd config/default
           echo "- op: replace
@@ -155,7 +150,7 @@ jobs:
           kubectl config use-context k3d-kcp
           kubectl get crds
           kubectl apply -f template.yaml
-      - name: Run Status Propagation Tests
+      - name: Run ${{ matrix.e2e-test }}
         working-directory: ./lifecycle-manager
         run: |
-          make -C tests/e2e_test test-status-propagation-e2e
+          make -C tests/e2e_test ${{ matrix.e2e-test }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -133,12 +133,18 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
-          repository: github.com/kyma-project/template-operator
+          repository: kyma-project/template-operator
           path: ../template-operator/
       - name: Create Template Operator Module
         run: |
-          pwd
-          ls
+          echo "- op: replace \
+            path: /spec/template/spec/containers/0/args/1 \
+            value: --final-state=Warning" >> config/default/warning_patch.yaml
+          
+          pushd config/default
+          kustomize edit add patch --path warning_patch.yaml --kind Deployment
+          popd
+          kyma alpha create module --kubebuilder-project  --channel=regular --name kyma.project.io/module/template-operator --version 0.0.1 --path . --registry k3d-registry.localhost:5111 --insecure --module-archive-version-overwrite
       - name: Run Status Propagation Tests
         run: |
           make -C tests/e2e_test test-status-propagation-e2e

--- a/internal/manifest/parse.go
+++ b/internal/manifest/parse.go
@@ -94,13 +94,13 @@ func pullLayer(ctx context.Context, imageRef string, keyChain authn.Keychain) (v
 	if isInsecureLayer {
 		imgLayer, err := crane.PullLayer(noSchemeImageRef, crane.Insecure, crane.WithAuthFromKeychain(keyChain))
 		if err != nil {
-			return nil, fmt.Errorf("INSECURE: %s due to: %w; noSchemeImageRef: %s; InsecureLayer; %t", ErrImageLayerPull.Error(), err, noSchemeImageRef, isInsecureLayer)
+			return nil, fmt.Errorf("%s due to: %w", ErrImageLayerPull.Error(), err)
 		}
 		return imgLayer, nil
 	}
 	imgLayer, err := crane.PullLayer(noSchemeImageRef, crane.WithAuthFromKeychain(keyChain), crane.WithContext(ctx))
 	if err != nil {
-		return nil, fmt.Errorf("SECURE: %s due to: %w; noSchemeImageRef: %s; InsecureLayer; %t", ErrImageLayerPull.Error(), err, noSchemeImageRef, isInsecureLayer)
+		return nil, fmt.Errorf("%s due to: %w", ErrImageLayerPull.Error(), err)
 	}
 	return imgLayer, nil
 }

--- a/internal/manifest/parse.go
+++ b/internal/manifest/parse.go
@@ -94,13 +94,13 @@ func pullLayer(ctx context.Context, imageRef string, keyChain authn.Keychain) (v
 	if isInsecureLayer {
 		imgLayer, err := crane.PullLayer(noSchemeImageRef, crane.Insecure, crane.WithAuthFromKeychain(keyChain))
 		if err != nil {
-			return nil, fmt.Errorf("%s due to: %w", ErrImageLayerPull.Error(), err)
+			return nil, fmt.Errorf("INSECURE: %s due to: %w; noSchemeImageRef: %s; InsecureLayer; %t", ErrImageLayerPull.Error(), err, noSchemeImageRef, isInsecureLayer)
 		}
 		return imgLayer, nil
 	}
 	imgLayer, err := crane.PullLayer(noSchemeImageRef, crane.WithAuthFromKeychain(keyChain), crane.WithContext(ctx))
 	if err != nil {
-		return nil, fmt.Errorf("%s due to: %w", ErrImageLayerPull.Error(), err)
+		return nil, fmt.Errorf("SECURE: %s due to: %w; noSchemeImageRef: %s; InsecureLayer; %t", ErrImageLayerPull.Error(), err, noSchemeImageRef, isInsecureLayer)
 	}
 	return imgLayer, nil
 }

--- a/internal/manifest/ready_check.go
+++ b/internal/manifest/ready_check.go
@@ -187,6 +187,16 @@ func parseStateChecks(manifest *v1beta2.Manifest) ([]*v1beta2.CustomStateCheck, 
 				Value:       string(v1beta2.StateError),
 				MappedState: v1beta2.StateError,
 			},
+			{
+				JSONPath:    customResourceStatePath,
+				Value:       string(v1beta2.StateDeleting),
+				MappedState: v1beta2.StateDeleting,
+			},
+			{
+				JSONPath:    customResourceStatePath,
+				Value:       string(v1beta2.StateWarning),
+				MappedState: v1beta2.StateWarning,
+			},
 		}, false, nil
 	}
 	var stateCheck []*v1beta2.CustomStateCheck

--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -32,7 +32,7 @@ help: ## Display this help.
 ##@ E2E Tests
 
 .PHONY: test
-test: test-watcher-e2e test-kyma-deletion-e2e
+test: test-watcher-e2e test-kyma-deletion-e2e test-status-propagation-e2e
 
 .PHONY: test-kyma-deletion-e2e
 test-kyma-deletion-e2e:
@@ -41,3 +41,7 @@ test-kyma-deletion-e2e:
 .PHONY: test-watcher-e2e
 test-watcher-e2e: ## Runs the Watcher E2E Test
 	go test --tags=watcher_e2e -ginkgo.vv
+
+.PHONY: test-status-propagation-e2e
+test-status-propagation-e2e:
+	go test --tags=status_propagation_e2e -ginkgo.vv

--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -35,7 +35,7 @@ help: ## Display this help.
 test: test-watcher-e2e test-kyma-deletion-e2e test-status-propagation-e2e
 
 .PHONY: test-kyma-deletion-e2e
-test-kyma-deletion-e2e:
+test-kyma-deletion-e2e: ## Runs the Kyma Deletion E2E Test
 	go test --tags=deletion_e2e -ginkgo.vv
 
 .PHONY: test-watcher-e2e
@@ -43,5 +43,5 @@ test-watcher-e2e: ## Runs the Watcher E2E Test
 	go test --tags=watcher_e2e -ginkgo.vv
 
 .PHONY: test-status-propagation-e2e
-test-status-propagation-e2e:
+test-status-propagation-e2e: ## Runs the Status Propagation E2E Test
 	go test --tags=status_propagation_e2e -ginkgo.vv

--- a/tests/e2e_test/kyma_deletion_test.go
+++ b/tests/e2e_test/kyma_deletion_test.go
@@ -3,21 +3,15 @@
 package e2e_test
 
 import (
-	"context"
-	"errors"
 	"os/exec"
 	"time"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils"
-	"github.com/kyma-project/lifecycle-manager/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var errKymaNotDeleted = errors.New("kyma CR not deleted")
 
 const (
 	timeout       = 10 * time.Second
@@ -119,20 +113,9 @@ var _ = Describe("KCP Kyma CR should be deleted successfully when SKR cluster ge
 		})
 
 		It("Kyma CR should be removed", func() {
-			Eventually(checkKCPKymaCRDeleted, timeout, interval).
+			Eventually(CheckKCPKymaCRDeleted, timeout, interval).
 				WithContext(ctx).
 				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
 				Should(Succeed())
 		})
 	})
-
-func checkKCPKymaCRDeleted(ctx context.Context,
-	kymaName string, kymaNamespace string, k8sClient client.Client,
-) error {
-	kyma := &v1beta2.Kyma{}
-	err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kyma)
-	if util.IsNotFound(err) {
-		return nil
-	}
-	return errKymaNotDeleted
-}

--- a/tests/e2e_test/status_propagation_test.go
+++ b/tests/e2e_test/status_propagation_test.go
@@ -3,7 +3,7 @@
 package e2e_test
 
 import (
-	"errors"
+	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -12,6 +12,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -27,13 +28,6 @@ const (
 
 	defaultRuntimeNamespace = "kyma-system"
 	controlPlaneNamespace   = "kcp-system"
-)
-
-var (
-	errPodNotFound               = errors.New("could not find pod")
-	errWatcherDeploymentNotReady = errors.New("watcher Deployment is not ready")
-	errLogNotFound               = errors.New("logMsg was not found in log")
-	errKymaNotDeleted            = errors.New("kyma CR not deleted")
 )
 
 var _ = Describe("Enable Template Operator, Kyma CR should have status `Warning`",
@@ -92,7 +86,7 @@ var _ = Describe("Enable Template Operator, Kyma CR should have status `Warning`
 		})
 
 		It("Kyma CR should be removed", func() {
-			Eventually(checkKCPKymaCRDeleted, timeout, interval).
+			Eventually(CheckKCPKymaCRDeleted, timeout, interval).
 				WithContext(ctx).
 				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
 				Should(Succeed())

--- a/tests/e2e_test/status_propagation_test.go
+++ b/tests/e2e_test/status_propagation_test.go
@@ -1,0 +1,77 @@
+//go:build status_propagation_e2e
+
+package e2e_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	timeout      = 10 * time.Second
+	readyTimeout = 2 * time.Minute
+	interval     = 1 * time.Second
+
+	watcherPodContainer = "server"
+	exampleSKRDomain    = "example.domain.com"
+
+	KLMPodPrefix    = "klm-controller-manager"
+	KLMPodContainer = "manager"
+
+	defaultRuntimeNamespace = "kyma-system"
+	controlPlaneNamespace   = "kcp-system"
+)
+
+var (
+	errPodNotFound               = errors.New("could not find pod")
+	errWatcherDeploymentNotReady = errors.New("watcher Deployment is not ready")
+	errLogNotFound               = errors.New("logMsg was not found in log")
+	errKymaNotDeleted            = errors.New("kyma CR not deleted")
+)
+
+var _ = Describe("Kyma CR change on runtime cluster triggers new reconciliation using the Watcher",
+	Ordered, func() {
+		channel := "regular"
+		switchedChannel := "fast"
+		kyma := testutils.NewKymaForE2E("kyma-sample", "kcp-system", channel)
+		GinkgoWriter.Printf("kyma before create %v\n", kyma)
+		remoteNamespace := "kyma-system"
+		incomingRequestMsg := fmt.Sprintf("event received from SKR, adding %s/%s to queue",
+			kyma.GetNamespace(), kyma.GetName())
+
+		BeforeAll(func() {
+			// make sure we can list Kymas to ensure CRDs have been installed
+			err := controlPlaneClient.List(ctx, &v1beta2.KymaList{})
+			Expect(meta.IsNoMatchError(err)).To(BeFalse())
+		})
+
+		It("Should create empty Kyma CR on remote cluster", func() {
+			Eventually(CreateKymaSecret, timeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
+				Should(Succeed())
+			Eventually(controlPlaneClient.Create, timeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma).
+				Should(Succeed())
+			By("verifying kyma is ready")
+			Eventually(CheckKymaIsInState, readyTimeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, v1beta2.StateReady).
+				Should(Succeed())
+			By("verifying remote kyma is ready")
+			Eventually(CheckRemoteKymaCR, readyTimeout, interval).
+				WithContext(ctx).
+				WithArguments(remoteNamespace, []v1beta2.Module{}, runtimeClient, v1beta2.StateReady).
+				Should(Succeed())
+		})
+
+	})

--- a/tests/e2e_test/status_propagation_test.go
+++ b/tests/e2e_test/status_propagation_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	timeout       = 10 * time.Second
-	statusTimeout = 1 * time.Minute
+	statusTimeout = 2 * time.Minute
 	interval      = 1 * time.Second
 )
 
@@ -63,6 +63,19 @@ var _ = Describe("Enable Template Operator, Kyma CR should have status `Warning`
 			Eventually(CheckKymaIsInState, statusTimeout, interval).
 				WithContext(ctx).
 				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, v1beta2.StateWarning).
+				Should(Succeed())
+		})
+
+		It("Should disable Template Operator and Kyma should result in Ready status", func() {
+			By("Disabling Template Operator")
+			Eventually(DisableModule, timeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), "template-operator", controlPlaneClient).
+				Should(Succeed())
+			By("Checking state of kyma")
+			Eventually(CheckKymaIsInState, statusTimeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, v1beta2.StateReady).
 				Should(Succeed())
 		})
 

--- a/tests/e2e_test/status_propagation_test.go
+++ b/tests/e2e_test/status_propagation_test.go
@@ -83,6 +83,21 @@ var _ = Describe("Enable Template Operator, Kyma CR should have status `Warning`
 				Should(Succeed())
 		})
 
+		It("Should delete KCP Kyma", func() {
+			By("Deleting KCP Kyma")
+			Eventually(controlPlaneClient.Delete, readyTimeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma).
+				Should(Succeed())
+		})
+
+		It("Kyma CR should be removed", func() {
+			Eventually(checkKCPKymaCRDeleted, timeout, interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
+				Should(Succeed())
+		})
+
 	})
 
 func enableModule(ctx context.Context, kymaName, kymaNamespace, moduleName, moduleChannel string, k8sClient client.Client) error {

--- a/tests/e2e_test/suite_test.go
+++ b/tests/e2e_test/suite_test.go
@@ -1,4 +1,4 @@
-//go:build watcher_e2e || deletion_e2e
+//go:build watcher_e2e || deletion_e2e || status_propagation_e2e
 
 package e2e_test
 

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -1,4 +1,4 @@
-//go:build watcher_e2e || deletion_e2e
+//go:build watcher_e2e || deletion_e2e || status_propagation_e2e
 
 package e2e_test
 
@@ -21,6 +21,7 @@ import (
 var (
 	errKymaNotInExpectedState = errors.New("kyma CR not in expected state")
 	errModuleNotExisting      = errors.New("module does not exists in KymaCR")
+	errKymaNotDeleted         = errors.New("kyma CR not deleted")
 )
 
 const (
@@ -99,4 +100,15 @@ func DeleteKymaSecret(ctx context.Context, kymaName, kymaNamespace string, k8sCl
 	}
 	Expect(err).ToNot(HaveOccurred())
 	return k8sClient.Delete(ctx, secret)
+}
+
+func CheckKCPKymaCRDeleted(ctx context.Context,
+	kymaName string, kymaNamespace string, k8sClient client.Client,
+) error {
+	kyma := &v1beta2.Kyma{}
+	err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kyma)
+	if util.IsNotFound(err) {
+		return nil
+	}
+	return errKymaNotDeleted
 }

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -129,3 +129,16 @@ func CheckKCPKymaCRDeleted(ctx context.Context,
 	}
 	return errKymaNotDeleted
 }
+
+func EnableModule(ctx context.Context, kymaName, kymaNamespace, moduleName, moduleChannel string, k8sClient client.Client) error {
+	kyma := &v1beta2.Kyma{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kyma); err != nil {
+		return err
+	}
+	GinkgoWriter.Printf("kyma %v\n", kyma)
+	kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
+		Name:    moduleName,
+		Channel: moduleChannel,
+	})
+	return k8sClient.Update(ctx, kyma)
+}

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -41,8 +41,9 @@ func CheckKymaIsInState(ctx context.Context,
 	}
 	GinkgoWriter.Printf("kyma %v\n", kyma)
 	if kyma.Status.State != expectedState {
-		return fmt.Errorf("%w: expect %s, but in %s",
-			errKymaNotInExpectedState, expectedState, kyma.Status.State)
+
+		return fmt.Errorf("%w: expect %s, but in %s. Kyma CR: %#v",
+			errKymaNotInExpectedState, expectedState, kyma.Status.State, kyma)
 	}
 	return nil
 }

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -142,3 +142,23 @@ func EnableModule(ctx context.Context, kymaName, kymaNamespace, moduleName, modu
 	})
 	return k8sClient.Update(ctx, kyma)
 }
+
+func DisableModule(ctx context.Context, kymaName, kymaNamespace, moduleName string, k8sClient client.Client) error {
+	kyma := &v1beta2.Kyma{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: kymaName, Namespace: kymaNamespace}, kyma); err != nil {
+		return err
+	}
+	GinkgoWriter.Printf("kyma %v\n", kyma)
+
+	for i, module := range kyma.Spec.Modules {
+		if module.Name == moduleName {
+			kyma.Spec.Modules = removeModuleWithIndex(kyma.Spec.Modules, i)
+			break
+		}
+	}
+	return k8sClient.Update(ctx, kyma)
+}
+
+func removeModuleWithIndex(s []v1beta2.Module, index int) []v1beta2.Module {
+	return append(s[:index], s[index+1:]...)
+}

--- a/tests/e2e_test/watcher_test.go
+++ b/tests/e2e_test/watcher_test.go
@@ -48,7 +48,6 @@ var (
 	errPodNotFound               = errors.New("could not find pod")
 	errWatcherDeploymentNotReady = errors.New("watcher Deployment is not ready")
 	errLogNotFound               = errors.New("logMsg was not found in log")
-	errKymaNotDeleted            = errors.New("kyma CR not deleted")
 )
 
 var _ = Describe("Kyma CR change on runtime cluster triggers new reconciliation using the Watcher",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix #822 
- Introduce new e2e test to check Status propagation;
    - Template operator is being deployed with `--final-state` set to `Warning`; will be checked after template-operator is being enabled; after disabling it should return to Ready
- Use matrix in GH Actions pipeline, to have all e2e scenario tests run in parallel, if there are multiple runners available the pipeline will run faster (7min instead of 11min most of the time, if three runners are available ~5min) + e2e scenarios are fully decoupled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
