### PR TITLE
chore: Add the Markdown Link Checker GitHub action

### DIFF
--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -1,0 +1,19 @@
+name: Lint Markdown Links
+run-name: ${{github.event.pull_request.title}}
+
+on: [ pull_request ]
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'
+          config-file: '.mlc.config.json'
+          folder-path: '.'
+          max-depth: -1
+          check-modified-files-only: 'yes'
+          base-branch: 'main'

--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -1,0 +1,9 @@
+{
+  "replacementPatterns": [
+    {
+      "_comment": "a replacement rule for all the in-repository references",
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdown-link-check-disable-next-line -->
 [![REUSE status](https://api.reuse.software/badge/github.com/kyma-project/lifecycle-manager)](https://api.reuse.software/info/github.com/kyma-project/lifecycle-manager)
 # Lifecycle Manager
 
@@ -16,7 +17,7 @@ See the list of basic concepts relating to Lifecycle Manager to understand its w
 - Manifest CR - represents resources that make up a module and are to be installed by Lifecycle Manager. The Manifest CR is a rendered module enabled on a particular cluster.
 - Module CR, such as Keda CR - allows you to configure the behavior of a module. This is a per-module CR.
 
-For the worklow details, read the [Architecture](./docs/technical-reference/architecture.md) document.
+For the worklow details, read the [Architecture](docs/technical-reference/architecture.md) document.
 
 ## Quick Start
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,3 @@
 # Lifecycle Manager API
 
-To see Lifecycle Manager API documentation, go to the [Lifecycle Manager API](../docs/technical-reference/api/README.md) document in the `/docs` folder.
+To see Lifecycle Manager API documentation, go to the [Lifecycle Manager API](/docs/technical-reference/api/README.md) document in the `/docs` folder.

--- a/controllers/README.md
+++ b/controllers/README.md
@@ -1,5 +1,5 @@
 # Controllers used within Lifecycle Manager
 
 This package contains all controllers that can be registered within the Lifecycle Manager.
-For more details, read [Lifecycle Manager Controllers](../docs/technical-reference/controllers.md) in the `/docs` folder.
-For more information on how the API behaves after the controller finishes up the synchronization, please look at the [Lifecycle Manager API](../docs/technical-reference/api/README.md) document.
+For more details, read [Lifecycle Manager Controllers](/docs/technical-reference/controllers.md) in the `/docs` folder.
+For more information on how the API behaves after the controller finishes up the synchronization, please look at the [Lifecycle Manager API](/docs/technical-reference/api/README.md) document.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,6 @@ The table of contents lists all the documents in repository with their short des
   - [Internal Manifest Reconciliation Library Extensions](../internal/manifest/README.md)
   - [Smoke tests](../tests/smoke_test/README.md)
 - User tutorials
-  - [Managing module enablement with the CustomResourcePolicy](./user-tutorials/manage-module-with-custom-resource-policy.md)
-  - [Quick Start](./user-tutorials/quick-start.md)
+  - [Managing module enablement with the CustomResourcePolicy](./user-tutorials/02-10-manage-module-with-custom-resource-policy.md)
+  - [Quick Start](./user-tutorials/01-10-control-plane-quick-start.md)
 - [Modularization](modularization.md) - describes the modularization concept and its building blocks in the context of Lifecycle Manager

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,24 +8,24 @@ The `docs` folder contains documentation on the Lifecycle Manager project.
 
 The table of contents lists all the documents in repository with their short description.
 
-- [Developer tutorials](./developer-tutorials/README.md) - a directory containing infrastructure-related guides for developers
-  - [Provide credential for private OCI registry authentication](./developer-tutorials/config-private-registry.md)
-  - [Local test setup in the control-plane mode using k3d](./developer-tutorials/local-test-setup.md)
-  - [Create a test environment on Google Container Registry (GCR)](./developer-tutorials/prepare-gcr-registry.md)
-  - [Provision cluster and OCI registry](./developer-tutorials/provision-cluster-and-registry.md)
-  - [Enable Webhooks in Lifecycle Manager](./developer-tutorials/starting-operator-with-webhooks.md)
+- [Developer tutorials](developer-tutorials/README.md) - a directory containing infrastructure-related guides for developers
+  - [Provide credential for private OCI registry authentication](developer-tutorials/config-private-registry.md)
+  - [Local test setup in the control-plane mode using k3d](developer-tutorials/local-test-setup.md)
+  - [Create a test environment on Google Container Registry (GCR)](developer-tutorials/prepare-gcr-registry.md)
+  - [Provision cluster and OCI registry](developer-tutorials/provision-cluster-and-registry.md)
+  - [Enable Webhooks in Lifecycle Manager](developer-tutorials/starting-operator-with-webhooks.md)
 - Technical reference - a directory with techncial details on Lifecycle Manager, such as architecture, APIs, or running modes
-  - [API](./technical-reference/api/README.md) - a directory with the description of Lifecycle Manager's custom resources (CRs)
-    - [Kyma CR](./technical-reference/api/kyma-cr.md)
-    - [Manifest CR](./technical-reference/api/manifest-cr.md)
-    - [ModuleTemplate CR](./technical-reference/api/moduleTemplate-cr.md)
-  - [Architecure](./technical-reference/architecture.md) - describes Lifecycle Manager's architecture
-  - [Controllers](./technical-reference/controllers.md) - describes Kyma, Manifest and Watcher controllers
-  - [Running Modes](./technical-reference/running-modes.md) - describes Lifecycle Manager's running modes
-  - [Declarative Reconciliation Library Reference Documentation](../internal/declarative/README.md)
-  - [Internal Manifest Reconciliation Library Extensions](../internal/manifest/README.md)
-  - [Smoke tests](../tests/smoke_test/README.md)
+  - [API](technical-reference/api/README.md) - a directory with the description of Lifecycle Manager's custom resources (CRs)
+    - [Kyma CR](technical-reference/api/kyma-cr.md)
+    - [Manifest CR](technical-reference/api/manifest-cr.md)
+    - [ModuleTemplate CR](technical-reference/api/moduleTemplate-cr.md)
+  - [Architecture](technical-reference/architecture.md) - describes Lifecycle Manager's architecture
+  - [Controllers](technical-reference/controllers.md) - describes Kyma, Manifest and Watcher controllers
+  - [Running Modes](technical-reference/running-modes.md) - describes Lifecycle Manager's running modes
+  - [Declarative Reconciliation Library Reference Documentation](/internal/declarative/README.md)
+  - [Internal Manifest Reconciliation Library Extensions](/internal/manifest/README.md)
+  - [Smoke tests](/tests/smoke_test/README.md)
 - User tutorials
-  - [Managing module enablement with the CustomResourcePolicy](./user-tutorials/02-10-manage-module-with-custom-resource-policy.md)
-  - [Quick Start](./user-tutorials/01-10-control-plane-quick-start.md)
+  - [Managing module enablement with the CustomResourcePolicy](user-tutorials/02-10-manage-module-with-custom-resource-policy.md)
+  - [Quick Start](user-tutorials/01-10-control-plane-quick-start.md)
 - [Modularization](modularization.md) - describes the modularization concept and its building blocks in the context of Lifecycle Manager

--- a/docs/developer-tutorials/local-test-setup.md
+++ b/docs/developer-tutorials/local-test-setup.md
@@ -15,8 +15,8 @@ This setup is deployed with the following security features enabled:
 
 > **NOTE:** If you want to use remote clusters instead of a local k3d setup or external registries, please refer to the following guides for the cluster and registry setup:
 >
-> - [Provision cluster and OCI registry](./provision-cluster-and-registry.md)
-> - [Create a test environment on Google Container Registry (GCR)](./prepare-gcr-registry.md)
+> - [Provision cluster and OCI registry](provision-cluster-and-registry.md)
+> - [Create a test environment on Google Container Registry (GCR)](prepare-gcr-registry.md)
 
 ## Procedure
 

--- a/docs/modularization.md
+++ b/docs/modularization.md
@@ -13,10 +13,10 @@ The modules themselves are built and distributed as OCI artifacts. The internal 
 If you use Kyma [CLI](https://github.com/kyma-project/cli), you can create a Kyma module by running `kyma alpha create module`. This command packages all the contents on the provided path as an OCI artifact and pushes the artifact to the provided OCI registry. Use the `kyma alpha create module --help` command to learn more about the module structure and how it is created. You can also use the CLI's auto-detection of [Kubebuilder](https://kubebuilder.io) projects to easily bundle your module with little effort.
 
 The modules are installed and controlled by Lifecycle Manager. We use [Open Component Model](https://ocm.software) to describe all of our modules descriptively.
-Based on the [ModuleTemplate CR](../api/v1beta2/moduletemplate_types.go), the module is resolved from its layers and version and is used as a template for the [Manifest CR](api/v1beta1/manifest_types.go).
+Based on the [ModuleTemplate CR](/api/v1beta2/moduletemplate_types.go), the module is resolved from its layers and version and is used as a template for the [Manifest CR](/api/v1beta1/manifest_types.go).
 Whenever a module is accepted by Lifecycle Manager the ModuleTemplate CR gets translated into a Manifest CR, which describes the actual desired state of the module operator.
 
-The Lifecycle Manager then updates the [Kyma CR](../api/v1alpha2/kyma_types.go) of the cluster based on the observed status changes in the module CR (similar to a native Kubernetes deployment tracking availability).
+The Lifecycle Manager then updates the [Kyma CR](/api/v1beta2/kyma_types.go) of the cluster based on the observed status changes in the module CR (similar to a native Kubernetes deployment tracking availability).
 
 Module operators only have to watch their custom resources and reconcile modules in the target clusters to the desired state.
 

--- a/docs/modularization.md
+++ b/docs/modularization.md
@@ -2,9 +2,9 @@
 
 Modules are the next generation of components in Kyma that are available for local and cluster installation.
 
-Modules are no longer represented by a single helm-chart, but instead are bundled and released within channels through a [ModuleTemplate custom resource (CR)](../api/v1beta2/moduletemplate_types.go), a unique link of a module, and its desired state of resources and configuration, and a channel.
+Modules are no longer represented by a single helm-chart, but instead are bundled and released within channels through a [ModuleTemplate custom resource (CR)](/api/v1beta2/moduletemplate_types.go), a unique link of a module, and its desired state of resources and configuration, and a channel.
 
-Lifecycle Manager manages clusters using the [Kyma CR](../api/v1beta2/kyma_types.go). The CR defines the desired state of modules in a cluster. With the CR you can enable and disable modules with domain-specific functionality with additional configuration.
+Lifecycle Manager manages clusters using the [Kyma CR](/api/v1beta2/kyma_types.go). The CR defines the desired state of modules in a cluster. With the CR you can enable and disable modules with domain-specific functionality with additional configuration.
 
 The modules themselves are built and distributed as OCI artifacts. The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3. Modules contain an immutable layer set of a module operator deployment description and its configuration.
 

--- a/docs/technical-reference/api/README.md
+++ b/docs/technical-reference/api/README.md
@@ -32,7 +32,7 @@ The v1beta2 API introduces three groups of modules:
 
 By default, without any labels configured on Kyma and ModuleTemplate CRs, a ModuleTemplate CR is synchronized with remote clusters.
 
-**NOTE:** The ModuleTemplate CRs synchronization is enabled only when Lifecycle Manager runs in the [control-plane mode](../../technical-reference/running-modes). Lifecycle Manager running in the single-cluster mode, doesn't require any CR synchronization.
+**NOTE:** The ModuleTemplate CRs synchronization is enabled only when Lifecycle Manager runs in the [control-plane mode](../running-modes.md). Lifecycle Manager running in the single-cluster mode, doesn't require any CR synchronization.
 
 **NOTE:** Disabling synchronization for already synchronized ModuleTemplates CRs doesn't remove them from remote clusters. The CRs remain as they are, but any subsequent changes to these ModuleTemplate CRs in the Control Plane are not synchronized.
 
@@ -44,7 +44,7 @@ See the list of CRs involved in Lifecycle Manager's workflow and their stability
 
 | Version | Name                                                | Stability                                                                                                                                                                                                    |
 |:--------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| v1beta2 | [Kyma](../../api/v1beta2/kyma_types.go)                         | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
-| v1beta2 | [ModuleTemplate](../../api/v1beta2/moduletemplate_types.go)     | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
-| v1beta2 | [Manifest](../../api/v1beta2/manifest_types.go)                 | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
-| v1beta2 | [Watcher](../../api/v1beta2/watcher_types.go)                   | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
+| v1beta2 | [Kyma](/api/v1beta2/kyma_types.go)                         | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
+| v1beta2 | [ModuleTemplate](/api/v1beta2/moduletemplate_types.go)     | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
+| v1beta2 | [Manifest](/api/v1beta2/manifest_types.go)                 | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
+| v1beta2 | [Watcher](/api/v1beta2/watcher_types.go)                   | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |

--- a/docs/technical-reference/api/README.md
+++ b/docs/technical-reference/api/README.md
@@ -4,11 +4,11 @@
 
 The Lifecycle Manager API types consist of three major custom resources (CRs). Each CR deals with a specific aspect of reconciling modules into their corresponding states.
 
-1. [Kyma CR](../../../api/v1beta2/kyma_types.go) that introduces a single entry point CustomResourceDefinition to control a cluster and it's desired state.
-2. [Manifest CR](../../../api/v1beta2/manifest_types.go) that introduces a single entry point CustomResourceDefinition to control a module and it's desired state.
-3. [ModuleTemplate CR](../../../api/v1beta2/moduletemplate_types.go) that contains all reference data for the modules to be installed correctly. It is a standardized desired state for a module available in a given release channel.
+1. [Kyma CR](/api/v1beta2/kyma_types.go) that introduces a single entry point CustomResourceDefinition to control a cluster and it's desired state.
+2. [Manifest CR](/api/v1beta2/manifest_types.go) that introduces a single entry point CustomResourceDefinition to control a module and it's desired state.
+3. [ModuleTemplate CR](/api/v1beta2/moduletemplate_types.go) that contains all reference data for the modules to be installed correctly. It is a standardized desired state for a module available in a given release channel.
 
-Additionally, we maintain the [Watcher CR](../../../api/v1beta2/watcher_types.go) to define the callback functionality for synchronized remote clusters that allows lower latencies before the Control Plane detects any changes.
+Additionally, we maintain the [Watcher CR](/api/v1beta2/watcher_types.go) to define the callback functionality for synchronized remote clusters that allows lower latencies before the Control Plane detects any changes.
 
 ## Custom Resource Definitions
 
@@ -36,7 +36,7 @@ By default, without any labels configured on Kyma and ModuleTemplate CRs, a Modu
 
 **NOTE:** Disabling synchronization for already synchronized ModuleTemplates CRs doesn't remove them from remote clusters. The CRs remain as they are, but any subsequent changes to these ModuleTemplate CRs in the Control Plane are not synchronized.
 
-For details, read about [the Kyma CR synchronization labels](../api/kyma-cr.md#operatorkyma-projectio-labels) and [the ModuleTemplate CR synchronization labels](../api/moduleTemplate-cr.md#operatorkyma-projectio-labels).
+For details, read about [the Kyma CR synchronization labels](kyma-cr.md#operatorkyma-projectio-labels) and [the ModuleTemplate CR synchronization labels](moduleTemplate-cr.md#operatorkyma-projectio-labels).
 
 ## Stability
 

--- a/docs/technical-reference/api/kyma-cr.md
+++ b/docs/technical-reference/api/kyma-cr.md
@@ -1,6 +1,6 @@
 # Kyma Custom Resource
 
-The [Kyma custom resource (CR)](../../../api/v1beta2/kyma_types.go) contains 3 fields that are together used to declare the desired state of a cluster:
+The [Kyma custom resource (CR)](/api/v1beta2/kyma_types.go) contains 3 fields that are together used to declare the desired state of a cluster:
 
 1. **.spec.channel** and **.spec.modules[].channel**: The Release Channel that should be used by default for all modules that are to be installed in the cluster.
 2. **.spec.modules**: The modules that should be installed into the cluster. Each module contains a name serving as a link to the ModuleTemplate CR.
@@ -111,7 +111,7 @@ Namespace/Name, or module name label) to the ModuleTemplate CR. If not specified
 
 The **state** attribute is a simple representation of the state of the entire Kyma CR installation. It is defined as an aggregated status that is either `Ready`, `Processing`, `Error`, or `Deleting`, based on the status of _all_ Manifest CRs on top of the validity/integrity of the synchronization to a remote cluster if enabled.
 
-The **state** will always be reported based on the last reconciliation loop of the [Kyma controller](../../../controllers/kyma_controller.go). It will be set to `Ready` only if all installations were successfully executed and are consistent at the time of the reconciliation.
+The **state** will always be reported based on the last reconciliation loop of the [Kyma controller](/controllers/kyma_controller.go). It will be set to `Ready` only if all installations were successfully executed and are consistent at the time of the reconciliation.
 
 ### **.status.conditions**
 
@@ -168,7 +168,7 @@ In addition, we also regularly issue `Events` for important things happening at 
 
 ### `operator.kyma-project.io` labels
 
-Various overarching features can be enabled/disabled or provided as hints to the reconciler by providing a specific label key and value to the Kyma CR and its related resources. For better understanding, use the matching [API label reference](../../../api/v1beta2/operator_labels.go).
+Various overarching features can be enabled/disabled or provided as hints to the reconciler by providing a specific label key and value to the Kyma CR and its related resources. For better understanding, use the matching [API label reference](/api/v1beta2/operator_labels.go).
 
 The most important labels include, but are not limited to:
 

--- a/docs/technical-reference/api/manifest-cr.md
+++ b/docs/technical-reference/api/manifest-cr.md
@@ -1,6 +1,6 @@
 # Manifest Custom Resource
 
-The [Manifest](../../../api/v1beta1/manifest_types.go) is our internal representation of what results from the resolution of a `ModuleTemplate` in the context of a single cluster represented through `Kyma`. Thus, a lot of configuration elements are similar or entirely equivalent to the layer data found in the `ModuleTemplate` and it is currently being considered for specification rework.
+The [Manifest](/api/v1beta1/manifest_types.go) is our internal representation of what results from the resolution of a `ModuleTemplate` in the context of a single cluster represented through `Kyma`. Thus, a lot of configuration elements are similar or entirely equivalent to the layer data found in the `ModuleTemplate` and it is currently being considered for specification rework.
 
 ### `.spec.remote`
 
@@ -24,7 +24,7 @@ will use the value `kyma-sample` to lookup a secret with the same value `kyma-sa
 
 ### `.spec.config`
 
-The config reference uses an image layer reference that contains configuration data that can be used to further influence any potential rendering process while the resources are processed by the [declarative library](../../../internal/declarative/README.md#resource-rendering). It is resolved through a translation of the `ModuleTemplate` to the `Manifest` during the [resolution of the modules](../../../pkg/module/parse/template_to_module.go) in the `Kyma` control loop.
+The config reference uses an image layer reference that contains configuration data that can be used to further influence any potential rendering process while the resources are processed by the [declarative library](/internal/declarative/README.md#resource-rendering). It is resolved through a translation of the `ModuleTemplate` to the `Manifest` during the [resolution of the modules](/pkg/module/parse/template_to_module.go) in the `Kyma` control loop.
 
 There can be at most one config layer, and it is referenced by the name `config` with type `yaml` as `localOciBlob` or `OCIBlob`:
 
@@ -51,7 +51,7 @@ spec:
 
 ### `.spec.install`
 
-The install layer contains the relevant data required to determine the resources for the [renderer during the manifest reconciliation](../../../internal/declarative/README.md#resource-rendering).
+The install layer contains the relevant data required to determine the resources for the [renderer during the manifest reconciliation](/internal/declarative/README.md#resource-rendering).
 
 It is mapped from an access type layer in the descriptor:
 
@@ -86,4 +86,4 @@ The resource is the default data that should be initialized for the module and i
 
 ### `.status`
 
-The Manifest status is an unmodified version of the [declarative status](../../../internal/declarative/README.md#resource-tracking), so the tracking process of the library applies. There is no custom API for this.
+The Manifest status is an unmodified version of the [declarative status](/internal/declarative/README.md#resource-tracking), so the tracking process of the library applies. There is no custom API for this.

--- a/docs/technical-reference/api/manifest-cr.md
+++ b/docs/technical-reference/api/manifest-cr.md
@@ -77,7 +77,7 @@ install:
       type: oci-ref
 ```
 
-The [internal spec resolver](../../../internal/manifest/v1beta1/spec_resolver.go) will use this layer to resolve the correct specification style and renderer type from the layer data.
+The [internal spec resolver](/internal/manifest/spec_resolver.go) will use this layer to resolve the correct specification style and renderer type from the layer data.
 
 ### `.spec.resource`
 

--- a/docs/technical-reference/api/moduleTemplate-cr.md
+++ b/docs/technical-reference/api/moduleTemplate-cr.md
@@ -1,6 +1,6 @@
 # ModuleTemplate Custom Resource
 
-The core of our modular discovery, the [ModuleTemplate custom resource (CR)](../../../api/v1beta2/moduletemplate_types.go) contains 3 main parts that are used to initialize and resolve modules.
+The core of our modular discovery, the [ModuleTemplate custom resource (CR)](/api/v1beta2/moduletemplate_types.go) contains 3 main parts that are used to initialize and resolve modules.
 
 ### **.spec.channel**
 

--- a/docs/technical-reference/architecture.md
+++ b/docs/technical-reference/architecture.md
@@ -29,9 +29,9 @@ To run, Lifecycle Manager uses the following workflow:
 
 Apart from the custom resources, Lifecycle Manager uses also Kyma, Manifest and Watcher controllers:
 
-- [Kyma controller](../../controllers/kyma_controller.go) - reconciles the Kyma CR which means creating Manifest CRs for each Kyma module enabled in the Kyma CR and deleting them when modules are disabled in the Kyma CR. It is also responsible for synchronising ModuleTemplate CRs between KCP and Kyma runtimes.
-- [Manifest controller](../../controllers/manifest_controller.go) - reconciles the Manifest CRs created by the Kyma controller, which means, installing components specified in the Manifest CR on the target SKR cluster and removing them when the Manifest CRs are flagged for deletion.
-- [Watcher controller](../../controllers/watcher_controller.go) - reconciles the Watcher CR which means creating Istio Virtual Service resources on KCP when a Watcher CR is created and removing the same resources when it is deleted. This is done in order to configure the routing of the messages coming from the watcher agent installed on each Kyma runtime and going to a listener agent deployed on KCP.
+- [Kyma controller](/controllers/kyma_controller.go) - reconciles the Kyma CR which means creating Manifest CRs for each Kyma module enabled in the Kyma CR and deleting them when modules are disabled in the Kyma CR. It is also responsible for synchronising ModuleTemplate CRs between KCP and Kyma runtimes.
+- [Manifest controller](/controllers/manifest_controller.go) - reconciles the Manifest CRs created by the Kyma controller, which means, installing components specified in the Manifest CR on the target SKR cluster and removing them when the Manifest CRs are flagged for deletion.
+- [Watcher controller](/controllers/watcher_controller.go) - reconciles the Watcher CR which means creating Istio Virtual Service resources on KCP when a Watcher CR is created and removing the same resources when it is deleted. This is done in order to configure the routing of the messages coming from the watcher agent installed on each Kyma runtime and going to a listener agent deployed on KCP.
 
 For more details about Lifecycle Manager controllers, read the [Controllers](controllers.md) document.
 

--- a/docs/technical-reference/controllers.md
+++ b/docs/technical-reference/controllers.md
@@ -4,12 +4,12 @@ This document describes the controllers used by Lifecycle Manager.
 
 ## Kyma Controller
 
-[Kyma Controller](../../controllers/kyma_controller.go) is dealing with the introspection, interpretation and status update of the [Kyma custom resource (CR)](../../api/v1beta2/kyma_types.go).
+[Kyma Controller](/controllers/kyma_controller.go) is dealing with the introspection, interpretation and status update of the [Kyma custom resource (CR)](/api/v1beta2/kyma_types.go).
 
 Its main responsibilities are:
 
-1. Interpret the `.spec.modules` list and use the correct [ModuleTemplate CR](../../api/v1beta2/moduletemplate_types.go) for a module.
-2. Translate the ModuleTemplate CR into a [Manifest CR](../../api/v1beta2/manifest_types.go) and create it with an OwnerReference to the Kyma CR where the module was listed.
+1. Interpret the `.spec.modules` list and use the correct [ModuleTemplate CR](/api/v1beta2/moduletemplate_types.go) for a module.
+2. Translate the ModuleTemplate CR into a [Manifest CR](/api/v1beta2/manifest_types.go) and create it with an OwnerReference to the Kyma CR where the module was listed.
 3. Propagate changes from ModuleTemplate CR updates (e.g. updates to the Module Layers contained in the OCI Descriptor) into the correct Manifest CR and process upgrades, but prohibit downgrades.
 4. Track all created Manifest CRs and aggregate the status into a `State`, that reflects the integrity of the Kyma installation managed by Lifecycle Manager.
 5. Synchronize all the above changes to the Kyma CR Status as well as available ModuleTemplate CRs into a remote cluster.
@@ -26,16 +26,16 @@ and will only be triggered if `operator.kyma-project.io/sync=true` label is set 
 
 In this case, a so called `SyncContext` is initialized.
 Every time the Kyma on the control plane is enqueued for synchronization,
-it's spec is merged with the remote specification through our [custom synchronization handlers](../../pkg/remote/kyma_synchronization_context.go).
+it's spec is merged with the remote specification through our [custom synchronization handlers](/pkg/remote/kyma_synchronization_context.go).
 These are not only able to synchronize the Kyma resource in the remote,
 but they also replace the specification for all further parts of the reconciliation as a _virtual_ Kyma.
 For more information, checkout the `ReplaceWithVirtualKyma` function.
 
 ## Manifest Controller
 
-[Manifest Controller](../../controllers/manifest_controller.go) deals with the reconciliation and installation of data desired through a Manifest CR, a representation of a single module desired in a cluster.
-Since it mainly is a delegation to the [declarative reconciliation library](../../internal/declarative/README.md) with certain [internal implementation additions](../../internal/manifest/README.md) please look at the respective documentation for these parts to understand them more.
+[Manifest Controller](/controllers/manifest_controller.go) deals with the reconciliation and installation of data desired through a Manifest CR, a representation of a single module desired in a cluster.
+Since it mainly is a delegation to the [declarative reconciliation library](/internal/declarative/README.md) with certain [internal implementation additions](/internal/manifest/README.md) please look at the respective documentation for these parts to understand them more.
 
 ## Watcher Controller
 
-[Watcher Controller](../../controllers/watcher_controller.go) deals with the update of VirtualService rules derived from the [Watcher CR](../../api/v1beta2/watcher_types.go). This is then used to initialize the Watcher CR from the Kyma Controller in each runtime, a small component initialized to propagate changes from the runtime(remote) clusters back to react to changes that can affect the Manifest CR integrity.
+[Watcher Controller](/controllers/watcher_controller.go) deals with the update of VirtualService rules derived from the [Watcher CR](/api/v1beta2/watcher_types.go). This is then used to initialize the Watcher CR from the Kyma Controller in each runtime, a small component initialized to propagate changes from the runtime(remote) clusters back to react to changes that can affect the Manifest CR integrity.

--- a/docs/technical-reference/running-modes.md
+++ b/docs/technical-reference/running-modes.md
@@ -2,7 +2,7 @@
 
 Lifecycle Manager can run in two modes:
 
-- single-cluster - deployment mode in which Lifecycle Manager is running on the same clutser on which you deploy Kyma. This mode doesn't require Kyma or ModuleTemplate CRs [synchronization](../technical-reference/api/README.md#synchronization-of-module-catalog-with-remote-clusters).
+- single-cluster - deployment mode in which Lifecycle Manager is running on the same clutser on which you deploy Kyma. This mode doesn't require Kyma or ModuleTemplate CRs [synchronization](api/README.md#synchronization-of-module-catalog-with-remote-clusters).
 - control-plane - deployment mode in which Lifecycle Manager is running on the central Kubernetes cluster that manages multiple remote clusters that are targets for Kyma installations. In this mode, Kyma and ModuleTemplate CRs are synchronized between the central cluster and remote ones. Access to remote clusters is enabled using centrally-managed K8s Secrets with the required connection configuration.
 
 To configure the mode for Lifecycle Manager, use the `in-kcp-mode` command-line flag. By default, the flag is set to `false`. If set to `true`, Lifecycle Manager runs in the control-plane mode.

--- a/docs/technical-reference/running-modes.md
+++ b/docs/technical-reference/running-modes.md
@@ -12,7 +12,7 @@ Use the single-cluster mode for local development and testing. For E2E testing, 
 ## Release Lifecycles for Modules
 
 Teams providing module operators should work (and release) independently from lifecycle-manager. In other words, lifecycle-manager should not have hard-coded dependencies to any module operator. 
-As such, all module interactions are abstracted through the [ModuleTemplate](../../../api/v1beta2/moduletemplate_types.go).
+As such, all module interactions are abstracted through the [ModuleTemplate](/api/v1beta2/moduletemplate_types.go).
 
 This abstraction of a template is used for generically deploying instances of a module within a Kyma Runtime at a specific Release Group we call `Channel` (for more information, visit the respective Chapter in the [Concept for Modularization](https://github.com/kyma-project/community/tree/main/concepts/modularization#release-channels)). It contains not only a specification of a Module with it's different components through [OCM Component Descriptors](https://github.com/gardener/component-spec/blob/master/doc/proposal/02-component-descriptor.md).
 

--- a/docs/user-tutorials/01-10-control-plane-quick-start.md
+++ b/docs/user-tutorials/01-10-control-plane-quick-start.md
@@ -85,4 +85,4 @@ After the successful deployment of the access Secrete, you can start to use Kyma
 ## Next Steps
 
 - To learn how to publish ModuleTemplate CRs in a private OCI registry, refer to the [Provide credentials for private OCI registry authentication](../developer-tutorials/config-private-registry.md) tutorial
-- To learn how to manage module enablement with the provided strategies, refer to the [Manage module enablement with CustomResourcePolicy](02-10-manage-module-with-custom-resource-policy.md/) tutorial
+- To learn how to manage module enablement with the provided strategies, refer to the [Manage module enablement with CustomResourcePolicy](02-10-manage-module-with-custom-resource-policy.md) tutorial

--- a/internal/declarative/README.md
+++ b/internal/declarative/README.md
@@ -67,16 +67,13 @@ All renderer implementations must implement the [renderer interface](v2/renderer
 
 This is our current selection of rendering engines:
 
-- [HELM](v2/renderer_helm.go): an optimized and specced-down version of the Helm Templating Engine to use with Charts
-- [kustomize](v2/renderer_kustomize.go): an embedded [krusty](https://pkg.go.dev/sigs.k8s.io/kustomize/api/krusty) kustomize implementation
-- [raw](v2/renderer_raw.go): Easy to use raw renderer that just passes through manifests as `.yaml` to the converter
-- [cached](v2/renderer_with_cache.go): Uses an existing renderer and passes rendered resources by levaring a file cache in order to save on reoccuring reconciliation times. Especially useful for long render times from libraries like `HELM` or `kustomize`
+- [raw](v2/renderer_raw.go): Easy to use raw renderer that just passes through manifests as `.yaml` to the converter.
 
 Every renderer reconciles in a particular order through the [renderer interface](v2/renderer.go):
 
 1. Construction of the Renderer based on the [object specification](v2/spec.go)
 2. Initializing of the Renderer through `Initializer(Object)`, setting up necessary status conditions or environment settings
-3. Prerequisite Initialization, e.g. dependencies of the output ([HELM](v2/renderer_helm.go) uses this for CRD layer initialization)
+3. Prerequisite Initialization, e.g. dependencies of the output
 4. Rendering of the Resources into a valid `.yaml` compliant byte array
 5. Removal of the PreRequisites if explicitly desired (by default they are not removed unlike the standard resources, imagine a CRD uninstallation)
 

--- a/internal/manifest/README.md
+++ b/internal/manifest/README.md
@@ -1,10 +1,10 @@
 # Internal Manifest Library
 
-This package contains internal reference coding that is used for translating and implementing the Manifest Reconciler parts that are not generically solved by the [declarative library](../../pkg/declarative/README.md).
+This package contains internal reference coding that is used for translating and implementing the Manifest Reconciler parts that are not generically solved by the [declarative library](/internal/declarative/README.md).
 
 It contains various aspects to:
-1. Translate the [Manifest](../../api/v1beta1/manifest_types.go) into a [declarative specification](../../internal/declarative/v2/spec.go) in a custom [specification resolver](v1beta1/spec_resolver.go). Use [the layer parsing methods](v1beta1/parse.go) to download and resolve OCI image layers from the Manifest to make them accessible to the declarative library.
-2. Lookup the correct Client for Single or Dual Cluster Mode based on the [SKR Client Lookup](v1beta1/skr_client_lookup.go) and a [ClusterClient](v1beta1/client.go) to read Secret Data as if they were a kubeconfig
-3. Lookup the correct Keychain to access image layers contained in private registries through a [Keychain](v1beta1/keychain.go)
-4. Interact with Default Data supplied to the `Manifest` for initializing a module with [Pre/Post-Hooks](v1beta1/custom_resource.go)
-5. Check for Module Readiness not only by looking at the resources supplied in the chart, but also to introspect the already mentioned CustomResource using a [custom ReadyCheck](v1beta1/ready_check.go)
+1. Translate the [Manifest](/api/v1beta1/manifest_types.go) into a [declarative specification](/internal/declarative/v2/spec.go) in a custom [specification resolver](spec_resolver.go). Use [the layer parsing methods](parse.go) to download and resolve OCI image layers from the Manifest to make them accessible to the declarative library.
+2. Lookup the correct Client for Single or Dual Cluster Mode based on the [SKR Client Lookup](skr_client_lookup.go) and a [ClusterClient](client.go) to read Secret Data as if they were a kubeconfig
+3. Lookup the correct Keychain to access image layers contained in private registries through a [Keychain](/pkg/ocmextensions/cred.go)
+4. Interact with Default Data supplied to the `Manifest` for initializing a module with [Pre/Post-Hooks](custom_resource.go)
+5. Check for Module Readiness not only by looking at the resources supplied in the chart, but also to introspect the already mentioned CustomResource using a [custom ReadyCheck](ready_check.go)

--- a/tests/e2e_test/README.md
+++ b/tests/e2e_test/README.md
@@ -6,8 +6,8 @@ See the [Run the e2e tests locally](#run-the-e2e-tests-locally) section for deta
 
 ## Contents
 
-- [Test suite](./e2e_suite_test.go) that sets up required clients and configurations.
-- [Watcher end-to-end tests](./e2e_watcher_test.go) that includes tests and the end-to-end workflow of the watcher.
+- [Test suite](./suite_test.go) that sets up required clients and configurations.
+- [Watcher end-to-end tests](./watcher_test.go) that includes tests and the end-to-end workflow of the watcher.
 - [Makefile](./Makefile) that includes targets to execute the watcher e2e test suite.
 
 ## Run the e2e tests locally

--- a/tests/e2e_test/README.md
+++ b/tests/e2e_test/README.md
@@ -12,7 +12,7 @@ See the [Run the e2e tests locally](#run-the-e2e-tests-locally) section for deta
 
 ## Run the e2e tests locally
 
-1. Set up your local environment using steps 1 to 3 from [this guide](../../docs/developer-tutorials/local-test-setup.md). Create a cluster, and install Istio CRDs and `cert-manager`. Skip all the remaining steps from the guide. 
+1. Set up your local environment using steps 1 to 3 from [this guide](/docs/developer-tutorials/local-test-setup.md). Create a cluster, and install Istio CRDs and `cert-manager`. Skip all the remaining steps from the guide. 
 2. Export the following  K8s configurations as environment variables:
     ```shell
     export KCP_KUBECONFIG=$(k3d kubeconfig write kcp-local)


### PR DESCRIPTION
**Description**

Adds a GitHub Action for the Markdown Link checker.

- Creates a GitHub Actions workflow using the [Markdown Link Check](https://github.com/marketplace/actions/markdown-link-check)
- Fixes the links that were broken

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
