### PR TITLE
feat: Suppress "Unauthorized" errors

### DIFF
--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -135,7 +135,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 
 // suppressUnauthorized replaces client-go error with our own in order to supress it's very long Error() payload
 func (c *ConcurrentDefaultSSA) suppressUnauthorized(src error) error {
-	if strings.HasSuffix(": Unauthorized", strings.TrimRight(src.Error(), " \n")) {
+	if strings.HasSuffix(strings.TrimRight(src.Error(), " \n"), ": Unauthorized") {
 		return ErrClientUnauthorized
 	}
 	return src

--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -133,7 +133,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 	return nil
 }
 
-// suppressUnauthorized replaces client-go error with our own in order to supress it's very long Error() payload.
+// suppressUnauthorized replaces client-go error with our own in order to suppress it's very long Error() payload.
 func (c *ConcurrentDefaultSSA) suppressUnauthorized(src error) error {
 	if strings.HasSuffix(strings.TrimRight(src.Error(), " \n"), ": Unauthorized") {
 		return ErrClientUnauthorized

--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -126,7 +126,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 	err := c.clnt.Patch(ctx, obj, client.Apply, client.ForceOwnership, c.owner)
 	if err != nil {
 		return fmt.Errorf(
-			"patch for %s failed: %w", info.ObjectName(), suppressUnauthorized(err),
+			"patch for %s failed: %w", info.ObjectName(), c.suppressUnauthorized(err),
 		)
 	}
 

--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -19,7 +19,7 @@ import (
 var (
 	ErrClientObjectConversionFailed = errors.New("client object conversion failed")
 	ErrServerSideApplyFailed        = errors.New("ServerSideApply failed")
-	ErrClientUnauthorized           = errors.New("Unauthorized")
+	ErrClientUnauthorized           = errors.New("ServerSideApply is unauthorised")
 )
 
 type SSA interface {

--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -65,7 +65,7 @@ func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.In
 
 	if errs != nil {
 		summaryErr := fmt.Errorf("%w (after %s)", ErrServerSideApplyFailed, ssaFinish)
-		if allUnauthorized(errs) {
+		if c.allUnauthorized(errs) {
 			return errors.Join(ErrClientUnauthorized, summaryErr)
 		}
 		errs = append(errs, summaryErr)
@@ -76,7 +76,7 @@ func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.In
 }
 
 func (c *ConcurrentDefaultSSA) allUnauthorized(errs []error) bool {
-	errCnt = len(errs)
+	errCnt := len(errs)
 
 	if errCnt == 0 {
 		return false
@@ -84,7 +84,7 @@ func (c *ConcurrentDefaultSSA) allUnauthorized(errs []error) bool {
 
 	unauthorizedFound := 0
 	for i := 0; i < len(errs); i++ {
-		if errors.Is(err, ErrClientUnauthorized) {
+		if errors.Is(errs[i], ErrClientUnauthorized) {
 			unauthorizedFound++
 		}
 	}

--- a/internal/declarative/v2/ssa.go
+++ b/internal/declarative/v2/ssa.go
@@ -133,7 +133,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 	return nil
 }
 
-// suppressUnauthorized replaces client-go error with our own in order to supress it's very long Error() payload
+// suppressUnauthorized replaces client-go error with our own in order to supress it's very long Error() payload.
 func (c *ConcurrentDefaultSSA) suppressUnauthorized(src error) error {
 	if strings.HasSuffix(strings.TrimRight(src.Error(), " \n"), ": Unauthorized") {
 		return ErrClientUnauthorized


### PR DESCRIPTION
**Description**

This PR intention is to prevent from etcd outages which we observe during secret rotation "peaks", when many SKR secrets are rotated in a short time.
Because of secrets rotation, the Lifecycle-Manager encounters a lot of connection errors and is producing many k8s Events objects.
We found out that some of these events are very big. Reducing the size of events may reduce the stress on etcd to an acceptable level.

Details:
When the secret is rotated, the client we use to access SKR returns an "Unauthorized" error. If this happens on a `patch` request, the error message contains a json-serialized copy of the object being patched.
Because we're putting these error messages into related k8s Event, this results in a very big `Event.message` field. In some cases it exceeds 90KiB.
This pull requests detects "Unauthorized" errors produced by go-client and replaces them with our custom error.
In addition, when all resources in a single SSA operation error-out with "Unauthorized", instead of concatenating them into one "big" error, they are all replaced by just a single custom "Unauthorized" error.
This reduces `Event.message` contents from over 90KiB to about 60 bytes - in the extreme case.

Side effects: We lose precise info which objects were patched when `Unauthorized` error occurred. But for now it looks we don't need this - we assume`Unauthorized` means that the runtime secret is not valid anymore and **every** operation on that runtime will return `Unauthorized`.
 
Changes proposed in this pull request:

- Replace client-go `Unauthorized` error with a custom one
- Replace all the errors produced by a single SSA batch operation with a single custom `Unauthorized` error, if all the individual errors are `Unauthorized`.