### PR TITLE
test(e2e): Add Acceptance Criteria report 

### DIFF
--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -51,13 +51,10 @@ $(GINKGO): $(LOCALBIN)
 	@test -s $(GINKGO) && $(GINKGO) version | grep -q $(GINKGO_VERSION) || \
 	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 
-
-.PHONY: e2e-coverage
 e2e-coverage: ginkgo ## Generate the effective Acceptance Criteria for all the test suites.
 	@for file in $(shell ls *_test.go | grep -v suite_test.go) ; do \
         $(GINKGO) outline --format indent $$file  | awk -F "," '{print $$1" "$$2}' | tail -n +2 ; \
     done
-
 
 ##@ E2E Tests
 

--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -15,12 +15,20 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+## Location to install local dependencies to.
+LOCALBIN ?= $(shell pwd)/../../bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Ginkgo binary metadata.
+GINKGO ?= $(LOCALBIN)/ginkgo
+GINKGO_VERSION ?= v2.12.0
 
 ##@ General
 
@@ -37,6 +45,19 @@ SHELL = /usr/bin/env bash -o pipefail
 
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+ginkgo: $(GINKGO) ## Download local ginkgo binary if necessary.
+$(GINKGO): $(LOCALBIN)
+	@test -s $(GINKGO) && $(GINKGO) version | grep -q $(GINKGO_VERSION) || \
+	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+
+.PHONY: e2e-coverage
+e2e-coverage: ginkgo ## Generate the effective Acceptance Criteria for all the test suites.
+	@for file in $(shell ls *_test.go | grep -v suite_test.go) ; do \
+        $(GINKGO) outline --format indent $$file  | awk -F "," '{print $$1" "$$2}' | tail -n +2 ; \
+    done
+
 
 ##@ E2E Tests
 

--- a/tests/e2e_test/Makefile
+++ b/tests/e2e_test/Makefile
@@ -1,3 +1,13 @@
+.DEFAULT_GOAL := test
+
+# Mark all the targets in the file as PHONY ones.
+# Effectively, all the targets passed to the make during the invocation are
+# passed through the MAKECMDGOALS special variable. So, the instruction below
+# defines the targets mentioned above as phony ones.
+#
+# The test target is explicitly listed because it is subject to omission.
+.PHONY: test $(MAKECMDGOALS)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -25,27 +35,21 @@ SHELL = /usr/bin/env bash -o pipefail
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
-.PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ E2E Tests
 
-.PHONY: test
 test: watcher-enqueue kyma-deletion module-status-propagation
 
-.PHONY: kyma-deletion
 kyma-deletion: ## Runs the Kyma Deletion E2E Test
 	go test -ginkgo.v -ginkgo.focus "KCP Kyma CR Deletion"
 
-.PHONY: kyma-metrics
 kyma-metrics: ## Runs the Kyma Metrics E2E Test
 	go test -ginkgo.v -ginkgo.focus "Kyma Metrics"
 
-.PHONY: watcher-enqueue
 watcher-enqueue: ## Runs the Watcher E2E Test
 	go test -ginkgo.v -ginkgo.focus "Enqueue Event from Watcher"
 
-.PHONY: module-status-propagation
 module-status-propagation: ## Runs the Status Propagation E2E Test
 	go test -ginkgo.v -ginkgo.focus "Warning Status Propagation"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Adds a `make e2e-coverage` make target which prints the current acceptance tests coverage:

```
Describe KCP Kyma CR should be deleted successfully when SKR cluster gets deleted
    Then Should create empty Kyma CR on remote cluster
        By verifying kyma is ready
        By verifying remote kyma is ready
    It Should remove SKR Cluster
        By removing SKR Cluster
        By deleting secret
        By Kyma should be in Error state
    It Should recreate SKR cluster and its secret
        By Creating SKR cluster
        By Creating Kyma secret
    It Kyma should be in Ready state after secret is re-fetched
        By Kyma should be in Ready state
    It Should delete KCP Kyma
        By Deleting KCP Kyma
    It Kyma CR should be removed
Describe When KCP Kyma CR deleted
    It Should create empty Kyma CR
        By verifying kyma is ready
        By verifying remote kyma is ready
    It Kyma reconciliation should remove metric when Kyma CR deleted 
        By getting the current kyma Ready state metric count
        By deleting KCP Kyma
        By waiting for Kyma CR to be removed
        By should decrease the metric count
Describe Enable Template Operator
    It Should create empty Kyma CR on remote cluster
        By verifying kyma is ready
        By verifying remote kyma is ready
    It Should enable Template Operator and Kyma should result in Warning status
        By Enabling Template Operator
        By Checking state of kyma
    It Should disable Template Operator and Kyma should result in Ready status
        By Disabling Template Operator
        By Checking state of kyma
    It Should delete KCP Kyma
        By Deleting KCP Kyma
    It Kyma CR should be removed
Describe Kyma CR change on runtime cluster triggers new reconciliation using the Watcher
    It Should create empty Kyma CR on remote cluster
        By verifying kyma is ready
        By verifying remote kyma is ready
    It Should redeploy watcher if it is deleted on remote cluster
        By verifying Runtime-Watcher is ready
        By deleting Runtime-Watcher deployment
        By verifying Runtime-Watcher deployment will be reapplied and becomes ready
    It Should redeploy certificates if deleted on remote cluster
        By verifying certificate secret exists on remote cluster
        By Deleting certificate secret on remote cluster
        By verifying certificate secret will be recreated on remote cluster
    It Should trigger new reconciliation
        By changing the spec of the remote KymaCR
        By verifying new reconciliation got triggered for corresponding KymaCR on KCP
    It Should delete Kyma CR on remote cluster
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
