### PR TITLE
fix: Logger config

### DIFF
--- a/config/load_test/kustomization.yaml
+++ b/config/load_test/kustomization.yaml
@@ -112,7 +112,7 @@ patches:
         value: --in-kcp-mode
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --log-level=9
+        value: --log-level=-1
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Always

--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -31,7 +31,7 @@ patches:
       value: --manifest-requeue-success-interval=5s
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --log-level=9
+      value: --log-level=-1
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --additional-dns-names=localhost,127.0.0.1,host.k3d.internal

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -9,9 +9,13 @@ import (
 )
 
 func ConfigLogger(level int8, syncer zapcore.WriteSyncer) logr.Logger {
-	if level > 0 {
-		level = -level
+	if zapcore.Level(level) < zapcore.DebugLevel {
+		level = int8(zapcore.DebugLevel)
 	}
+	if zapcore.Level(level) > zapcore.FatalLevel {
+		level = int8(zapcore.FatalLevel)
+	}
+
 	// The following settings is based on kyma community Improvement of log messages usability
 	// https://github.com/kyma-project/community/blob/main/concepts/observability-consistent-logging/improvement-of-log-messages-usability.md#log-structure
 	atomicLevel := zap.NewAtomicLevelAt(zapcore.Level(level))

--- a/pkg/testutils/klm.go
+++ b/pkg/testutils/klm.go
@@ -45,9 +45,9 @@ func CheckKLMLogs(ctx context.Context,
 	if strings.Contains(logs, logMsg) {
 		return nil
 	}
-	fmt.Println("----------------------------------------")
-	fmt.Println(logs)
-	fmt.Println("----------------------------------------")
+	fmt.Println("----------------------------------------") //nolint:forbidigo //debug
+	fmt.Println(logs)                                       //nolint:forbidigo //debug
+	fmt.Println("----------------------------------------") //nolint:forbidigo //debug
 
 	_, err = getPodLogs(ctx, runtimeConfig,
 		runtimeClient, remoteNamespace, watcher.SkrResourceName, watcherPodContainer, logsSince)

--- a/pkg/testutils/klm.go
+++ b/pkg/testutils/klm.go
@@ -45,6 +45,9 @@ func CheckKLMLogs(ctx context.Context,
 	if strings.Contains(logs, logMsg) {
 		return nil
 	}
+	fmt.Println("----------------------------------------")
+	fmt.Println(logs)
+	fmt.Println("----------------------------------------")
 
 	_, err = getPodLogs(ctx, runtimeConfig,
 		runtimeClient, remoteNamespace, watcher.SkrResourceName, watcherPodContainer, logsSince)

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -57,7 +57,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
-	logf.SetLogger(log.ConfigLogger(9, zapcore.AddSync(GinkgoWriter)))
+	logf.SetLogger(log.ConfigLogger(-1, zapcore.AddSync(GinkgoWriter)))
 
 	By("bootstrapping test environment")
 


### PR DESCRIPTION
**Description**

The existing log level setting logic was inverting any positive value to a negative one, thus effectively making any logging level a "Debug" level.
See: https://github.com/uber-go/zap/blob/master/zapcore/level.go, the "Debug" level has value of `-1` and any negative value looks like it's mapped to this one. The other values are non-negative ("Info" level is zero).

Changes proposed in this pull request:

- Replace "inverting" logic with the logic that keeps the provided value within allowable limits.
- Adjust logging levels in local testing kustomize files as necessary

**Related issue(s)**
