### PR TITLE
feat: Introduce different requeue after interval to control the frequency of unexpected requeue events

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -366,7 +366,10 @@ func setupManifestReconciler(mgr ctrl.Manager, flagVar *flags.FlagVar, options c
 		flagVar.FailureMaxDelay, flagVar.RateLimiterFrequency, flagVar.RateLimiterBurst)
 
 	if err := controller.SetupWithManager(
-		mgr, options, flagVar.ManifestRequeueSuccessInterval, controller.SetupUpSetting{
+		mgr, options, queue.RequeueIntervals{
+			Success: flagVar.ManifestRequeueSuccessInterval,
+			Busy:    flagVar.KymaRequeueBusyInterval,
+		}, controller.SetupUpSetting{
 			ListenerAddr:                 flagVar.ManifestListenerAddr,
 			EnableDomainNameVerification: flagVar.EnableDomainNameVerification,
 		}, metrics.NewManifestMetrics(sharedMetrics),

--- a/internal/controller/manifest_controller.go
+++ b/internal/controller/manifest_controller.go
@@ -28,7 +28,8 @@ import (
 func SetupWithManager(mgr manager.Manager,
 	options ctrlruntime.Options,
 	requeueIntervals queue.RequeueIntervals,
-	settings SetupUpSetting, manifestMetrics *metrics.ManifestMetrics) error {
+	settings SetupUpSetting, manifestMetrics *metrics.ManifestMetrics,
+) error {
 	var verifyFunc watcherevent.Verify
 	if settings.EnableDomainNameVerification {
 		// Verifier used to verify incoming listener requests
@@ -76,7 +77,8 @@ func SetupWithManager(mgr manager.Manager,
 }
 
 func ManifestReconciler(mgr manager.Manager, requeueIntervals queue.RequeueIntervals,
-	manifestMetrics *metrics.ManifestMetrics) *declarativev2.Reconciler {
+	manifestMetrics *metrics.ManifestMetrics,
+) *declarativev2.Reconciler {
 	kcp := &declarativev2.ClusterInfo{
 		Client: mgr.GetClient(),
 		Config: mgr.GetConfig(),

--- a/internal/controller/manifest_controller.go
+++ b/internal/controller/manifest_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	watcherevent "github.com/kyma-project/runtime-watcher/listener/pkg/event"
 	"github.com/kyma-project/runtime-watcher/listener/pkg/types"
@@ -22,16 +21,14 @@ import (
 	declarativev2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"github.com/kyma-project/lifecycle-manager/internal/manifest"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
+	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 	"github.com/kyma-project/lifecycle-manager/pkg/security"
 )
 
-func SetupWithManager(
-	mgr manager.Manager,
+func SetupWithManager(mgr manager.Manager,
 	options ctrlruntime.Options,
-	checkInterval time.Duration,
-	settings SetupUpSetting,
-	manifestMetrics *metrics.ManifestMetrics,
-) error {
+	requeueIntervals queue.RequeueIntervals,
+	settings SetupUpSetting, manifestMetrics *metrics.ManifestMetrics) error {
 	var verifyFunc watcherevent.Verify
 	if settings.EnableDomainNameVerification {
 		// Verifier used to verify incoming listener requests
@@ -71,24 +68,22 @@ func SetupWithManager(
 			},
 		).WithOptions(options)
 
-	if err := controllerManagedByManager.Complete(ManifestReconciler(mgr, checkInterval, manifestMetrics)); err != nil {
+	if err := controllerManagedByManager.Complete(ManifestReconciler(mgr, requeueIntervals,
+		manifestMetrics)); err != nil {
 		return fmt.Errorf("failed to initialize manifest controller by manager: %w", err)
 	}
 	return nil
 }
 
-func ManifestReconciler(
-	mgr manager.Manager,
-	checkInterval time.Duration,
-	manifestMetrics *metrics.ManifestMetrics,
-) *declarativev2.Reconciler {
+func ManifestReconciler(mgr manager.Manager, requeueIntervals queue.RequeueIntervals,
+	manifestMetrics *metrics.ManifestMetrics) *declarativev2.Reconciler {
 	kcp := &declarativev2.ClusterInfo{
 		Client: mgr.GetClient(),
 		Config: mgr.GetConfig(),
 	}
 	lookup := &manifest.RemoteClusterLookup{KCP: kcp}
 	return declarativev2.NewFromManager(
-		mgr, &v1beta2.Manifest{}, manifestMetrics,
+		mgr, &v1beta2.Manifest{}, requeueIntervals, manifestMetrics,
 		declarativev2.WithSpecResolver(
 			manifest.NewSpecResolver(kcp),
 		),
@@ -97,7 +92,6 @@ func ManifestReconciler(
 		manifest.WithClientCacheKey(),
 		declarativev2.WithPostRun{manifest.PostRunCreateCR},
 		declarativev2.WithPreDelete{manifest.PreDeleteDeleteCR},
-		declarativev2.WithPeriodicConsistencyCheck(checkInterval),
 		declarativev2.WithModuleCRDeletionCheck(manifest.NewModuleCRDeletionCheck()),
 	)
 }

--- a/internal/declarative/v2/options.go
+++ b/internal/declarative/v2/options.go
@@ -10,7 +10,6 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -37,7 +36,6 @@ func DefaultOptions() *Options {
 			KymaComponentTransform,
 			DisclaimerTransform,
 		),
-		WithPermanentConsistencyCheck(false),
 		WithSingletonClientCache(NewMemorySingletonClientCache()),
 		WithManifestCache(os.TempDir()),
 		WithSkipReconcileOn(SkipReconcileOnDefaultLabelPresentAndTrue),
@@ -77,8 +75,6 @@ type Options struct {
 	DeletePrerequisites bool
 
 	ShouldSkip SkipReconcile
-
-	CtrlOnSuccess ctrl.Result
 }
 
 type Option interface {
@@ -220,18 +216,6 @@ type WithModuleCRDeletionCheckOption struct {
 
 func (o WithModuleCRDeletionCheckOption) Apply(options *Options) {
 	options.DeletionCheck = o
-}
-
-type WithPeriodicConsistencyCheck time.Duration
-
-func (o WithPeriodicConsistencyCheck) Apply(options *Options) {
-	options.CtrlOnSuccess.RequeueAfter = time.Duration(o)
-}
-
-type WithPermanentConsistencyCheck bool
-
-func (o WithPermanentConsistencyCheck) Apply(options *Options) {
-	options.CtrlOnSuccess = ctrl.Result{Requeue: bool(o)}
 }
 
 type WithSingletonClientCacheOption struct {

--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -39,7 +39,8 @@ const (
 )
 
 func NewFromManager(mgr manager.Manager, prototype Object, requeueIntervals queue.RequeueIntervals,
-	metrics *metrics.ManifestMetrics, options ...Option) *Reconciler {
+	metrics *metrics.ManifestMetrics, options ...Option,
+) *Reconciler {
 	r := &Reconciler{}
 	r.prototype = prototype
 	r.Metrics = metrics
@@ -93,13 +94,13 @@ func newResourcesCondition(obj Object) apimetav1.Condition {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	obj, ok := r.prototype.DeepCopyObject().(Object)
 	if !ok {
-		r.Metrics.RecordRequeueReason(metrics.ManifestTypeCast, metrics.UnexpectedRequeue)
+		r.Metrics.RecordRequeueReason(metrics.ManifestTypeCast, queue.UnexpectedRequeue)
 		return ctrl.Result{}, common.ErrTypeAssert
 	}
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		logf.FromContext(ctx).Info(req.NamespacedName.String() + " got deleted!")
 		if !util.IsNotFound(err) {
-			r.Metrics.RecordRequeueReason(metrics.ManifestRetrieval, metrics.UnexpectedRequeue)
+			r.Metrics.RecordRequeueReason(metrics.ManifestRetrieval, queue.UnexpectedRequeue)
 			return ctrl.Result{}, fmt.Errorf("manifestController: %w", err)
 		}
 		return ctrl.Result{Requeue: false}, nil
@@ -110,89 +111,86 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if err := r.initialize(obj); err != nil {
-		return r.ssaStatus(ctx, obj, metrics.ManifestInit, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestInit)
 	}
 
 	if obj.GetDeletionTimestamp().IsZero() {
 		objMeta := r.partialObjectMetadata(obj)
 		if controllerutil.AddFinalizer(objMeta, r.Finalizer) {
-			return r.ssaSpec(ctx, objMeta, metrics.ManifestAddFinalizer, metrics.IntendedRequeue)
+			return r.ssaSpec(ctx, objMeta, metrics.ManifestAddFinalizer)
 		}
 	}
 
 	spec, err := r.Spec(ctx, obj)
 	if err != nil {
 		if !obj.GetDeletionTimestamp().IsZero() {
-			return r.removeFinalizers(ctx, obj, []string{r.Finalizer}, metrics.ManifestRemoveFinalizerWhenParseSpec,
-				metrics.IntendedRequeue)
+			return r.removeFinalizers(ctx, obj, []string{r.Finalizer}, metrics.ManifestRemoveFinalizerWhenParseSpec)
 		}
-		return r.ssaStatus(ctx, obj, metrics.ManifestParseSpec, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestParseSpec)
 	}
 
 	if notContainsSyncedOCIRefAnnotation(obj) {
 		updateSyncedOCIRefAnnotation(obj, spec.OCIRef)
-		return r.updateObject(ctx, obj, metrics.ManifestInitSyncedOCIRef, metrics.IntendedRequeue)
+		return r.updateObject(ctx, obj, metrics.ManifestInitSyncedOCIRef, queue.IntendedRequeue)
 	}
 
 	clnt, err := r.getTargetClient(ctx, obj)
 	if err != nil {
 		if !obj.GetDeletionTimestamp().IsZero() && errors.Is(err, ErrAccessSecretNotFound) {
-			return r.removeFinalizers(ctx, obj, obj.GetFinalizers(),
-				metrics.ManifestRemoveFinalizerWhenSecretGone, metrics.IntendedRequeue)
+			return r.removeFinalizers(ctx, obj, obj.GetFinalizers(), metrics.ManifestRemoveFinalizerWhenSecretGone)
 		}
 
 		r.Event(obj, "Warning", "ClientInitialization", err.Error())
 		obj.SetStatus(obj.GetStatus().WithState(shared.StateError).WithErr(err))
-		return r.ssaStatus(ctx, obj, metrics.ManifestClientInit, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestClientInit)
 	}
 
 	target, current, err := r.renderResources(ctx, clnt, obj, spec)
 	if err != nil {
 		if util.IsConnectionRefusedOrUnauthorizedOrAskingForCredentials(err) {
 			r.invalidateClientCache(ctx, obj)
-			return r.ssaStatus(ctx, obj, metrics.ManifestUnauthorized, metrics.UnexpectedRequeue)
+			return r.ssaStatus(ctx, obj, metrics.ManifestUnauthorized)
 		}
 
-		return r.ssaStatus(ctx, obj, metrics.ManifestRenderResources, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestRenderResources)
 	}
 
 	diff := ResourceList(current).Difference(target)
 	if err := r.pruneDiff(ctx, clnt, obj, diff, spec); errors.Is(err, ErrDeletionNotFinished) {
-		r.Metrics.RecordRequeueReason(metrics.ManifestPruneDiffNotFinished, metrics.IntendedRequeue)
+		r.Metrics.RecordRequeueReason(metrics.ManifestPruneDiffNotFinished, queue.IntendedRequeue)
 		return ctrl.Result{Requeue: true}, nil
 	} else if err != nil {
-		return r.ssaStatus(ctx, obj, metrics.ManifestPruneDiff, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestPruneDiff)
 	}
 
 	if err := r.doPreDelete(ctx, clnt, obj); err != nil {
 		if errors.Is(err, ErrRequeueRequired) {
-			r.Metrics.RecordRequeueReason(metrics.ManifestPreDeleteEnqueueRequired, metrics.IntendedRequeue)
+			r.Metrics.RecordRequeueReason(metrics.ManifestPreDeleteEnqueueRequired, queue.IntendedRequeue)
 			return ctrl.Result{Requeue: true}, nil
 		}
-		return r.ssaStatus(ctx, obj, metrics.ManifestPreDelete, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestPreDelete)
 	}
 
 	if err = r.syncResources(ctx, clnt, obj, target); err != nil {
 		if errors.Is(err, ErrRequeueRequired) {
-			r.Metrics.RecordRequeueReason(metrics.ManifestSyncResourcesEnqueueRequired, metrics.IntendedRequeue)
+			r.Metrics.RecordRequeueReason(metrics.ManifestSyncResourcesEnqueueRequired, queue.IntendedRequeue)
 			return ctrl.Result{Requeue: true}, nil
 		}
 		if errors.Is(err, ErrClientUnauthorized) {
 			r.invalidateClientCache(ctx, obj)
 		}
-		return r.ssaStatus(ctx, obj, metrics.ManifestSyncResources, metrics.UnexpectedRequeue)
+		return r.ssaStatus(ctx, obj, metrics.ManifestSyncResources)
 	}
 
 	// This situation happens when manifest get new installation layer to update resources,
 	// we need to make sure all updates successfully before we can update synced oci ref
 	if requireUpdateSyncedOCIRefAnnotation(obj, spec.OCIRef) {
 		updateSyncedOCIRefAnnotation(obj, spec.OCIRef)
-		return r.updateObject(ctx, obj, metrics.ManifestUpdateSyncedOCIRef, metrics.IntendedRequeue)
+		return r.updateObject(ctx, obj, metrics.ManifestUpdateSyncedOCIRef, queue.IntendedRequeue)
 	}
 
 	if !obj.GetDeletionTimestamp().IsZero() {
-		return r.removeFinalizers(ctx, obj, []string{r.Finalizer}, metrics.ManifestRemoveFinalizerInDeleting,
-			metrics.IntendedRequeue)
+		return r.removeFinalizers(ctx, obj, []string{r.Finalizer}, metrics.ManifestRemoveFinalizerInDeleting)
 	}
 	return ctrl.Result{RequeueAfter: r.Success}, nil
 }
@@ -210,7 +208,6 @@ func (r *Reconciler) invalidateClientCache(ctx context.Context, obj Object) {
 
 func (r *Reconciler) removeFinalizers(ctx context.Context, obj Object, finalizersToRemove []string,
 	requeueReason metrics.ManifestRequeueReason,
-	requeueType metrics.RequeueType,
 ) (ctrl.Result, error) {
 	finalizerRemoved := false
 	for _, f := range finalizersToRemove {
@@ -219,12 +216,12 @@ func (r *Reconciler) removeFinalizers(ctx context.Context, obj Object, finalizer
 		}
 	}
 	if finalizerRemoved {
-		return r.updateObject(ctx, obj, requeueReason, requeueType)
+		return r.updateObject(ctx, obj, requeueReason, queue.IntendedRequeue)
 	}
 	msg := fmt.Sprintf("waiting as other finalizers are present: %s", obj.GetFinalizers())
 	r.Event(obj, "Normal", "FinalizerRemoval", msg)
 	obj.SetStatus(obj.GetStatus().WithState(shared.StateDeleting).WithOperation(msg))
-	return r.ssaStatus(ctx, obj, requeueReason, requeueType)
+	return r.ssaStatus(ctx, obj, requeueReason)
 }
 
 func (r *Reconciler) partialObjectMetadata(obj Object) *apimetav1.PartialObjectMetadata {
@@ -617,26 +614,22 @@ func (r *Reconciler) configClient(ctx context.Context, obj Object) (Client, erro
 
 func (r *Reconciler) ssaStatus(ctx context.Context, obj client.Object,
 	requeueReason metrics.ManifestRequeueReason,
-	requeueType metrics.RequeueType,
 ) (ctrl.Result, error) {
 	resetNonPatchableField(obj)
-	r.Metrics.RecordRequeueReason(requeueReason, requeueType)
+	r.Metrics.RecordRequeueReason(requeueReason, queue.UnexpectedRequeue)
 	if err := r.Status().Patch(ctx, obj, client.Apply, client.ForceOwnership, r.FieldOwner); err != nil {
 		r.Event(obj, "Warning", "PatchStatus", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
 	}
-	if requeueType == metrics.UnexpectedRequeue {
-		return ctrl.Result{RequeueAfter: r.RequeueIntervals.Busy}, nil
-	}
-	return ctrl.Result{Requeue: true}, nil
+
+	return ctrl.Result{RequeueAfter: r.RequeueIntervals.Busy}, nil
 }
 
 func (r *Reconciler) ssaSpec(ctx context.Context, obj client.Object,
 	requeueReason metrics.ManifestRequeueReason,
-	requeueType metrics.RequeueType,
 ) (ctrl.Result, error) {
 	resetNonPatchableField(obj)
-	r.Metrics.RecordRequeueReason(requeueReason, requeueType)
+	r.Metrics.RecordRequeueReason(requeueReason, queue.IntendedRequeue)
 	if err := r.Patch(ctx, obj, client.Apply, client.ForceOwnership, r.FieldOwner); err != nil {
 		r.Event(obj, "Warning", "PatchObject", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to patch object: %w", err)
@@ -652,7 +645,7 @@ func resetNonPatchableField(obj client.Object) {
 
 func (r *Reconciler) updateObject(ctx context.Context, obj client.Object,
 	requeueReason metrics.ManifestRequeueReason,
-	requeueType metrics.RequeueType,
+	requeueType queue.RequeueType,
 ) (ctrl.Result, error) {
 	r.Metrics.RecordRequeueReason(requeueReason, requeueType)
 	if err := r.Update(ctx, obj); err != nil {

--- a/internal/pkg/metrics/common.go
+++ b/internal/pkg/metrics/common.go
@@ -15,13 +15,9 @@ const (
 	KymaNameLabel   = "kyma_name"
 )
 
-type RequeueType string
-
 const (
-	IntendedRequeue    RequeueType = "intended"
-	UnexpectedRequeue  RequeueType = "unexpected"
-	requeueReasonLabel             = "requeue_reason"
-	requeueTypeLabel               = "requeue_type"
+	requeueReasonLabel = "requeue_reason"
+	requeueTypeLabel   = "requeue_type"
 )
 
 var (

--- a/internal/pkg/metrics/kyma.go
+++ b/internal/pkg/metrics/kyma.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 )
 
 const (
@@ -144,7 +145,7 @@ func calcStateValue(state, newState shared.State) float64 {
 	return 0
 }
 
-func (k *KymaMetrics) RecordRequeueReason(kymaRequeueReason KymaRequeueReason, requeueType RequeueType) {
+func (k *KymaMetrics) RecordRequeueReason(kymaRequeueReason KymaRequeueReason, requeueType queue.RequeueType) {
 	k.requeueReasonCounter.WithLabelValues(string(kymaRequeueReason), string(requeueType)).Inc()
 }
 

--- a/internal/pkg/metrics/manifest.go
+++ b/internal/pkg/metrics/manifest.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "github.com/kyma-project/lifecycle-manager/pkg/queue"
+
 type ManifestRequeueReason string
 
 const (
@@ -32,6 +34,6 @@ func NewManifestMetrics(sharedMetrics *SharedMetrics) *ManifestMetrics {
 	return &ManifestMetrics{SharedMetrics: sharedMetrics}
 }
 
-func (k *ManifestMetrics) RecordRequeueReason(requeueReason ManifestRequeueReason, requeueType RequeueType) {
+func (k *ManifestMetrics) RecordRequeueReason(requeueReason ManifestRequeueReason, requeueType queue.RequeueType) {
 	k.requeueReasonCounter.WithLabelValues(string(requeueReason), string(requeueType)).Inc()
 }

--- a/pkg/queue/requeue_intervals.go
+++ b/pkg/queue/requeue_intervals.go
@@ -29,3 +29,10 @@ func DetermineRequeueInterval(state shared.State, intervals RequeueIntervals) ti
 		return intervals.Success
 	}
 }
+
+type RequeueType string
+
+const (
+	IntendedRequeue   RequeueType = "intended"
+	UnexpectedRequeue RequeueType = "unexpected"
+)

--- a/tests/e2e/kyma_metrics_test.go
+++ b/tests/e2e/kyma_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
+	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,11 +53,11 @@ var _ = Describe("Manage Module Metrics", Ordered, func() {
 		It("Then Related Manifest Requeue Metrics Get Increased", func() {
 			Eventually(IsManifestRequeueReasonCountIncreased).
 				WithContext(ctx).
-				WithArguments(string(metrics.ManifestAddFinalizer), string(metrics.IntendedRequeue)).
+				WithArguments(string(metrics.ManifestAddFinalizer), string(queue.IntendedRequeue)).
 				Should(BeTrue())
 			Eventually(IsManifestRequeueReasonCountIncreased).
 				WithContext(ctx).
-				WithArguments(string(metrics.ManifestSyncResourcesEnqueueRequired), string(metrics.IntendedRequeue)).
+				WithArguments(string(metrics.ManifestSyncResourcesEnqueueRequired), string(queue.IntendedRequeue)).
 				Should(BeTrue())
 		})
 
@@ -95,11 +96,11 @@ var _ = Describe("Manage Module Metrics", Ordered, func() {
 		It("Then Related Manifest Requeue Metrics Get Increased", func() {
 			Eventually(IsManifestRequeueReasonCountIncreased).
 				WithContext(ctx).
-				WithArguments(string(metrics.ManifestPreDeleteEnqueueRequired), string(metrics.IntendedRequeue)).
+				WithArguments(string(metrics.ManifestPreDeleteEnqueueRequired), string(queue.IntendedRequeue)).
 				Should(BeTrue())
 			Eventually(IsManifestRequeueReasonCountIncreased).
 				WithContext(ctx).
-				WithArguments(string(metrics.ManifestRemoveFinalizerInDeleting), string(metrics.IntendedRequeue)).
+				WithArguments(string(metrics.ManifestRemoveFinalizerInDeleting), string(queue.IntendedRequeue)).
 				Should(BeTrue())
 		})
 
@@ -117,7 +118,7 @@ var _ = Describe("Manage Module Metrics", Ordered, func() {
 		It("Then count of lifecycle_mgr_requeue_reason_total for kyma_deletion is 1", func() {
 			Eventually(GetRequeueReasonCount).
 				WithContext(ctx).
-				WithArguments(string(metrics.KymaDeletion), string(metrics.IntendedRequeue)).
+				WithArguments(string(metrics.KymaDeletion), string(queue.IntendedRequeue)).
 				Should(Equal(1))
 
 			By("And Kyma Metrics are removed")

--- a/tests/integration/controller/manifest/custom_resource_check/suite_test.go
+++ b/tests/integration/controller/manifest/custom_resource_check/suite_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/manifest"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
 	"github.com/kyma-project/lifecycle-manager/pkg/log"
+	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 	"github.com/kyma-project/lifecycle-manager/tests/integration"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -134,22 +135,19 @@ var _ = BeforeSuite(func() {
 	controlPlaneClient = k8sManager.GetClient()
 
 	kcp := &declarativev2.ClusterInfo{Config: cfg, Client: controlPlaneClient}
-	reconciler = declarativev2.NewFromManager(
-		k8sManager, &v1beta2.Manifest{}, metrics.NewManifestMetrics(metrics.NewSharedMetrics()),
-		declarativev2.WithSpecResolver(
+	reconciler = declarativev2.NewFromManager(k8sManager, &v1beta2.Manifest{}, queue.RequeueIntervals{
+		Success: 1 * time.Second,
+		Error:   1 * time.Second,
+	},
+		metrics.NewManifestMetrics(metrics.NewSharedMetrics()), declarativev2.WithSpecResolver(
 			manifest.NewSpecResolver(kcp),
-		),
-		declarativev2.WithPermanentConsistencyCheck(true),
-		declarativev2.WithRemoteTargetCluster(
+		), declarativev2.WithRemoteTargetCluster(
 			func(_ context.Context, _ declarativev2.Object) (*declarativev2.ClusterInfo, error) {
 				return &declarativev2.ClusterInfo{Config: authUser.Config()}, nil
 			},
-		),
-		manifest.WithClientCacheKey(),
-		declarativev2.WithPostRun{manifest.PostRunCreateCR},
+		), manifest.WithClientCacheKey(), declarativev2.WithPostRun{manifest.PostRunCreateCR},
 		declarativev2.WithPreDelete{manifest.PreDeleteDeleteCR},
-		declarativev2.WithCustomReadyCheck(manifest.NewCustomResourceReadyCheck()),
-	)
+		declarativev2.WithCustomReadyCheck(manifest.NewCustomResourceReadyCheck()))
 
 	err = ctrl.NewControllerManagedBy(k8sManager).
 		For(&v1beta2.Manifest{}).


### PR DESCRIPTION
At the moment, manifest controller only do requeue after for success reconcilation, however for certain cases, if the requeue is unexpected, there is no need to requeue inmediately, which brings unneccesary high amount of requeue event. For example, currently we havemany unexpected `manifest_sync_resources` requeue

This PR address it by introduce another time interval, which reuse `KymaRequeueBusyInterval`, trying to reduce the unexpected requeue numbers.

I also dropped the `CtrlOnSuccess` options, instead introduce the  `queue.RequeueIntervals` directly to manifest Reconciler struct to have fine grained requeue control. 