### PR TITLE
chore(infra): Configure dependabot to adhere to the Conventional Commits spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "gomod"
-      include: "scope"
+      prefix: "chore(dependabot)"
   - package-ecosystem: "docker"
     directory: "/"
     labels:
@@ -20,5 +19,4 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "docker"
-      include: "scope"
+      prefix: "chore(dependabot)"

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -1,7 +1,11 @@
 name: Lint Markdown Links
 run-name: ${{github.event.pull_request.title}}
 
-on: [ pull_request ]
+on:
+  pull_request:
+  schedule:
+    # Run every day at 5:00 AM
+    - cron: "0 5 * * *"
 
 jobs:
   markdown-link-check:


### PR DESCRIPTION
Changes proposed in this pull request:

- Configure Dependabot's dependency bumps to adhere to the Conventional Commits spec
