### PR TITLE
feat: Invalidate manifest client cache

### DIFF
--- a/internal/declarative/v2/client_cache.go
+++ b/internal/declarative/v2/client_cache.go
@@ -7,6 +7,7 @@ import (
 type ClientCache interface {
 	GetClientFromCache(key any) Client
 	SetClientInCache(key any, client Client)
+	Delete(key any)
 }
 
 type MemoryClientCache struct {
@@ -34,4 +35,8 @@ func (r *MemoryClientCache) GetClientFromCache(key any) Client {
 
 func (r *MemoryClientCache) SetClientInCache(key any, client Client) {
 	r.cache.Store(key, client)
+}
+
+func (r *MemoryClientCache) Delete(key any) {
+	r.cache.Delete(key)
 }

--- a/internal/manifest/client.go
+++ b/internal/manifest/client.go
@@ -73,9 +73,9 @@ func WithClientCacheKey() declarativev2.WithClientCacheKeyOption {
 		}
 
 		labelValue, err := internal.GetResourceLabel(resource, shared.KymaName)
-		objectKey := client.ObjectKeyFromObject(resource)
 		var labelErr *types.LabelNotFoundError
 		if errors.As(err, &labelErr) {
+			objectKey := client.ObjectKeyFromObject(resource)
 			logger.V(internal.DebugLogLevel).Info(
 				"client can not been cached due to lack of expected label",
 				"resource", objectKey)


### PR DESCRIPTION
**Description**

Observed on DEV: Lifecycle Manager slowly loses connectivity to the SKR's. The error reported in the Manifest CR: `Unauthorized`.
This correlates with short life of the SKR secrets on DEV (100 minutes).
Restarting the LM Pod helps for ~ 100 minutes.
It looks like the clients used in the manifest-controller loop are not refreshed when the secret is rotated/expires.

This PR is an attempt to get more insight into the problem.
On `Unauthorized` error it should invalidate the cached client.
Additional logging is provided for debugging purposes, to be removed once we find the 100% valid fix for the issue.

Changes proposed in this pull request:
- Invalidate manifest controller client cache entry upon `Unauthorized` errors