### PR TITLE
chore: Use GH-Action instead prow job for unit testing

### DIFF
--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -3,6 +3,10 @@ name: Lint golangci
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '**.go'
   workflow_dispatch:
 jobs:
   golangci:

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Override Kustomize Controller Image TAG and Image repository environment variables in Pull Request to PR Image
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -3,8 +3,19 @@ name: TestSuite E2E
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '**.go'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '**.sh'
+      - '**.go'
 jobs:
   wait-for-img:
     name: "Wait for Image Build"

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -3,8 +3,19 @@ name: TestSuite Smoke
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '**.go'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '**.sh'
+      - '**.go'
 jobs:
   wait-for-img:
     name: "Wait for Image Build"

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -14,7 +14,6 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
-      - '**.sh'
       - '**.go'
 jobs:
   wait-for-img:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,4 +1,4 @@
-name: TestSuite EnvTest and UnitTest
+name: TestSuite integration and unit tests
 
 on:
   pull_request:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Run 'make test'
         working-directory: ./lifecycle-manager
         run: |

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -3,6 +3,11 @@ name: TestSuite integration and unit tests
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '**.go'
 jobs:
   envtest-and-unittest:
     name: "Run 'make test'"

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -15,13 +15,10 @@ jobs:
     steps:
       - name: Checkout lifecycle-manager
         uses: actions/checkout@v3
-        with:
-          path: ./lifecycle-manager/
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
       - name: Run 'make test'
-        working-directory: ./lifecycle-manager
         run: |
           make test

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,22 @@
+name: TestSuite EnvTest and UnitTest
+
+on:
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  envtest-and-unittest:
+    name: "Run 'make test'"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lifecycle-manager
+        uses: actions/checkout@v3
+        with:
+          path: ./lifecycle-manager/
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Run 'make test'
+        working-directory: ./lifecycle-manager
+        run: |
+          make test


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use GH-Actions instead prow to run `make test`
- Prow job still needs to be cleaned up: https://github.com/kyma-project/test-infra/pull/8896
    - Way faster than prow (currently, test takes ~5min + waiting time for free runner)
- Use go 1.21 in GH-Actions, since KLM is written in 1.21

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
