### PR TITLE
fix: No such host in purge reconciler

### DIFF
--- a/internal/controller/purge_controller.go
+++ b/internal/controller/purge_controller.go
@@ -83,7 +83,7 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	start := time.Now()
 	remoteClient, err := r.ResolveRemoteClient(ctx, client.ObjectKeyFromObject(kyma))
-	if util.IsNotFound(err) {
+	if util.IsNotFound(err) || util.IsNoSuchHost(err) {
 		if err := r.dropPurgeFinalizer(ctx, kyma); err != nil {
 			r.Metrics.UpdatePurgeError(ctx, kyma, metrics.ErrPurgeFinalizerRemoval)
 			return ctrl.Result{}, err

--- a/internal/controller/purge_controller.go
+++ b/internal/controller/purge_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -83,7 +84,7 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	start := time.Now()
 	remoteClient, err := r.ResolveRemoteClient(ctx, client.ObjectKeyFromObject(kyma))
-	if util.IsNotFound(err) || util.IsNoSuchHost(err) {
+	if util.IsNotFound(err) || noSuchHostCheck(err, logger) {
 		if err := r.dropPurgeFinalizer(ctx, kyma); err != nil {
 			r.Metrics.UpdatePurgeError(ctx, kyma, metrics.ErrPurgeFinalizerRemoval)
 			return ctrl.Result{}, err
@@ -109,6 +110,13 @@ func (r *PurgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	r.Metrics.UpdatePurgeTime(duration)
 
 	return ctrl.Result{}, nil
+}
+
+func noSuchHostCheck(err error, logger logr.Logger) bool {
+	lgr := func(msg string) {
+		logger.V(log.InfoLevel).Info(msg)
+	}
+	return util.IsNoSuchHost(err, lgr)
 }
 
 func (r *PurgeReconciler) UpdateStatus(ctx context.Context, kyma *v1beta2.Kyma, state shared.State, message string,

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -16,13 +16,18 @@ const (
 	NoSuchHostMsg = "no such host"
 )
 
-func IsNoSuchHost(err error) bool {
+func IsNoSuchHost(err error, lgr func(string)) bool {
+	if err == nil {
+		return false
+	}
+
 	var dnsErr *net.DNSError
+
 	if errors.As(err, &dnsErr) {
+		lgr(fmt.Sprintf("this error is a net.DNSError: %s", dnsErr.Err))
 		return dnsErr.Err == NoSuchHostMsg
 	}
-	fmt.Println("----------------------------------------")
-	fmt.Printf("this error is not a net.DNSError but: %T", err)
+	lgr(fmt.Sprintf("this error is not a net.DNSError but: %T", err))
 	return false
 }
 

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -9,6 +11,20 @@ import (
 	machineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 )
+
+const (
+	NoSuchHostMsg = "no such host"
+)
+
+func IsNoSuchHost(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.Err == NoSuchHostMsg
+	}
+	fmt.Println("----------------------------------------")
+	fmt.Printf("this error is not a net.DNSError but: %T", err)
+	return false
+}
 
 func IsNotFound(err error) bool {
 	if err == nil {


### PR DESCRIPTION
**Description**

This PR is intended to get more insight into the "host not found" errors that appear on DEV.
The error itself looks like a `net.DNSError`. I was unable to reproduce it locally.
The errors are produced by the purge reconciler in the following conditions:
- The SKR cluster is removed
- The SKR secret is removed
- The purge reconciler finalizer is still there (and it's the only finalizer)

Changes proposed in this pull request:

- an attempt to catch (and handle) "host not found" error.