### PR TITLE
chore: Unify GitHub actions names and titles

### DIFF
--- a/.github/workflows/lint-conventional-prs.yml
+++ b/.github/workflows/lint-conventional-prs.yml
@@ -1,4 +1,4 @@
-name: PR Title Check
+name: Lint PR Title
 run-name: ${{github.event.pull_request.title}}
 
 on:

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -1,4 +1,5 @@
-name: pull-lifecycle-mgr-lint
+name: Lint golangci
+
 on:
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: TestSuite E2E
 
 on:
   push:

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -1,4 +1,4 @@
-name: Smoke Tests
+name: TestSuite Smoke
 
 on:
   push:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Unify the titles for the GitHub actions and respective config files

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
