### PR TITLE
fix broken e2e test and disable gosumdb check

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -51,6 +51,7 @@ jobs:
       CM_VERSION: v1.12.3
       KLM_VERSION_TAG: latest
       KLM_IMAGE_REPO: prod
+      GOSUMDB: off
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -72,6 +72,7 @@ jobs:
       K3D_VERSION: v5.4.7
       KUSTOMIZE_VERSION: 4.5.7
       ISTIO_VERSION: 1.17.1
+      GOSUMDB: off
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -13,6 +13,8 @@ jobs:
   envtest-and-unittest:
     name: "Run 'make test'"
     runs-on: ubuntu-latest
+    env:
+      GOSUMDB: off
     steps:
       - name: Checkout lifecycle-manager
         uses: actions/checkout@v3

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -43,16 +43,16 @@ var (
 	ErrNotDeleted                 = errors.New("resource not deleted")
 	ErrDeletionTimestampFound     = errors.New("deletion timestamp not nil")
 	ErrEmptyRestConfig            = errors.New("rest.Config is nil")
-	ErrDeletionTimestamp          = errors.New("DeletionTimeStamp does not exist or is not a string")
 	ErrSampleCrNotInExpectedState = errors.New("resource not in expected state")
 	ErrFetchingStatus             = errors.New("could not fetch status from resource")
 )
 
 func NewTestModule(name, channel string) v1beta2.Module {
-	return v1beta2.Module{
-		Name:    fmt.Sprintf("%s-%s", name, builder.RandomName()),
-		Channel: channel,
-	}
+	return NewTestModuleWithFixName(fmt.Sprintf("%s-%s", name, builder.RandomName()), channel)
+}
+
+func NewTemplateOperator(channel string) v1beta2.Module {
+	return NewTestModuleWithFixName("template-operator", channel)
 }
 
 func NewTestModuleWithFixName(name, channel string) v1beta2.Module {

--- a/tests/e2e_test/purge_controller_test.go
+++ b/tests/e2e_test/purge_controller_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 var _ = Describe("Purge Controller", Ordered, func() {
-	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", "regular",
-		v1beta2.SyncStrategyLocalSecret)
+	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system",
+		v1beta2.DefaultChannel, v1beta2.SyncStrategyLocalSecret)
+	module := NewTemplateOperator(v1beta2.DefaultChannel)
 	moduleCR := NewTestModuleCR(remoteNamespace)
 	moduleCRFinalizer := "cr-finalizer"
 
@@ -21,7 +22,7 @@ var _ = Describe("Purge Controller", Ordered, func() {
 		It("When enable Template Operator", func() {
 			Eventually(EnableModule).
 				WithContext(ctx).
-				WithArguments(defaultRemoteKymaName, remoteNamespace, moduleName, kyma.Spec.Channel, runtimeClient).
+				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module).
 				Should(Succeed())
 		})
 

--- a/tests/e2e_test/purge_metrics_test.go
+++ b/tests/e2e_test/purge_metrics_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 var _ = Describe("Purge Metrics", Ordered, func() {
-	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", "regular",
-		v1beta2.SyncStrategyLocalSecret)
+	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system",
+		v1beta2.DefaultChannel, v1beta2.SyncStrategyLocalSecret)
+	module := NewTemplateOperator(v1beta2.DefaultChannel)
 	moduleCR := NewTestModuleCR(remoteNamespace)
 	moduleCRFinalizer := "cr-finalizer"
 
@@ -21,7 +22,7 @@ var _ = Describe("Purge Metrics", Ordered, func() {
 		It("When enable Template Operator", func() {
 			Eventually(EnableModule).
 				WithContext(ctx).
-				WithArguments(defaultRemoteKymaName, remoteNamespace, moduleName, kyma.Spec.Channel, runtimeClient).
+				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module).
 				Should(Succeed())
 		})
 

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -50,7 +50,6 @@ const (
 	interval              = 1 * time.Second
 	remoteNamespace       = "kyma-system"
 	controlPlaneNamespace = "kcp-system"
-	moduleName            = "template-operator"
 )
 
 func InitEmptyKymaBeforeAll(kyma *v1beta2.Kyma) {


### PR DESCRIPTION
github action seems can't use gosumdb to authenticate downloaded module, since the action pipeline is just design for testing purpose, there is no needs to authenticate module. This PR disabled this feature by set a global env value GOSUMDB to `off` based on this [article](https://goproxy.io/docs/GOSUMDB-env.html) 
check failing test [here](https://github.com/kyma-project/lifecycle-manager/actions/runs/6611749687/job/17956816677?pr=976#step:4:7)

additionally, fixed broken e2e test in main.