### PR TITLE
fix: Remove flaky watcher test condition

### DIFF
--- a/controllers/withwatcher/kyma_controller_test.go
+++ b/controllers/withwatcher/kyma_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
@@ -46,13 +45,7 @@ var _ = Describe("Kyma with multiple module CRs in remote sync mode", Ordered, f
 	kymaObjKey := client.ObjectKeyFromObject(kyma)
 	tlsSecret := createTLSSecret(kymaObjKey)
 
-	delete(kyma.ObjectMeta.Annotations, v1beta2.SyncStrategyAnnotation)
 	registerDefaultLifecycleForKymaWithWatcher(kyma, watcherCrForKyma, tlsSecret, issuer)
-
-	It("kyma reconciliation does not install webhook when sync label missing", func() {
-		Consistently(latestWebhookIsConfigured(suiteCtx, runtimeClient, watcherCrForKyma,
-			kymaObjKey), 5*time.Second, Interval).ShouldNot(Succeed())
-	})
 
 	It("kyma reconciliation installs watcher with correct webhook config", func() {
 		kyma.ObjectMeta.Annotations[v1beta2.SyncStrategyAnnotation] = v1beta2.SyncStrategyLocalClient


### PR DESCRIPTION
Check does not install webhook will collide with other watcher tests which install webhook