### PR TITLE
chore(reporting): Fixes the package report generation

### DIFF
--- a/.github/workflows/report-package-metrics.yml
+++ b/.github/workflows/report-package-metrics.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Check out the target branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           path: target
       - name: Check out the base branch
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description**

The `github.head_ref` GitHub Action parameter is not working as expected for PR that originate from forks.

Changes proposed in this pull request:

- Remove setting the `github.head_ref` parameter explicitly, rolling back to the default value