### PR TITLE
fix: Change download kubectl from apt

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -55,18 +55,15 @@ jobs:
       - name: Install prerequisites
         run: |
           sudo add-apt-repository ppa:longsleep/golang-backports -y
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
-          sudo apt install git curl wget make bash golang-go -y
+          sudo apt install git curl wget make bash golang-go kubectl ca-certificates -y
       - name: Install Istio CLI
         run: |
           curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
           chmod +x istio-$ISTIO_VERSION/bin/istioctl
           mv istio-$ISTIO_VERSION/bin/istioctl /usr/local/bin
-      - name: Install kubectl
-        run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl /usr/local/bin
       - name: Install Kyma CLI
         run: |
           wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -73,6 +73,13 @@ jobs:
       KUSTOMIZE_VERSION: 4.5.7
       ISTIO_VERSION: 1.17.1
     steps:
+      - name: Install prerequisites
+        run: |
+          sudo add-apt-repository ppa:longsleep/golang-backports -y
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo apt update -y
+          sudo apt install git curl wget make bash golang-go kubectl ca-certificates -y
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
       - name: Setup kustomize
@@ -105,10 +112,6 @@ jobs:
       - name: Setup Control-Plane requirements
         if: ${{ matrix.target  == 'control-plane' }}
         run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl /usr/local/bin
-          
           kubectl label node k3d-kyma-server-0 iam.gke.io/gke-metadata-server-enabled=true
 
           curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -


### PR DESCRIPTION
currently, direct download kubectl from github action seems not working, will download a broken kubectl binary, with error [here](https://github.com/kyma-project/lifecycle-manager/actions/runs/6568311861/job/17851834303?pr=962#step:14:14).

This PR changed the way to download kubectl from apt, from official [document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management)