### PR TITLE
fix: Fix skip reconciliation for Manifest

### DIFF
--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -417,7 +417,7 @@ func (kyma *Kyma) HasSyncLabelEnabled() bool {
 }
 
 func (kyma *Kyma) SkipReconciliation() bool {
-	skip, found := kyma.Labels[v2.DefaultSkipReconcileLabel]
+	skip, found := kyma.Labels[v2.SkipReconcileLabel]
 	return found && strings.ToLower(skip) == EnableLabelValue
 }
 

--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	"strings"
 
+	v2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -416,7 +417,7 @@ func (kyma *Kyma) HasSyncLabelEnabled() bool {
 }
 
 func (kyma *Kyma) SkipReconciliation() bool {
-	skip, found := kyma.Labels[SkipReconcileLabel]
+	skip, found := kyma.Labels[v2.DefaultSkipReconcileLabel]
 	return found && strings.ToLower(skip) == EnableLabelValue
 }
 

--- a/api/v1beta2/operator_labels.go
+++ b/api/v1beta2/operator_labels.go
@@ -25,10 +25,8 @@ const (
 	// if this resource is changed.
 	WatchedByLabel = OperatorPrefix + Separator + "watched-by"
 	// PurposeLabel defines the purpose of the resource, i.e. Secrets which will be used to certificate management.
-	PurposeLabel = OperatorPrefix + Separator + "purpose"
-	CertManager  = "klm-watcher-cert-manager"
-	// SkipReconcileLabel indicates this specific resource will be skipped during reconciliation.
-	SkipReconcileLabel    = OperatorPrefix + Separator + "skip-reconciliation"
+	PurposeLabel          = OperatorPrefix + Separator + "purpose"
+	CertManager           = "klm-watcher-cert-manager"
 	UnmanagedKyma         = "unmanaged-kyma"
 	DefaultRemoteKymaName = "default"
 	InternalLabel         = OperatorPrefix + Separator + "internal"

--- a/internal/controller/kyma_controller/kyma_test.go
+++ b/internal/controller/kyma_controller/kyma_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	v2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 	. "github.com/onsi/ginkgo/v2"
@@ -267,7 +268,7 @@ var _ = Describe("Kyma skip Reconciliation", Ordered, func() {
 			Should(BeEquivalentTo(v1beta2.StateReady))
 
 		By("Add skip-reconciliation label to Kyma CR")
-		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v1beta2.SkipReconcileLabel, "true"),
+		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.DefaultSkipReconcileLabel, "true"),
 			Timeout, Interval).Should(Succeed())
 	})
 
@@ -285,7 +286,7 @@ var _ = Describe("Kyma skip Reconciliation", Ordered, func() {
 	)
 
 	It("Stop Kyma skip Reconciliation so that it can be deleted", func() {
-		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v1beta2.SkipReconcileLabel, "false"),
+		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.DefaultSkipReconcileLabel, "false"),
 			Timeout, Interval).Should(Succeed())
 	})
 })

--- a/internal/controller/kyma_controller/kyma_test.go
+++ b/internal/controller/kyma_controller/kyma_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Kyma skip Reconciliation", Ordered, func() {
 			Should(BeEquivalentTo(v1beta2.StateReady))
 
 		By("Add skip-reconciliation label to Kyma CR")
-		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.DefaultSkipReconcileLabel, "true"),
+		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.SkipReconcileLabel, "true"),
 			Timeout, Interval).Should(Succeed())
 	})
 
@@ -286,7 +286,7 @@ var _ = Describe("Kyma skip Reconciliation", Ordered, func() {
 	)
 
 	It("Stop Kyma skip Reconciliation so that it can be deleted", func() {
-		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.DefaultSkipReconcileLabel, "false"),
+		Eventually(UpdateKymaLabel(ctx, controlPlaneClient, kyma, v2.SkipReconcileLabel, "false"),
 			Timeout, Interval).Should(Succeed())
 	})
 })

--- a/internal/controller/kyma_controller/manifest_test.go
+++ b/internal/controller/kyma_controller/manifest_test.go
@@ -292,6 +292,34 @@ var _ = Describe("Update Module Template Version", Ordered, func() {
 	})
 })
 
