### PR TITLE
chore(reporting): Fix the package metrics report

### DIFF
--- a/.github/workflows/report-package-metrics.yml
+++ b/.github/workflows/report-package-metrics.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Check out the target branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           path: target
       - name: Check out the base branch
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description**

Removes the unnecessary `github.head_ref` parameter which is not working for PRs originating from the forked repositories.
