### PR TITLE
feat: Introduce version to manifest CR

### DIFF
--- a/api/v1beta2/manifest_types.go
+++ b/api/v1beta2/manifest_types.go
@@ -32,7 +32,7 @@ const (
 // InstallInfo defines installation information.
 type InstallInfo struct {
 	// Source in the ImageSpec format
-	//+kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Source machineryruntime.RawExtension `json:"source"`
 
 	// Name specifies a unique install name for Manifest
@@ -48,15 +48,19 @@ type ManifestSpec struct {
 	// Remote indicates if Manifest should be installed on a remote cluster
 	Remote bool `json:"remote"`
 
+	// Version specifies current Resource version
+	// +optional
+	Version string `json:"version,omitempty"`
+
 	// Config specifies OCI image configuration for Manifest
 	Config *ImageSpec `json:"config,omitempty"`
 
 	// Install specifies a list of installations for Manifest
 	Install InstallInfo `json:"install"`
 
-	//+kubebuilder:pruning:PreserveUnknownFields
-	//+kubebuilder:validation:XEmbeddedResource
-	//+nullable
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:XEmbeddedResource
+	// +nullable
 	// Resource specifies a resource to be watched for state updates
 	Resource *unstructured.Unstructured `json:"resource,omitempty"`
 }
@@ -91,10 +95,10 @@ const (
 	OciRefType RefTypeMetadata = "oci-ref"
 )
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="State",type=string,JSONPath=".status.state"
-//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Manifest is the Schema for the manifests API.
 type Manifest struct {
@@ -113,7 +117,7 @@ func (manifest *Manifest) SetStatus(status shared.Status) {
 	manifest.Status = status
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // ManifestList contains a list of Manifest.
 type ManifestList struct {

--- a/config/crd/bases/operator.kyma-project.io_manifests.yaml
+++ b/config/crd/bases/operator.kyma-project.io_manifests.yaml
@@ -140,6 +140,9 @@ spec:
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
+              version:
+                description: Version specifies current Resource version
+                type: string
             required:
             - install
             - remote
@@ -398,6 +401,9 @@ spec:
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
+              version:
+                description: Version specifies current Resource version
+                type: string
             required:
             - install
             - remote

--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -18,7 +18,6 @@ type (
 	Module  struct {
 		ModuleName string
 		FQDN       string
-		Version    string
 		Template   *channel.ModuleTemplateTO
 		*v1beta2.Manifest
 	}

--- a/pkg/module/parse/template_to_module.go
+++ b/pkg/module/parse/template_to_module.go
@@ -74,7 +74,6 @@ func (p *Parser) GenerateModulesFromTemplates(ctx context.Context,
 			continue
 		}
 		fqdn := descriptor.GetName()
-		version := descriptor.GetVersion()
 		name := common.CreateModuleName(fqdn, kyma.Name, module.Name)
 		overwriteNameAndNamespace(template, name, p.remoteSyncNamespace)
 		var manifest *v1beta2.Manifest
@@ -94,7 +93,6 @@ func (p *Parser) GenerateModulesFromTemplates(ctx context.Context,
 		modules = append(modules, &common.Module{
 			ModuleName: module.Name,
 			FQDN:       fqdn,
-			Version:    version,
 			Template:   template,
 			Manifest:   manifest,
 		})
@@ -175,7 +173,7 @@ func (p *Parser) newManifestFromTemplate(
 	if err := appendOptionalCustomStateCheck(manifest, template.Spec.CustomStateCheck); err != nil {
 		return nil, fmt.Errorf("could not translate custom state check: %w", err)
 	}
-
+	manifest.Spec.Version = descriptor.Version
 	return manifest, nil
 }
 

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -203,7 +203,7 @@ func generateModuleStatus(module *common.Module, existStatus *v1beta2.ModuleStat
 		FQDN:    module.FQDN,
 		State:   manifestObject.Status.State,
 		Channel: module.Template.Spec.Channel,
-		Version: module.Version,
+		Version: manifestObject.Spec.Version,
 		Manifest: &v1beta2.TrackingObject{
 			PartialMeta: v1beta2.PartialMetaFromObject(manifestObject),
 			TypeMeta:    apimetav1.TypeMeta{Kind: manifestKind, APIVersion: manifestAPIVersion},

--- a/tests/integration/controller/kyma/manifest_test.go
+++ b/tests/integration/controller/kyma/manifest_test.go
@@ -43,6 +43,7 @@ const (
 var (
 	ErrEmptyModuleTemplateData = errors.New("module template spec.data is empty")
 	ErrVersionMismatch         = errors.New("manifest spec.version mismatch with module template")
+	ErrInvalidManifest         = errors.New("invalid ManifestResource")
 )
 
 var _ = Describe("Manifest.Spec.Remote in default mode", Ordered, func() {
@@ -486,8 +487,8 @@ func validateManifestSpecResource(manifestResource, moduleTemplateData *unstruct
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("Invalid ManifestResource.\nActual:\n%s\nExpected:\n%s", actualJSON,
-			expectedJSON) //nolint:goerr113
+		return fmt.Errorf("%w: \nActual:\n%s\nExpected:\n%s", ErrInvalidManifest, actualJSON,
+			expectedJSON)
 	}
 	return nil
 }


### PR DESCRIPTION
add version as new field to manifest CR, it makes LM to know the version of the module from Manifest CR more straightforward.
It also makes it possible to determine if necessary to update manifest based on the version.

