### PR TITLE
fix: Wait for deployment before apply resources for e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -179,6 +179,7 @@ jobs:
           for retry in $(seq 1 $maxRetry)
           do
             if make local-deploy-with-watcher IMG=europe-docker.pkg.dev/kyma-project/$KLM_IMAGE_REPO/lifecycle-manager:$KLM_VERSION_TAG; then
+              kubectl wait pods -n kcp-system -l app.kubernetes.io/name=lifecycle-manager --for condition=Ready --timeout=90s
               echo "KLM deployed successfully"
               exit 0
             elif [[ $retry -lt $maxRetry ]]; then


### PR DESCRIPTION
sometimes, the e2e test might failed due to webhook service is not finish provision yet, but the pipeline start to apply resources, [example](https://github.com/kyma-project/lifecycle-manager/actions/runs/7345689889/job/19999289728#step:25:1), this PR trying to fix it by using `kubectl rollout status` to wait until deployment fully in ready state before apply any resources. 