### PR TITLE
chore: Add script for storage version migrator

### DIFF
--- a/scripts/migrator_cleanup.sh
+++ b/scripts/migrator_cleanup.sh
@@ -10,7 +10,6 @@ done
 
 kubectl config use-context $context
 
-
 kubectl delete clusterrolebinding storage-version-migration-migrator
 kubectl delete clusterrolebinding storage-version-migration-trigger
 kubectl delete clusterrolebinding storage-version-migration-crd-creator
@@ -25,5 +24,3 @@ kubectl delete deployment trigger -n kube-system
 
 kubectl delete crd storageversionmigrations.migration.k8s.io
 kubectl delete crd storagestates.migration.k8s.io
-
-

--- a/scripts/migrator_cleanup.sh
+++ b/scripts/migrator_cleanup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+while getopts c: flag
+
+do
+        case "${flag}" in
+                c) context=${OPTARG};;
+                *) echo "Invalid option: -$flag" ;;
+        esac
+done
+
+kubectl config use-context $context
+
+
+kubectl delete clusterrolebinding storage-version-migration-migrator
+kubectl delete clusterrolebinding storage-version-migration-trigger
+kubectl delete clusterrolebinding storage-version-migration-crd-creator
+kubectl delete clusterrolebinding storage-version-migration-initializer
+
+kubectl delete clusterrole storage-version-migration-crd-creator
+kubectl delete clusterrole storage-version-migration-initializer
+kubectl delete clusterrole storage-version-migration-trigger
+
+kubectl delete deployment migrator -n kube-system
+kubectl delete deployment trigger -n kube-system
+
+kubectl delete crd storageversionmigrations.migration.k8s.io
+kubectl delete crd storagestates.migration.k8s.io
+
+

--- a/scripts/storage_version_migrator.sh
+++ b/scripts/storage_version_migrator.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+while getopts c: flag
+
+do
+        case "${flag}" in
+                c) context=${OPTARG};;
+                *) echo "Invalid option: -$flag" ;;
+        esac
+done
+
+git clone https://github.com/kubernetes-sigs/kube-storage-version-migrator.git
+cd kube-storage-version-migrator
+kubectl config use-context $context
+make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5 NAMESPACE=kcp-system
+pushd manifests.local
+kubectl apply -k ./
+popd
+

--- a/scripts/storage_version_migrator.sh
+++ b/scripts/storage_version_migrator.sh
@@ -11,7 +11,7 @@ done
 git clone https://github.com/kubernetes-sigs/kube-storage-version-migrator.git
 cd kube-storage-version-migrator
 kubectl config use-context $context
-make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5 NAMESPACE=kcp-system
+make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5
 pushd manifests.local
 kubectl apply -k ./
 popd

--- a/scripts/storage_version_migrator.sh
+++ b/scripts/storage_version_migrator.sh
@@ -11,8 +11,16 @@ done
 git clone https://github.com/kubernetes-sigs/kube-storage-version-migrator.git
 cd kube-storage-version-migrator
 kubectl config use-context $context
-make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5
+make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5 NAMESPACE=kcp-system
 pushd manifests.local
 kubectl apply -k ./
 popd
 
+# This script deploys the storage version migrator. The migrator deploys its resources in the `kcp-system` namespace
+# and it gets triggered every 10 minutes to migrate all resources stored in the etcd to the latest storage version.
+
+# To run the script, use the following command:
+
+# `sh ./scripts/storage_version_migrator.sh -c ${CONTEXT}`
+
+#where CONTEXT is the context for the cluster where you want to do the API migration

--- a/scripts/storage_version_migrator.sh
+++ b/scripts/storage_version_migrator.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# This script deploys the storage version migrator. The migrator deploys its resources in the `kube-system` namespace
+# and it gets triggered every 10 minutes to migrate all resources stored in the etcd to the latest storage version.
+
+# To run the script, use the following command:
+# `sh ./scripts/storage_version_migrator.sh -c ${CONTEXT}`
+# where CONTEXT is the context for the cluster where you want to do the API migration
+
 while getopts c: flag
 
 do
@@ -15,12 +23,3 @@ make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERS
 pushd manifests.local
 kubectl apply -k ./
 popd
-
-# This script deploys the storage version migrator. The migrator deploys its resources in the `kube-system` namespace
-# and it gets triggered every 10 minutes to migrate all resources stored in the etcd to the latest storage version.
-
-# To run the script, use the following command:
-
-# `sh ./scripts/storage_version_migrator.sh -c ${CONTEXT}`
-
-#where CONTEXT is the context for the cluster where you want to do the API migration

--- a/scripts/storage_version_migrator.sh
+++ b/scripts/storage_version_migrator.sh
@@ -11,12 +11,12 @@ done
 git clone https://github.com/kubernetes-sigs/kube-storage-version-migrator.git
 cd kube-storage-version-migrator
 kubectl config use-context $context
-make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5 NAMESPACE=kcp-system
+make local-manifests REGISTRY=eu.gcr.io/k8s-artifacts-prod/storage-migrator VERSION=v0.0.5
 pushd manifests.local
 kubectl apply -k ./
 popd
 
-# This script deploys the storage version migrator. The migrator deploys its resources in the `kcp-system` namespace
+# This script deploys the storage version migrator. The migrator deploys its resources in the `kube-system` namespace
 # and it gets triggered every 10 minutes to migrate all resources stored in the etcd to the latest storage version.
 
 # To run the script, use the following command:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add script for storage version migrator deployment

This script deploys the storage version migrator. The migrator deploys its resources in the `kube-system` namespace and it gets triggered every 10 minutes to migrate all resources stored in the etcd to the latest storage version. 
To run the script, use the following command:
`sh ./scripts/storage_version_migrator.sh -c ${CONTEXT}`

where CONTEXT is the context for the cluster where you want to do the API migration 

**Related issue(s)**
#1119 