### PR TITLE
chore(metrics, report): Add a GitHub Action to generate a go package metrics report

### DIFF
--- a/.github/workflows/report-package-metrics.yml
+++ b/.github/workflows/report-package-metrics.yml
@@ -1,0 +1,48 @@
+name: Report Package Dependencies Metrics
+run-name: Generate package dependencies report
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+env:
+  spm: ${{ github.workspace }}/scripts/coverage-metrics/bin/utils/package-metrics/spm.py
+  compare: ${{ github.workspace }}/scripts/coverage-metrics/bin/utils/package-metrics/compare.py
+  pip_requirements: ${{ github.workspace }}/scripts/coverage-metrics/bin/utils/package-metrics/requirements.txt
+  base_metrics: /tmp/base.json
+  target_metrics: /tmp/target.json
+
+jobs:
+  generate-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          path: target
+      - name: Check out the base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+      - name: Check out report scripts
+        uses: actions/checkout@v4
+        with:
+          repository: kyma-project/qa-toolkit
+          path: scripts
+      - name: Adjust the metrics utilities
+        run: |
+          chmod a+x $spm
+          chmod a+x $compare
+          python -m pip install --upgrade pip
+          pip install -r $pip_requirements
+      - name: Genarate a report
+        run: |
+          $spm --module github.com/kyma-project/lifecycle-manager --path ${{ github.workspace }}/target --out $target_metrics
+          $spm --module github.com/kyma-project/lifecycle-manager --path ${{ github.workspace }}/base --out $base_metrics
+          $compare --base $base_metrics --target $target_metrics


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Creates a GH Action to generate a package metrics report
- The script used for the metric calculation resides in the [qa-toolkit](https://github.com/kyma-project/qa-toolkit/pull/7)

**Related issue(s)**
#1089 
