### PR TITLE
fix: cleanup metrics before kyma finalizer removed

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -40,7 +40,16 @@ jobs:
   e2e-integration:
     strategy:
       matrix:
-        e2e-test: ["watcher-enqueue", "kyma-deletion", "module-status-propagation", "kyma-metrics", "module-without-default-cr", "non-blocking-deletion", "purge-controller", "purge-metrics", "module-upgrade"]
+        e2e-test: [ "watcher-enqueue",
+                    "kyma-deletion",
+                    "module-status-propagation",
+                    "kyma-metrics",
+                    "module-without-default-cr",
+                    "non-blocking-deletion",
+                    "purge-controller",
+                    "purge-metrics",
+                    "module-upgrade"
+        ]
     name: "E2E"
     needs: [wait-for-img]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -160,7 +160,12 @@ jobs:
           path: template-operator
       - name: Create Template Operator Module
         working-directory: template-operator
-        if: ${{ matrix.e2e-test == 'non-blocking-deletion' ||  matrix.e2e-test == 'purge-controller' ||  matrix.e2e-test == 'purge-metrics' || matrix.e2e-test == 'kyma-deletion'}}
+        if: ${{ matrix.e2e-test == 'kyma-metrics' ||
+          matrix.e2e-test == 'non-blocking-deletion' ||
+          matrix.e2e-test == 'purge-controller' ||
+          matrix.e2e-test == 'purge-metrics' ||
+          matrix.e2e-test == 'kyma-deletion'
+          }}
         run: |
           make build-manifests
           kyma alpha create module --module-config-file ./module-config.yaml --path . --registry k3d-kcp-registry:5111 --insecure

--- a/internal/controller/kyma/metrics/metrics.go
+++ b/internal/controller/kyma/metrics/metrics.go
@@ -60,43 +60,23 @@ func UpdateAll(kyma *v1beta2.Kyma) error {
 	return nil
 }
 
