### PR TITLE
feat: Set Kyma Module Status to `Warning` if ModuleTemplate is not found

### DIFF
--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -216,6 +216,15 @@ func generateModuleStatus(module *common.Module, existStatus *v1beta2.ModuleStat
 		newModuleStatus.Message = module.Template.Err.Error()
 		return *newModuleStatus
 	}
+	if errors.Is(module.Template.Err, templatelookup.ErrNoTemplatesInListResult) {
+		return v1beta2.ModuleStatus{
+			Name:    module.ModuleName,
+			Channel: module.Template.DesiredChannel,
+			FQDN:    module.FQDN,
+			State:   shared.StateWarning,
+			Message: module.Template.Err.Error(),
+		}
+	}
 	if module.Template.Err != nil {
 		return v1beta2.ModuleStatus{
 			Name:    module.ModuleName,

--- a/tests/integration/controller/kyma/kyma_test.go
+++ b/tests/integration/controller/kyma/kyma_test.go
@@ -177,46 +177,52 @@ var _ = Describe("Kyma enable one Module", Ordered, func() {
 	})
 })
 
-var _ = Describe("Kyma enable one Mandatory Module", Ordered, func() {
+var _ = FDescribe("Kyma enable one Mandatory Module", Ordered, func() {
 	kyma := NewTestKyma("mandatory-module-kyma")
 
 	RegisterDefaultLifecycleForKyma(kyma)
 
-	It("should result Kyma in Error state", func() {
-		By("enabling one mandatory Module")
-		kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
-			Name: "mandatory-template-operator",
+	It("should result Kyma in Warning state", func() {
+		By("enabling one mandatory Module", func() {
+			kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
+				Name: "mandatory-template-operator",
+			})
+			Eventually(controlPlaneClient.Update, Timeout, Interval).
+				WithContext(ctx).WithArguments(kyma).Should(Succeed())
 		})
-		Eventually(controlPlaneClient.Update, Timeout, Interval).
-			WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		By("checking the state to be Error")
-		Eventually(KymaIsInState, Timeout, Interval).
-			WithContext(ctx).
-			WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateError).
-			Should(Succeed())
+		By("checking the state to be Warning", func() {
+			Eventually(KymaIsInState, Timeout, Interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateWarning).
+				Should(Succeed())
+		})
 
-		By("Kyma status contains expected condition")
-		kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(
-			kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionFalse)).To(BeTrue())
+		By("Kyma status contains expected condition", func() {
+			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(
+				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionFalse)).To(BeTrue())
+		})
 	})
 	It("should result Kyma in Ready state", func() {
-		By("disabling one mandatory Module")
-		kyma.Spec.Modules = []v1beta2.Module{}
-		Eventually(controlPlaneClient.Update, Timeout, Interval).
-			WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		By("checking the state to be Ready")
-		Eventually(KymaIsInState, Timeout, Interval).
-			WithContext(ctx).
-			WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
-			Should(Succeed())
+		By("disabling one mandatory Module", func() {
+			kyma.Spec.Modules = []v1beta2.Module{}
+			Eventually(controlPlaneClient.Update, Timeout, Interval).
+				WithContext(ctx).WithArguments(kyma).Should(Succeed())
+		})
+		By("checking the state to be Ready", func() {
+			Eventually(KymaIsInState, Timeout, Interval).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+				Should(Succeed())
+		})
 
-		By("Kyma status contains expected condition")
-		kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(
-			kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionTrue)).To(BeTrue())
+		By("Kyma status contains expected condition", func() {
+			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(
+				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionTrue)).To(BeTrue())
+		})
 	})
 })
 

--- a/tests/integration/controller/kyma/kyma_test.go
+++ b/tests/integration/controller/kyma/kyma_test.go
@@ -208,14 +208,14 @@ var _ = Describe("Kyma enable Mandatory Module or non-existent Module Kyma.Spec.
 			moduleName:       "non-existent-module",
 		},
 	}
