### PR TITLE
fix: Delete SKR Certificate and Secret only if they exist

### DIFF
--- a/pkg/watcher/certificate_manager.go
+++ b/pkg/watcher/certificate_manager.go
@@ -124,7 +124,7 @@ func (c *CertificateManager) RemoveCertificate(ctx context.Context) error {
 		return fmt.Errorf("failed to get certificate: %w", err)
 	}
 
-	if !util.IsNotFound(err) {
+	if err == nil {
 		if err = c.kcpClient.Delete(ctx, certificate); err != nil {
 			return fmt.Errorf("failed to delete certificate: %w", err)
 		}
@@ -143,7 +143,7 @@ func (c *CertificateManager) removeSecret(ctx context.Context) error {
 		return fmt.Errorf("failed to get certificate secret: %w", err)
 	}
 
-	if !util.IsNotFound(err) {
+	if err == nil {
 		if err = c.kcpClient.Delete(ctx, certSecret); err != nil {
 			return fmt.Errorf("failed to delete certificate secret: %w", err)
 		}

--- a/pkg/watcher/certificate_manager.go
+++ b/pkg/watcher/certificate_manager.go
@@ -116,15 +116,18 @@ func (c *CertificateManager) Remove(ctx context.Context) error {
 
 func (c *CertificateManager) RemoveCertificate(ctx context.Context) error {
 	certificate := &certmanagerv1.Certificate{}
-	if err := c.kcpClient.Get(ctx, client.ObjectKey{
+	err := c.kcpClient.Get(ctx, client.ObjectKey{
 		Name:      c.certificateName,
 		Namespace: c.config.IstioNamespace,
-	}, certificate); err != nil && !util.IsNotFound(err) {
+	}, certificate)
+	if err != nil && !util.IsNotFound(err) {
 		return fmt.Errorf("failed to get certificate: %w", err)
 	}
 
-	if err := c.kcpClient.Delete(ctx, certificate); err != nil {
-		return fmt.Errorf("failed to delete certificate: %w", err)
+	if !util.IsNotFound(err) {
+		if err = c.kcpClient.Delete(ctx, certificate); err != nil {
+			return fmt.Errorf("failed to delete certificate: %w", err)
+		}
 	}
 
 	return nil
@@ -132,17 +135,20 @@ func (c *CertificateManager) RemoveCertificate(ctx context.Context) error {
 
 func (c *CertificateManager) removeSecret(ctx context.Context) error {
 	certSecret := &apicorev1.Secret{}
-	if err := c.kcpClient.Get(ctx, client.ObjectKey{
+	err := c.kcpClient.Get(ctx, client.ObjectKey{
 		Name:      c.secretName,
 		Namespace: c.config.IstioNamespace,
-	}, certSecret); err != nil && !util.IsNotFound(err) {
+	}, certSecret)
+	if err != nil && !util.IsNotFound(err) {
 		return fmt.Errorf("failed to get certificate secret: %w", err)
 	}
 
-	err := c.kcpClient.Delete(ctx, certSecret)
-	if err != nil {
-		return fmt.Errorf("failed to delete certificate secret: %w", err)
+	if !util.IsNotFound(err) {
+		if err = c.kcpClient.Delete(ctx, certSecret); err != nil {
+			return fmt.Errorf("failed to delete certificate secret: %w", err)
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Delete SKR Certificate and Secret only if they exist. The current behavior executed the deletion of the certificate/secret even if they are not found which cause infinite reconciliations when the Kyma gets deleted. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
