### PR TITLE
fix: Remove Secret only when the secret creation time is before the CA Certificate validity

### DIFF
--- a/pkg/watcher/certificate.go
+++ b/pkg/watcher/certificate.go
@@ -98,11 +98,8 @@ func (c *CertificateManager) Remove(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = c.RemoveSecret(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return c.RemoveSecret(ctx)
 }
 
 func (c *CertificateManager) RemoveCertificate(ctx context.Context) error {

--- a/pkg/watcher/certificate.go
+++ b/pkg/watcher/certificate.go
@@ -94,6 +94,18 @@ func (c *CertificateManager) Create(ctx context.Context) error {
 
 // Remove removes the certificate including its certificate secret.
 func (c *CertificateManager) Remove(ctx context.Context) error {
+	err := c.RemoveCertificate(ctx)
+	if err != nil {
+		return err
+	}
+	err = c.RemoveSecret(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CertificateManager) RemoveCertificate(ctx context.Context) error {
 	certificate := &certmanagerv1.Certificate{}
 	if err := c.kcpClient.Get(ctx, client.ObjectKey{
 		Name:      c.certificateName,
@@ -101,9 +113,15 @@ func (c *CertificateManager) Remove(ctx context.Context) error {
 	}, certificate); err != nil && !util.IsNotFound(err) {
 		return fmt.Errorf("failed to get certificate: %w", err)
 	}
+
 	if err := c.kcpClient.Delete(ctx, certificate); err != nil {
 		return fmt.Errorf("failed to delete certificate: %w", err)
 	}
+
+	return nil
+}
+
+func (c *CertificateManager) RemoveSecret(ctx context.Context) error {
 	certSecret := &apicorev1.Secret{}
 	if err := c.kcpClient.Get(ctx, client.ObjectKey{
 		Name:      c.secretName,

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -122,7 +122,7 @@ func (m *SKRWebhookManifestManager) Install(ctx context.Context, kyma *v1beta2.K
 	if certSecret != nil && (certSecret.CreationTimestamp.Before(caCertificate.Status.NotBefore)) {
 		logger.V(log.DebugLevel).Info("CA Certificate was rotated, removing certificate",
 			"kyma", kymaObjKey)
-		if err = certificate.Remove(ctx); err != nil {
+		if err = certificate.RemoveSecret(ctx); err != nil {
 			return fmt.Errorf("error while removing certificate: %w", err)
 		}
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove Secret only when the secret creation time is before the CA Certificate validity

**Related issue(s)**
#1061 
