### PR TITLE
fix: Use the Busy Interval for the Warning state

### DIFF
--- a/pkg/queue/requeue_intervals.go
+++ b/pkg/queue/requeue_intervals.go
@@ -23,7 +23,7 @@ func DetermineRequeueInterval(state shared.State, intervals RequeueIntervals) ti
 	case shared.StateReady:
 		fallthrough
 	case shared.StateWarning:
-		fallthrough
+		return intervals.Busy
 	default:
 		return intervals.Success
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use the Busy interval set for the `Warning` state

**Related issue(s)**
Resolves #1055 
