### PR TITLE
fix: Stop requeue kyma not deleted for purge controller 

### DIFF
--- a/internal/controller/purge_controller.go
+++ b/internal/controller/purge_controller.go
@@ -73,7 +73,7 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: false}, nil
 	}
 
 	requeueAfter := r.calculateRequeueAfterTime(ctx, kyma)


### PR DESCRIPTION
If kyma is not under delete, it's not necessary to requeue it.