### PR TITLE
feat: Kustomize remove vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ dry-run: kustomize manifests
 dry-run-control-plane: kustomize manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	mkdir -p dry-run
-	$(KUSTOMIZE) build config/control-plane > dry-run/manifests.yaml
+	$(KUSTOMIZE) build config/control-plane
 
 ##@ Build
 
@@ -109,7 +109,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -118,18 +118,18 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default
 	
 .PHONY: lt-deploy
 lt-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/load_test | kubectl apply -f -
+	$(KUSTOMIZE) build config/load_test
 
 .PHONY: local-deploy-with-watcher
 
 local-deploy-with-watcher: generate kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/watcher_local_test | kubectl apply -f -
+	$(KUSTOMIZE) build config/watcher_local_test
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ dry-run: kustomize manifests
 dry-run-control-plane: kustomize manifests
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	mkdir -p dry-run
-	$(KUSTOMIZE) build config/control-plane
+	$(KUSTOMIZE) build config/control-plane > dry-run/manifests.yaml
 
 ##@ Build
 
@@ -109,7 +109,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -118,18 +118,17 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
 	
 .PHONY: lt-deploy
 lt-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/load_test
+	$(KUSTOMIZE) build config/load_test | kubectl apply -f -
 
 .PHONY: local-deploy-with-watcher
-
 local-deploy-with-watcher: generate kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/watcher_local_test
+	$(KUSTOMIZE) build config/watcher_local_test | kubectl apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ lt-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified
 	$(KUSTOMIZE) build config/load_test | kubectl apply -f -
 
 .PHONY: local-deploy-with-watcher
+
 local-deploy-with-watcher: generate kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/watcher_local_test | kubectl apply -f -

--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -108,33 +108,82 @@ transformers:
     name: klm-status
     version: v1
 
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
+replacements:
+# substitutes CERTIFICATE_NAMESPACE, the namespace of the certificate CR
+- source:
     kind: Certificate
-    group: cert-manager.io
-    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+# substitutes CERTIFICATE_NAME, the name of the certificate CR
+- source:
     kind: Certificate
-    group: cert-manager.io
-    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+# substitutes SERVICE_NAMESPACE, the namespace of the service
+- source:
     kind: Service
     version: v1
     name: webhook-service
-  fieldref:
     fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+# substitutes SERVICE_NAME, the name of the service
+- source:
     kind: Service
     version: v1
     name: webhook-service
+    fieldpath: metadata.name
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -61,31 +61,67 @@ components:
   # [GRAFANA] To generate configmap for provision grafana dashboard
   #- ../grafana
 
-vars:
+replacements:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
+# substitutes CERTIFICATE_NAMESPACE, the namespace of the certificate CR
+- source:
     kind: Certificate
-    group: cert-manager.io
-    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+
+# substitutes CERTIFICATE_NAME, the name of the certificate CR
+- source:
     kind: Certificate
-    group: cert-manager.io
-    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -62,7 +62,6 @@ components:
   #- ../grafana
 
 replacements:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # substitutes CERTIFICATE_NAMESPACE, the namespace of the certificate CR
 - source:
     kind: Certificate
@@ -84,7 +83,6 @@ replacements:
     options:
       delimiter: '/'
       index: 0
-
 # substitutes CERTIFICATE_NAME, the name of the certificate CR
 - source:
     kind: Certificate
@@ -106,22 +104,39 @@ replacements:
     options:
       delimiter: '/'
       index: 1
-
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+# substitutes SERVICE_NAMESPACE, the namespace of the service
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldpath: metadata.namespace
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+# substitutes SERVICE_NAME, the name of the service
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldpath: metadata.name
+  targets:
+  - select:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,15 +1,6 @@
 # This patch add annotation to admission webhook config and
-# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# the placeholders $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) are substituted by kustomize.
 
-# No MutatingWebhookConfiguration needed, uncomment follow when necessary
-
-#apiVersion: admissionregistration.k8s.io/v1
-#kind: MutatingWebhookConfiguration
-#metadata:
-#  name: mutating-webhook-configuration
-#  annotations:
-#    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-#---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/config/load_test/kustomization.yaml
+++ b/config/load_test/kustomization.yaml
@@ -22,35 +22,85 @@ commonLabels:
   app.kubernetes.io/managed-by: kustomize
   app.kubernetes.io/part-of: manual-deployment
 
-# the following config is for teaching kustomize how to do var substitution
-vars:
-  # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
+replacements:
+# substitutes CERTIFICATE_NAMESPACE, the namespace of the certificate CR
+- source:
+    kind: Certificate
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+# substitutes CERTIFICATE_NAME, the name of the certificate CR
+- source:
+    kind: Certificate
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+  - select:
+      kind: CustomResourceDefinition
+    fieldpaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+# substitutes SERVICE_NAMESPACE, the namespace of the service
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldpath: metadata.namespace
+  targets:
+  - select:
       group: cert-manager.io
       version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
       kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+# substitutes SERVICE_NAME, the name of the service
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldpath: metadata.name
+  targets:
+  - select:
       group: cert-manager.io
       version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
+      kind: Certificate
+      name: serving-cert
+    fieldpaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
 
 patches:
   - patch: |-


### PR DESCRIPTION
**Description**

This PR refines `kustomize` configuration.
The deprecated `vars` is changed to `replacements`.
The change is necessary to switch from kustomize API `v1beta1` to `v1`

Changes proposed in this pull request:

- `vars` is changed to `replacements`

**Related issue(s)**
See also: #391 
