### PR TITLE
chore: Download go binary from github action

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -54,11 +54,14 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo add-apt-repository ppa:longsleep/golang-backports -y
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
           echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
-          sudo apt install git curl wget make bash golang-go kubectl ca-certificates -y
+          sudo apt install git curl wget make bash kubectl ca-certificates -y
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
       - name: Install Istio CLI
         run: |
           curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
@@ -112,10 +115,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: lifecycle-manager
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
       - name: Override Kustomize Controller Image TAG and Image repository environment variables in Pull Request to PR Image
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -55,18 +55,15 @@ jobs:
       - name: Install prerequisites
         run: |
           sudo add-apt-repository ppa:longsleep/golang-backports -y
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
-          sudo apt install git curl wget make bash golang-go -y
+          sudo apt install git curl wget make bash golang-go kubectl ca-certificates -y
       - name: Install Istio CLI
         run: |
           curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -
           chmod +x istio-$ISTIO_VERSION/bin/istioctl
           mv istio-$ISTIO_VERSION/bin/istioctl /usr/local/bin
-      - name: Install kubectl
-        run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl /usr/local/bin
       - name: Install Kyma CLI
         run: |
           wget -q https://storage.googleapis.com/kyma-cli-unstable/kyma-linux

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -57,7 +57,7 @@ jobs:
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
           echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
-          sudo apt install git curl wget make bash kubectl ca-certificates -y
+          sudo apt install kubectl -y
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -78,7 +78,7 @@ jobs:
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
           echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
-          sudo apt install git curl wget make bash kubectl ca-certificates -y
+          sudo apt install kubectl -y
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
       - name: Setup kustomize

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -73,6 +73,13 @@ jobs:
       KUSTOMIZE_VERSION: 4.5.7
       ISTIO_VERSION: 1.17.1
     steps:
+      - name: Install prerequisites
+        run: |
+          sudo add-apt-repository ppa:longsleep/golang-backports -y
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo apt update -y
+          sudo apt install git curl wget make bash golang-go kubectl ca-certificates -y
       - name: Checkout Lifecycle-Manager
         uses: actions/checkout@v3
       - name: Setup kustomize
@@ -105,10 +112,6 @@ jobs:
       - name: Setup Control-Plane requirements
         if: ${{ matrix.target  == 'control-plane' }}
         run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl /usr/local/bin
-          
           kubectl label node k3d-kyma-server-0 iam.gke.io/gke-metadata-server-enabled=true
 
           curl -L https://istio.io/downloadIstio | TARGET_ARCH=x86_64 sh -


### PR DESCRIPTION
only use `actions/setup-go` download go binary

remove already installed packages
```
Reading package lists...
Building dependency tree...
Reading state information...
bash is already the newest version (5.1-6ubuntu1).
make is already the newest version (4.3-4.1build1).
wget is already the newest version (1.21.2-2ubuntu1).
ca-certificates is already the newest version (20230311ubuntu0.22.04.1).
curl is already the newest version (7.81.0-1ubuntu1.14).
git is already the newest version (1:2.42.0-0ppa1~ubuntu22.04.1).
```