-// RemoveKymaStateMetrics deletes all 'lifecycle_mgr_kyma_state' metrics for the matching Kyma.
-func RemoveKymaStateMetrics(kyma *v1beta2.Kyma) error {
-	shootID, err := metrics.ExtractShootID(kyma)
-	if err != nil {
-		return err
-	}
-	instanceID, err := metrics.ExtractInstanceID(kyma)
-	if err != nil {
-		return err
-	}
-
+// CleanupMetrics deletes all 'lifecycle_mgr_kyma_state',
+// 'lifecycle_mgr_module_state' metrics for the matching Kyma.
+func CleanupMetrics(kyma *v1beta2.Kyma) {
 	kymaStateGauge.DeletePartialMatch(prometheus.Labels{
-		kymaNameLabel:   kyma.Name,
-		shootIDLabel:    shootID,
-		instanceIDLabel: instanceID,
+		kymaNameLabel: kyma.Name,
 	})
-	return nil
+	moduleStateGauge.DeletePartialMatch(prometheus.Labels{
+		kymaNameLabel: kyma.Name,
+	})
 }
 
 // RemoveModuleStateMetrics deletes all 'lifecycle_mgr_module_state' metrics for the matching module.
-func RemoveModuleStateMetrics(kyma *v1beta2.Kyma, moduleName string) error {
-	shootID, err := metrics.ExtractShootID(kyma)
-	if err != nil {
-		return err
-	}
-	instanceID, err := metrics.ExtractInstanceID(kyma)
-	if err != nil {
-		return err
-	}
-
+func RemoveModuleStateMetrics(kyma *v1beta2.Kyma, moduleName string) {
 	moduleStateGauge.DeletePartialMatch(prometheus.Labels{
 		moduleNameLabel: moduleName,
 		kymaNameLabel:   kyma.Name,
-		shootIDLabel:    shootID,
-		instanceIDLabel: instanceID,
 	})
-	return nil
 }
 
 func setKymaStateGauge(newState shared.State, kymaName, shootID, instanceID string) {

--- a/pkg/module/sync/runner_impl.go
+++ b/pkg/module/sync/runner_impl.go
@@ -241,15 +241,12 @@ func DeleteNoLongerExistingModuleStatus(
 	kyma *v1beta2.Kyma,
 	moduleFunc GetModuleFunc,
 ) {
-	logger := ctrlLog.FromContext(ctx).V(log.DebugLevel)
 	moduleStatusMap := kyma.GetModuleStatusMap()
 	moduleStatus := kyma.GetNoLongerExistingModuleStatus()
 	for idx := range moduleStatus {
 		moduleStatus := moduleStatus[idx]
 		if moduleStatus.Manifest == nil {
-			if err := metrics.RemoveModuleStateMetrics(kyma, moduleStatus.Name); err != nil {
-				logger.Info(fmt.Sprintf("error occurred while removing module state metrics: %s", err))
-			}
+			metrics.RemoveModuleStateMetrics(kyma, moduleStatus.Name)
 			delete(moduleStatusMap, moduleStatus.Name)
 			continue
 		}
@@ -259,9 +256,7 @@ func DeleteNoLongerExistingModuleStatus(
 		module.SetNamespace(moduleStatus.Manifest.GetNamespace())
 		err := moduleFunc(ctx, module)
 		if util.IsNotFound(err) {
-			if err := metrics.RemoveModuleStateMetrics(kyma, moduleStatus.Name); err != nil {
-				logger.Info(fmt.Sprintf("error occurred while removing module state metrics: %s", err))
-			}
+			metrics.RemoveModuleStateMetrics(kyma, moduleStatus.Name)
 			delete(moduleStatusMap, moduleStatus.Name)
 		} else {
 			moduleStatus.State = stateFromManifest(module)

--- a/tests/e2e_test/kyma_deletion_test.go
+++ b/tests/e2e_test/kyma_deletion_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("KCP Kyma CR Deletion", Ordered, func() {
-	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", "regular",
+	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", v1beta2.DefaultChannel,
 		v1beta2.SyncStrategyLocalSecret)
 	module := NewTemplateOperator(v1beta2.DefaultChannel)
 	moduleCR := NewTestModuleCR(remoteNamespace)
@@ -38,7 +38,7 @@ var _ = Describe("KCP Kyma CR Deletion", Ordered, func() {
 		It("And disabling Template Operator", func() {
 			Eventually(DisableModule).
 				WithContext(ctx).
-				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, "template-operator").
+				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module.Name).
 				Should(Succeed())
 		})
 

--- a/tests/e2e_test/kyma_metrics_test.go
+++ b/tests/e2e_test/kyma_metrics_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
@@ -8,37 +9,100 @@ import (
 )
 
 var _ = Describe("Kyma Metrics", Ordered, func() {
-	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", "regular",
+	kyma := NewKymaWithSyncLabel("kyma-sample", "kcp-system", v1beta2.DefaultChannel,
 		v1beta2.SyncStrategyLocalSecret)
-	GinkgoWriter.Printf("kyma before create %v\n", kyma)
-
+	module := NewTemplateOperator(v1beta2.DefaultChannel)
+	moduleCR := NewTestModuleCR(remoteNamespace)
 	InitEmptyKymaBeforeAll(kyma)
 
-	It("Kyma reconciliation should remove metric when Kyma CR deleted ", func() {
-		By("getting the current kyma Ready state metric count")
-		kymaStateReadyCount, err := GetKymaStateMetricCount(ctx, kyma.GetName(), "Ready")
-		Expect(err).Should(Not(HaveOccurred()))
-		GinkgoWriter.Printf("Kyma State Ready Metric count before CR deletion: %d", kymaStateReadyCount)
-		Expect(kymaStateReadyCount).Should(Equal(1))
+	Context("Given kyma deployed in KCP", func() {
+		It("When enabling Template Operator", func() {
+			Eventually(EnableModule).
+				WithContext(ctx).
+				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module).
+				Should(Succeed())
+			Eventually(ModuleCRExists).
+				WithContext(ctx).
+				WithArguments(runtimeClient, moduleCR).
+				Should(Succeed())
+		})
 
-		By("deleting KCP Kyma")
-		Eventually(DeleteKymaByForceRemovePurgeFinalizer).
-			WithContext(ctx).
-			WithArguments(controlPlaneClient, kyma).
-			Should(Succeed())
+		It("Then KCP Kyma should be in Ready state", func() {
+			Eventually(KymaIsInState).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+				Should(Succeed())
+		})
 
-		By("waiting for Kyma CR to be removed")
-		Eventually(KymaDeleted).
-			WithContext(ctx).
-			WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
-			Should(Succeed())
+		It("Then the count of kyma metric in ready equals 1", func() {
+			Eventually(GetKymaStateMetricCount).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), string(shared.StateReady)).
+				Should(Equal(1))
+		})
 
-		By("should decrease the metric count")
-		for _, state := range []string{"Deleting", "Warning", "Ready", "Processing", "Error"} {
-			count, err := GetKymaStateMetricCount(ctx, kyma.GetName(), state)
-			Expect(err).Should(Not(HaveOccurred()))
-			GinkgoWriter.Printf("Kyma %s State Metric count after CR deletion: %d", state, count)
-			Expect(count).Should(Equal(0))
-		}
+		It("And the count of kyma module metric in ready equals 1", func() {
+			Eventually(GetModuleStateMetricCount).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), module.Name, string(shared.StateReady)).
+				Should(Equal(1))
+		})
+
+		It("When disabling Template Operator", func() {
+			Eventually(DisableModule).
+				WithContext(ctx).
+				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module.Name).
+				Should(Succeed())
+
+			By("Then the Manifest CR is removed")
+			Eventually(ManifestExists).
+				WithContext(ctx).
+				WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name).
+				Should(Equal(ErrNotFound))
+
+			By("And the Kyma CR is in a \"Ready\" State")
+			Eventually(KymaIsInState).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+				Should(Succeed())
+		})
+
+		It("Then the count of kyma metric in ready equals 1", func() {
+			Eventually(GetKymaStateMetricCount).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), string(shared.StateReady)).
+				Should(Equal(1))
+		})
+
+		It("And the count of kyma module metric in ready equals 0", func() {
+			Eventually(GetModuleStateMetricCount).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), module.Name, string(shared.StateReady)).
+				Should(Equal(0))
+		})
+
+		It("When Kyma in KCP cluster is deleted", func() {
+			Eventually(DeleteKymaByForceRemovePurgeFinalizer).
+				WithContext(ctx).
+				WithArguments(controlPlaneClient, kyma).
+				Should(Succeed())
+			Eventually(KymaDeleted).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
+				Should(Succeed())
+		})
+
+		It("Then the count of metric should be removed", func() {
+			for _, state := range shared.AllStates() {
+				Eventually(GetKymaStateMetricCount).
+					WithContext(ctx).
+					WithArguments(kyma.GetName(), string(state)).
+					Should(Equal(0))
+				Eventually(GetModuleStateMetricCount).
+					WithContext(ctx).
+					WithArguments(kyma.GetName(), module.Name, string(state)).
+					Should(Equal(0))
+			}
+		})
 	})
 })

