### PR TITLE
fix: Do eventual check before constistent in e2e test 

### DIFF
--- a/tests/e2e/module_deletion_test.go
+++ b/tests/e2e/module_deletion_test.go
@@ -147,6 +147,10 @@ var _ = Describe("Non Blocking Kyma Module Deletion", Ordered, func() {
 				Should(Succeed())
 
 			By("And new Module CR is in \"Ready\" State")
+			Eventually(CheckSampleCRIsInState).
+				WithContext(ctx).
+				WithArguments("sample-yaml", "kyma-system", runtimeClient, "Ready").
+				Should(Succeed())
 			Consistently(CheckSampleCRIsInState).
 				WithContext(ctx).
 				WithArguments("sample-yaml", "kyma-system", runtimeClient, "Ready").


### PR DESCRIPTION
This PR try to fix one flaky test condition, error log [here](https://github.com/kyma-project/lifecycle-manager/actions/runs/7355684613/job/20024832759?pr=1208#step:30:92)