### PR TITLE
test: ModuleTemplate version update for Manifest CR suite

### DIFF
--- a/controllers/kyma_controller/manifest_test.go
+++ b/controllers/kyma_controller/manifest_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Update Module Template Version", Ordered, func() {
 			updateModuleTemplateWith := funWrap(updateKCPModuleTemplate(module.Name, "default"))
 			validateModuleTemplateWith := funWrap(validateKCPModuleTemplate(module.Name, "default"))
 
-			ensureModuleTemplateUpdated := composeFunctions(
+			ensureModuleTemplateUpdated := series(
 				updateModuleTemplateWith(newVersionAndLayerDigest),
 				validateModuleTemplateWith(updatedVersionAndLayerDigest),
 			)
@@ -585,8 +585,8 @@ func funWrap(inputFn func(moduleTemplateFn) error) func(moduleTemplateFn) func()
 	return res
 }
 
-// composeFunctions composes a series of simple parameterless functions into a single one.
-func composeFunctions(fns ...func() error) func() error {
+// series wraps a list of simple parameterless functions into a single one.
+func series(fns ...func() error) func() error {
 	return func() error {
 		var err error
 		for i := range fns {

--- a/controllers/kyma_controller/manifest_test.go
+++ b/controllers/kyma_controller/manifest_test.go
@@ -282,12 +282,15 @@ var _ = Describe("Update Module Template Version", Ordered, func() {
 			updateModuleTemplateWith := funWrap(updateKCPModuleTemplate(module.Name, "default"))
 			validateModuleTemplateWith := funWrap(validateKCPModuleTemplate(module.Name, "default"))
 
-			ensureModuleTemplateUpdated := series(
-				updateModuleTemplateWith(newVersionAndLayerDigest),
-				validateModuleTemplateWith(updatedVersionAndLayerDigest),
+			updateModuleTemplateVersionAndLayerDigest := updateModuleTemplateWith(newVersionAndLayerDigest)
+			validateVersionAndLayerDigestAreUpdated := validateModuleTemplateWith(updatedVersionAndLayerDigest)
+
+			ensureModuleTemplateUpdate := series(
+				updateModuleTemplateVersionAndLayerDigest,
+				validateVersionAndLayerDigestAreUpdated,
 			)
 
-			Eventually(ensureModuleTemplateUpdated, Timeout, Interval*2).Should(Succeed())
+			Eventually(ensureModuleTemplateUpdate, Timeout, Interval*2).Should(Succeed())
 		}
 
 		By("Manifest is updated with new value in spec.install.source.ref")


### PR DESCRIPTION
**Description**

Add test case for ModuleTemplate version upgrade in the Manifest CR test suite.
The flow:

- Given a deployed ModuleTempate and Kyma and Manifest CR in a `Ready` state
- When the ModuleTemplate version is updated to a new artifact by setting new version and `raw-manifest` layer hash.
- Then Manifest CR related fields get updated correctly

Changes proposed in this pull request:

- Add new test case for kyma controller

**Related issue(s)**
#702 