--- a/tests/e2e_test/module_deletion_test.go
+++ b/tests/e2e_test/module_deletion_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Non Blocking Kyma Module Deletion", Ordered, func() {
 				By("And the SKR Kyma CR is in a \"Ready\" State")
 				Eventually(KymaIsInState).
 					WithContext(ctx).
-					WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+					WithArguments(kyma.GetName(), kyma.GetNamespace(), runtimeClient, shared.StateReady).
 					Should(Succeed())
 			})
 

--- a/tests/e2e_test/module_deletion_test.go
+++ b/tests/e2e_test/module_deletion_test.go
@@ -13,28 +13,11 @@ var _ = Describe("Non Blocking Kyma Module Deletion", Ordered, func() {
 		v1beta2.SyncStrategyLocalSecret)
 	module := NewTemplateOperator(v1beta2.DefaultChannel)
 
-	Context("Given an SKR cluster", func() {
-		It("When a KCP Kyma CR is created on the KCP cluster", func() {
-			Eventually(CreateKymaSecret).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
-				Should(Succeed())
-			Eventually(controlPlaneClient.Create).
-				WithContext(ctx).
-				WithArguments(kyma).
-				Should(Succeed())
-			By("Then the Kyma CR is in a \"Ready\" State on the KCP cluster ")
-			Eventually(KymaIsInState).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
-				Should(Succeed())
-			By("And the Kyma CR is in \"Ready\" State on the SKR cluster")
-			Eventually(CheckRemoteKymaCR).
-				WithContext(ctx).
-				WithArguments(remoteNamespace, []v1beta2.Module{}, runtimeClient, shared.StateReady).
-				Should(Succeed())
-		})
-		It("When a Kyma Module is enabled", func() {
+	InitEmptyKymaBeforeAll(kyma)
+	CleanupKymaAfterAll(kyma)
+
+	Context("Given kyma deployed in KCP", func() {
+		It("When enabling Template Operator", func() {
 			Eventually(EnableModule).
 				WithContext(ctx).
 				WithArguments(runtimeClient, defaultRemoteKymaName, remoteNamespace, module).
@@ -169,18 +152,17 @@ var _ = Describe("Non Blocking Kyma Module Deletion", Ordered, func() {
 					WithArguments(controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name).
 					Should(Equal(ErrNotFound))
 
+				By("And the KCP Kyma CR is in a \"Ready\" State")
+				Eventually(KymaIsInState).
+					WithContext(ctx).
+					WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+					Should(Succeed())
+
 				By("And the SKR Kyma CR is in a \"Ready\" State")
 				Eventually(KymaIsInState).
 					WithContext(ctx).
-					WithArguments(kyma.GetName(), kyma.GetNamespace(), runtimeClient, shared.StateReady).
+					WithArguments(defaultRemoteKymaName, remoteNamespace, runtimeClient, shared.StateReady).
 					Should(Succeed())
 			})
-
-		AfterAll(func() {
-			Eventually(controlPlaneClient.Delete).
-				WithContext(ctx).
-				WithArguments(kyma).
-				Should(Succeed())
-		})
 	})
 })

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -239,6 +239,29 @@ func GetKymaStateMetricCount(ctx context.Context, kymaName, state string) (int, 
 	return 0, nil
 }
 
+func GetModuleStateMetricCount(ctx context.Context, kymaName, moduleName, state string) (int, error) {
+	bodyString, err := getMetricsBody(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	re := regexp.MustCompile(
+		`lifecycle_mgr_module_state{instance_id="[^"]+",kyma_name="` + kymaName +
+			`",module_name="` + moduleName +
+			`",shoot="[^"]+",state="` + state +
+			`"} (\d+)`)
+	match := re.FindStringSubmatch(bodyString)
+	if len(match) > 1 {
+		count, err := strconv.Atoi(match[1])
+		if err != nil {
+			return 0, err
+		}
+		return count, nil
+	}
+
+	return 0, nil
+}
+
 func CheckSampleCRIsInState(ctx context.Context, name, namespace string, clnt client.Client,
 	expectedState string,
 ) error {

--- a/tests/e2e_test/utils_test.go
+++ b/tests/e2e_test/utils_test.go
@@ -48,6 +48,7 @@ const (
 
 func InitEmptyKymaBeforeAll(kyma *v1beta2.Kyma) {
 	BeforeAll(func() {
+		By("When a KCP Kyma CR is created on the KCP cluster")
 		Eventually(CreateKymaSecret).
 			WithContext(ctx).
 			WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient).
@@ -56,12 +57,12 @@ func InitEmptyKymaBeforeAll(kyma *v1beta2.Kyma) {
 			WithContext(ctx).
 			WithArguments(kyma).
 			Should(Succeed())
-		By("verifying kyma is ready")
+		By("Then the Kyma CR is in a \"Ready\" State on the KCP cluster ")
 		Eventually(KymaIsInState).
 			WithContext(ctx).
 			WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
 			Should(Succeed())
-		By("verifying remote kyma is ready")
+		By("And the Kyma CR is in \"Ready\" State on the SKR cluster")
 		Eventually(CheckRemoteKymaCR).
 			WithContext(ctx).
 			WithArguments(remoteNamespace, []v1beta2.Module{}, runtimeClient, shared.StateReady).


### PR DESCRIPTION
only use kyma or module name as minimum label for `DeletePartialMatch`.
do the metrics cleanup before remove kyma finalizer.
