### PR TITLE
feat: Improve XFCC header parsing in SAN Verification code (Checkmarx)

### DIFF
--- a/pkg/security/internal_test.go
+++ b/pkg/security/internal_test.go
@@ -1,0 +1,57 @@
+package security
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getCertTokenFromXFCCHeader(t *testing.T) {
+	const headerPart1 = `By=http://frontend.lyft.com;Hash=468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688`
+	const headerPart2 = `Subject="/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test Client";URI=http://testclient.lyft.com;DNS=lyft.com;DNS=www.lyft.com` //nolint:lll
+	const headerCert = `Cert=RnJpIE9jdCAxMyAwODoyMTozMSBBTSBDRVNUIDIwMjMK`
+
+	t.Parallel()
+	tests := []struct {
+		name           string
+		xfccHeader     string
+		expectedKeys   int
+		expectedResult string
+	}{
+		{
+			name:           "For header without a certificate",
+			xfccHeader:     headerPart1 + ";" + headerPart2,
+			expectedKeys:   6,
+			expectedResult: "", // no "Cert=<value>" key pair
+		},
+		{
+			name:           "For header with the certificate at the beginning",
+			xfccHeader:     headerCert + ";" + headerPart1 + ";" + headerPart2,
+			expectedKeys:   7,
+			expectedResult: "RnJpIE9jdCAxMyAwODoyMTozMSBBTSBDRVNUIDIwMjMK",
+		},
+		{
+			name:           "For header with certificate at the end",
+			xfccHeader:     headerPart1 + ";" + headerPart2 + ";" + headerCert,
+			expectedKeys:   7,
+			expectedResult: "RnJpIE9jdCAxMyAwODoyMTozMSBBTSBDRVNUIDIwMjMK",
+		},
+		{
+			name:           "For header with certificate in the middle",
+			xfccHeader:     headerPart1 + ";" + headerCert + ";" + headerPart2,
+			expectedKeys:   7,
+			expectedResult: "RnJpIE9jdCAxMyAwODoyMTozMSBBTSBDRVNUIDIwMjMK",
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actualResult := getCertTokenFromXFCCHeader(test.xfccHeader)
+			require.Equal(t, test.expectedResult, actualResult)
+			actualKeys := len(strings.Split(test.xfccHeader, ";"))
+			require.Equal(t, test.expectedKeys, actualKeys)
+		})
+	}
+}

--- a/pkg/security/san_pinning.go
+++ b/pkg/security/san_pinning.go
@@ -156,10 +156,10 @@ func (e AnnotationMissingError) Error() string {
 }
 
 // getCertTokenFromXFCCHeader returns the first certificate embedded in the XFFC Header, if exists. Otherwise an empty string is returned.
-func getCertTokenFromXFCCHeader(header string) string {
-	certStartIdx := strings.Index(header, certificateKey)
+func getCertTokenFromXFCCHeader(hVal string) string {
+	certStartIdx := strings.Index(hVal, certificateKey)
 	if certStartIdx >= 0 {
-		tokenWithCert := header[(certStartIdx + len(certificateKey)):]
+		tokenWithCert := hVal[(certStartIdx + len(certificateKey)):]
 		//we should never have "," here but it's safer to add it anyway
 		certEndIdx := strings.IndexAny(tokenWithCert, ";,")
 		if certEndIdx == -1 {

--- a/pkg/security/san_pinning.go
+++ b/pkg/security/san_pinning.go
@@ -136,9 +136,7 @@ func (v *RequestVerifier) VerifySAN(certificate *x509.Certificate, kymaDomain st
 	dnsNames := certificate.DNSNames
 	IPAddresses := certificate.IPAddresses
 
-	if len(uris) > limitSANValues ||
-		len(dnsNames) > limitSANValues ||
-		len(IPAddresses) > limitSANValues {
+	if (len(uris) + len(dnsNames) + len(IPAddresses)) > limitSANValues {
 		return false, errTooManySANValues
 	}
 

--- a/pkg/security/san_pinning_test.go
+++ b/pkg/security/san_pinning_test.go
@@ -94,7 +94,8 @@ func TestRequestVerifier_verifySAN(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			got := verifier.VerifySAN(test.args.certificate, test.args.kymaDomain)
+			got, err := verifier.VerifySAN(test.args.certificate, test.args.kymaDomain)
+			require.Empty(t, err)
 			require.Equal(t, test.want, got)
 		})
 	}


### PR DESCRIPTION
**Description**

Checkmarx reported potential DDoS via resource-exhaustion around the XFCC header parsing in `pkg/security/san_pinning.go:81` (line number as in the current PR)
This PR does not "fix" the Checkmarx alert - it looks like Checkmarx is complaining about "slice expression" which, on its own, is not leading to any resource exhaustion.
Nevertheless we should protect the code from incjection of big and potentially malicious Certificate data and introduce some limits.

Note to the reviewer: The limits proposed in the PR are arbitrary, AFAIK there are no "hard" values defined for certificate size or a number of SAN of the certificate.
The proposed values seem to be big enough to handle any real scenario considering the Lifecycle-Manager environment.

Changes proposed in this pull request:

- Limit the size of the certificate data to 32 KiB
- Limit the number of SAN items to 100 (one hundred) 
