### PR TITLE
fix: Increase baseDelay for ExponentialFailureRateLimiter

### DIFF
--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -64,6 +64,9 @@ patches:
         value: --failure-max-delay=30s
       - op: add
         path: /spec/template/spec/containers/0/args/-
+        value: --failure-base-delay=5s
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
         value: --is-kyma-managed
     target:
       kind: Deployment


### PR DESCRIPTION
This PR is trying to resolve currently high volume of manifest CR requeue by `manifest_remove_finalizer_in_deleting`.

By increase base delay, it prevent the requeued item get in progressed within short period, currently, the default base delay is 100ms, with the concurrent workers, it will produce huge traffic to API server even with a small amount of items.