+var _ = Describe("Test Reconciliation Skip label for Manifest", Ordered, func() {
+	kyma := NewTestKyma("kyma")
+	module := NewTestModule("skip-reconciliation-module", v1beta2.DefaultChannel)
+	kyma.Spec.Modules = append(kyma.Spec.Modules, module)
+
+	RegisterDefaultLifecycleForKyma(kyma)
+	It("Given a Manifest CR exists", func() {
+		Eventually(ManifestExists, Timeout, Interval).
+			WithContext(ctx).
+			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name).
+			Should(Succeed())
+	})
+
+	It("When a skip label is added to Manifest", func() {
+		Eventually(AddSkipLabelToManifest, Timeout, Interval).
+			WithContext(ctx).
+			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name).
+			Should(Succeed())
+	})
+
+	It("Then Skip label always exists in Manifest CR", func() {
+		Consistently(SkipLabelExistsInManifest, Timeout, Interval).
+			WithContext(ctx).
+			WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name).
+			Should(BeTrue())
+	})
+})
+
 func findRawManifestResource(reslist []compdesc.Resource) *compdesc.Resource {
 	for _, r := range reslist {
 		if r.Name == v1beta2.RawManifestLayerName {

--- a/internal/declarative/v2/options.go
+++ b/internal/declarative/v2/options.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	FinalizerDefault          = "declarative.kyma-project.io/finalizer"
-	FieldOwnerDefault         = "declarative.kyma-project.io/applier"
-	EventRecorderDefault      = "declarative.kyma-project.io/events"
-	DefaultSkipReconcileLabel = "operator.kyma-project.io/skip-reconciliation"
-	DefaultInMemoryParseTTL   = 24 * time.Hour
+	FinalizerDefault        = "declarative.kyma-project.io/finalizer"
+	FieldOwnerDefault       = "declarative.kyma-project.io/applier"
+	EventRecorderDefault    = "declarative.kyma-project.io/events"
+	SkipReconcileLabel      = "operator.kyma-project.io/skip-reconciliation"
+	DefaultInMemoryParseTTL = 24 * time.Hour
 )
 
 func DefaultOptions() *Options {
@@ -315,8 +315,8 @@ type SkipReconcile func(context.Context, Object) (skip bool)
 
 // SkipReconcileOnDefaultLabelPresentAndTrue determines SkipReconcile by checking if DefaultSkipReconcileLabel is true.
 func SkipReconcileOnDefaultLabelPresentAndTrue(ctx context.Context, object Object) bool {
-	if object.GetLabels() != nil && object.GetLabels()[DefaultSkipReconcileLabel] == "true" {
-		log.FromContext(ctx, "skip-label", DefaultSkipReconcileLabel).
+	if object.GetLabels() != nil && object.GetLabels()[SkipReconcileLabel] == "true" {
+		log.FromContext(ctx, "skip-label", SkipReconcileLabel).
 			V(internal.DebugLogLevel).Info("resource gets skipped because of label")
 		return true
 	}

--- a/internal/declarative/v2/options.go
+++ b/internal/declarative/v2/options.go
@@ -22,7 +22,7 @@ const (
 	FinalizerDefault          = "declarative.kyma-project.io/finalizer"
 	FieldOwnerDefault         = "declarative.kyma-project.io/applier"
 	EventRecorderDefault      = "declarative.kyma-project.io/events"
-	DefaultSkipReconcileLabel = "declarative.kyma-project.io/skip-reconciliation"
+	DefaultSkipReconcileLabel = "operator.kyma-project.io/skip-reconciliation"
 	DefaultInMemoryParseTTL   = 24 * time.Hour
 )
 

--- a/pkg/testutils/manifest.go
+++ b/pkg/testutils/manifest.go
@@ -121,3 +121,38 @@ func GetManifestResource(ctx context.Context,
 
 	return moduleInCluster.Spec.Resource, nil
 }
+
+func AddSkipLabelToManifest(
+	ctx context.Context,
+	clnt client.Client,
+	kymaName,
+	kymaNamespace,
+	moduleName string,
+) error {
+	manifest, err := GetManifest(ctx, clnt, kymaName, kymaNamespace, moduleName)
+	if err != nil {
+		return fmt.Errorf("failed to get manifest, %w", err)
+	}
+
+	manifest.Labels[declarative.SkipReconcileLabel] = "true"
+	err = clnt.Update(ctx, manifest)
+	if err != nil {
+		return fmt.Errorf("failed to update manifest, %w", err)
+	}
+
+	return nil
+}
+
+func SkipLabelExistsInManifest(ctx context.Context,
+	clnt client.Client,
+	kymaName,
+	kymaNamespace,
+	moduleName string,
+) bool {
+	manifest, err := GetManifest(ctx, clnt, kymaName, kymaNamespace, moduleName)
+	if err != nil {
+		return false
+	}
+
+	return manifest.Labels[declarative.SkipReconcileLabel] == "true"
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added an integration test for the skip-label on the Manifest
- Renamed the `declarative.kyma-project.io/skip-reconciliation` to `operator.kyma-project.io/skip-reconciliation`

**Related issue(s)**
Resolves #937 
