### PR TITLE
chore(report): Fix the package metrics report GH Action

### DIFF
--- a/.github/workflows/report-package-metrics.yml
+++ b/.github/workflows/report-package-metrics.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Check out the target branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: target
       - name: Check out the base branch
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description**

Adds explicit Git reference for the target PR. The default setting fetches the `main` branch instead of the PR one.