-	for _, t := range testCases {
-		kyma := NewTestKyma(t.kymaName)
+	for _, testCase := range testCases {
+		kyma := NewTestKyma(testCase.kymaName)
 		RegisterDefaultLifecycleForKyma(kyma)
 
 		It("should result Kyma in Warning state", func() {
-			By(t.enableStatement, func() {
+			By(testCase.enableStatement, func() {
 				kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
-					Name: t.moduleName,
+					Name: testCase.moduleName,
 				})
 				Eventually(controlPlaneClient.Update, Timeout, Interval).
 					WithContext(ctx).WithArguments(kyma).Should(Succeed())
@@ -236,7 +236,7 @@ var _ = Describe("Kyma enable Mandatory Module or non-existent Module Kyma.Spec.
 			})
 		})
 		It("should result Kyma in Ready state", func() {
-			By(t.disableStatement, func() {
+			By(testCase.disableStatement, func() {
 				kyma.Spec.Modules = []v1beta2.Module{}
 				Eventually(controlPlaneClient.Update, Timeout, Interval).
 					WithContext(ctx).WithArguments(kyma).Should(Succeed())

--- a/tests/integration/controller/kyma/kyma_test.go
+++ b/tests/integration/controller/kyma/kyma_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Kyma enable one Module", Ordered, func() {
 	})
 })
 
-var _ = FDescribe("Kyma enable one Mandatory Module", Ordered, func() {
+var _ = Describe("Kyma enable one Mandatory Module", Ordered, func() {
 	kyma := NewTestKyma("mandatory-module-kyma")
 
 	RegisterDefaultLifecycleForKyma(kyma)

--- a/tests/integration/controller/kyma/kyma_test.go
+++ b/tests/integration/controller/kyma/kyma_test.go
@@ -188,102 +188,74 @@ var _ = Describe("Kyma enable one Module", Ordered, func() {
 	})
 })
 
-var _ = Describe("Kyma enable one non-existing Module", Ordered, func() {
-	kyma := NewTestKyma("non-existing-module-kyma")
+var _ = Describe("Kyma enable Mandatory Module or non-existent Module Kyma.Spec.Modules", Ordered, func() {
+	testCases := []struct {
+		enableStatement  string
+		disableStatement string
+		kymaName         string
+		moduleName       string
+	}{
+		{
+			enableStatement:  "enabling one mandatory Module",
+			disableStatement: "disabling mandatory Module",
+			kymaName:         "mandatory-module-kyma",
+			moduleName:       "mandatory-template-operator",
+		},
+		{
+			enableStatement:  "enabling one non-existing Module",
+			disableStatement: "disabling non-existent Module",
+			kymaName:         "non-existing-module-kyma",
+			moduleName:       "non-existent-module",
+		},
+	}
+	for _, t := range testCases {
+		kyma := NewTestKyma(t.kymaName)
+		RegisterDefaultLifecycleForKyma(kyma)
 
-	RegisterDefaultLifecycleForKyma(kyma)
-
-	It("should result Kyma in Warning state", func() {
-		By("enabling one non-existing Module", func() {
-			kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
-				Name: "non-existing-module",
+		It("should result Kyma in Warning state", func() {
+			By(t.enableStatement, func() {
+				kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
+					Name: t.moduleName,
+				})
+				Eventually(controlPlaneClient.Update, Timeout, Interval).
+					WithContext(ctx).WithArguments(kyma).Should(Succeed())
 			})
-			Eventually(controlPlaneClient.Update, Timeout, Interval).
-				WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		})
-		By("checking the state to be Warning", func() {
-			Eventually(KymaIsInState, Timeout, Interval).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateWarning).
-				Should(Succeed())
-		})
-
-		By("Kyma status contains expected condition", func() {
-			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(
-				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionFalse)).To(BeTrue())
-		})
-	})
-	It("should result Kyma in Ready state", func() {
-		By("disabling non-existent Module", func() {
-			kyma.Spec.Modules = []v1beta2.Module{}
-			Eventually(controlPlaneClient.Update, Timeout, Interval).
-				WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		})
-		By("checking the state to be Ready", func() {
-			Eventually(KymaIsInState, Timeout, Interval).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
-				Should(Succeed())
-		})
-
-		By("Kyma status contains expected condition", func() {
-			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(
-				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionTrue)).To(BeTrue())
-		})
-	})
-})
-
-var _ = Describe("Kyma enable one Mandatory Module", Ordered, func() {
-	kyma := NewTestKyma("mandatory-module-kyma")
-
-	RegisterDefaultLifecycleForKyma(kyma)
-
-	It("should result Kyma in Warning state", func() {
-		By("enabling one mandatory Module", func() {
-			kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
-				Name: "mandatory-template-operator",
+			By("checking the state to be Warning", func() {
+				Eventually(KymaIsInState, Timeout, Interval).
+					WithContext(ctx).
+					WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateWarning).
+					Should(Succeed())
 			})
-			Eventually(controlPlaneClient.Update, Timeout, Interval).
-				WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		})
-		By("checking the state to be Warning", func() {
-			Eventually(KymaIsInState, Timeout, Interval).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateWarning).
-				Should(Succeed())
-		})
 
-		By("Kyma status contains expected condition", func() {
-			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(
-				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionFalse)).To(BeTrue())
+			By("Kyma status contains expected condition", func() {
+				kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(
+					kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules,
+						apimetav1.ConditionFalse)).To(BeTrue())
+			})
 		})
-	})
-	It("should result Kyma in Ready state", func() {
-		By("disabling one mandatory Module", func() {
-			kyma.Spec.Modules = []v1beta2.Module{}
-			Eventually(controlPlaneClient.Update, Timeout, Interval).
-				WithContext(ctx).WithArguments(kyma).Should(Succeed())
-		})
-		By("checking the state to be Ready", func() {
-			Eventually(KymaIsInState, Timeout, Interval).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
-				Should(Succeed())
-		})
+		It("should result Kyma in Ready state", func() {
+			By(t.disableStatement, func() {
+				kyma.Spec.Modules = []v1beta2.Module{}
+				Eventually(controlPlaneClient.Update, Timeout, Interval).
+					WithContext(ctx).WithArguments(kyma).Should(Succeed())
+			})
+			By("checking the state to be Ready", func() {
+				Eventually(KymaIsInState, Timeout, Interval).
+					WithContext(ctx).
+					WithArguments(kyma.GetName(), kyma.GetNamespace(), controlPlaneClient, shared.StateReady).
+					Should(Succeed())
+			})
 
-		By("Kyma status contains expected condition", func() {
-			kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(
-				kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionTrue)).To(BeTrue())
+			By("Kyma status contains expected condition", func() {
+				kymaInCluster, err := GetKyma(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace())
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(
+					kymaInCluster.ContainsCondition(v1beta2.ConditionTypeModules, apimetav1.ConditionTrue)).To(BeTrue())
+			})
 		})
-	})
+	}
 })
 
 func containsCondition(kyma *v1beta2.Kyma) error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Sets Module and Kyma Status to `Warning` if no template was found for a Module
- Adapt Test case
- Fixed indentation for `By`-statements
    - The statements related to `By` should be inside the `By` call, otherwise if a test fails, the errr message is missleading

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
