### PR TITLE
refactor: Use logger from context instead

### DIFF
--- a/internal/controller/purge_controller.go
+++ b/internal/controller/purge_controller.go
@@ -85,7 +85,7 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	remoteClient, err := r.ResolveRemoteClient(ctx, client.ObjectKeyFromObject(kyma))
 	if util.IsNotFound(err) {
 		if err := r.dropPurgeFinalizer(ctx, kyma); err != nil {
-			r.Metrics.UpdatePurgeError(logger, kyma, metrics.ErrPurgeFinalizerRemoval)
+			r.Metrics.UpdatePurgeError(ctx, kyma, metrics.ErrPurgeFinalizerRemoval)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
@@ -97,12 +97,12 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	r.Metrics.UpdatePurgeCount()
 	if err := r.performCleanup(ctx, remoteClient); err != nil {
 		logger.Error(err, "Purge Cleanup failed")
-		r.Metrics.UpdatePurgeError(logger, kyma, metrics.ErrCleanup)
+		r.Metrics.UpdatePurgeError(ctx, kyma, metrics.ErrCleanup)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.dropPurgeFinalizer(ctx, kyma); err != nil {
-		r.Metrics.UpdatePurgeError(logger, kyma, metrics.ErrPurgeFinalizerRemoval)
+		r.Metrics.UpdatePurgeError(ctx, kyma, metrics.ErrPurgeFinalizerRemoval)
 		return ctrl.Result{}, err
 	}
 	duration := time.Since(start)

--- a/internal/pkg/metrics/purge.go
+++ b/internal/pkg/metrics/purge.go
@@ -1,10 +1,11 @@
 package metrics
 
 import (
+	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
@@ -56,10 +57,10 @@ func (p *PurgeMetrics) UpdatePurgeTime(duration time.Duration) {
 	p.purgeTimeGauge.Set(duration.Seconds())
 }
 
-func (p *PurgeMetrics) UpdatePurgeError(logger logr.Logger, kyma *v1beta2.Kyma, purgeError PurgeError) {
+func (p *PurgeMetrics) UpdatePurgeError(ctx context.Context, kyma *v1beta2.Kyma, purgeError PurgeError) {
 	shootID, err := ExtractShootID(kyma)
 	if err != nil {
-		logger.Error(err, "Failed to update error metrics")
+		logf.FromContext(ctx).Error(err, "Failed to update error metrics")
 		return
 	}
 	instanceID, err := ExtractInstanceID(kyma)
@@ -73,7 +74,7 @@ func (p *PurgeMetrics) UpdatePurgeError(logger logr.Logger, kyma *v1beta2.Kyma, 
 		errorReasonLabel: string(purgeError),
 	})
 	if err != nil {
-		logger.Error(err, "Failed to update error metrics")
+		logf.FromContext(ctx).Error(err, "Failed to update error metrics")
 		return
 	}
 	metric.Set(1)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- In the team we agreed on using logf.FromContext instead of passing the logger as parameter


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
