### PR TITLE
chore: Give each controller a specific name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -340,7 +340,7 @@ func setupKcpWatcherReconciler(mgr ctrl.Manager, options ctrlruntime.Options, fl
 
 	if err := (&controller.WatcherReconciler{
 		Client:             mgr.GetClient(),
-		EventRecorder:      mgr.GetEventRecorderFor(controller.WatcherControllerName),
+		EventRecorder:      mgr.GetEventRecorderFor(shared.OperatorName),
 		WatcherVSNamespace: flagVar.istioGatewayNamespace,
 		Scheme:             mgr.GetScheme(),
 		RestConfig:         mgr.GetConfig(),

--- a/internal/controller/manifest_controller.go
+++ b/internal/controller/manifest_controller.go
@@ -51,10 +51,13 @@ func SetupWithManager(
 
 	controllerManagedByManager := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Manifest{}).
+		Named(ManifestControllerName).
 		Watches(&apicorev1.Secret{}, handler.Funcs{}).
 		WatchesRawSource(
 			eventChannel, &handler.Funcs{
-				GenericFunc: func(ctx context.Context, event event.GenericEvent, queue workqueue.RateLimitingInterface) {
+				GenericFunc: func(ctx context.Context, event event.GenericEvent,
+					queue workqueue.RateLimitingInterface,
+				) {
 					ctrl.Log.WithName("listener").Info(
 						fmt.Sprintf(
 							"event coming from SKR, adding %s to queue",

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -34,7 +34,10 @@ type SetupUpSetting struct {
 }
 
 const (
-	WatcherControllerName = "watcher"
+	WatcherControllerName  = "watcher"
+	PurgeControllerName    = "purge"
+	KymaControllerName     = "kyma"
+	ManifestControllerName = "manifest"
 )
 
 var (
@@ -50,6 +53,7 @@ func (r *KymaReconciler) SetupWithManager(mgr ctrl.Manager,
 	predicates := predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).For(&v1beta2.Kyma{}).
+		Named(KymaControllerName).
 		WithOptions(options).
 		WithEventFilter(predicates).
 		Watches(
@@ -163,6 +167,7 @@ func (r *PurgeReconciler) SetupWithManager(mgr ctrl.Manager,
 ) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Kyma{}).
+		Named(PurgeControllerName).
 		WithOptions(options).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))
 

--- a/internal/pkg/metrics/kyma.go
+++ b/internal/pkg/metrics/kyma.go
@@ -28,7 +28,6 @@ type KymaMetrics struct {
 type RequeueReason string
 
 const (
-	KymaRetrievalError RequeueReason = "kyma_retrieval_error"
 	//nolint:gosec // requeue reason label, no confidential content
 	KymaUnderDeletionAndAccessSecretNotFound RequeueReason = "kyma_under_deletion_with_no_access_secret"
 	StatusUpdateToDeleting                   RequeueReason = "kyma_status_update_to_deleting"
@@ -52,6 +51,8 @@ const (
 	RemoteModuleCatalogDeletionError         RequeueReason = "remote_module_catalog_deletion_error"
 	ManifestCrsCleanupError                  RequeueReason = "manifest_crs_cleanup_error"
 	KymaDeletion                             RequeueReason = "kyma_deletion"
+
+	KymaRetrievalError RequeueReason = "kyma_retrieval_error"
 )
 
 func NewKymaMetrics() *KymaMetrics {


### PR DESCRIPTION
Sets the name of the controller, not by default rely on resource kind, so that it can distinguish controller which reconcile same resource, like kyma_controller and purge_controller, both reconcile Kyma CR.