### PR TITLE
fix: Set watcher version to last known working

### DIFF
--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -18,7 +18,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image=runtime-watcher-skr:0.0.4
+        value: --skr-watcher-image=runtime-watcher-skr:v20231025-140215fd
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --enable-domain-name-pinning=true

--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -38,9 +38,6 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --listener-port-overwrite=9443
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --skr-watcher-image=runtime-watcher-skr:latest
     - op: replace
       path: /spec/template/spec/containers/0/imagePullPolicy
       value: Always


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- We have a bug in released watcher versions and also e2e is testing against latest, but latest tagging is broken since October
- Remove the watcher img override for e2e test setup: it should use the same img in the tests as the image that is reference and deployed by lifecycle-manager!


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
