### PR TITLE
docs: Use cert-manager 1.13.3 in local test setup script

### DIFF
--- a/docs/developer-tutorials/local-test-setup.md
+++ b/docs/developer-tutorials/local-test-setup.md
@@ -54,7 +54,7 @@ This setup is deployed with the following security features enabled:
    2. `cert-manager` by Jetstack:
 
        ```shell
-       kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+       kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
        ```
 
 4. Deploy Lifecycle Manager on the cluster:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- As we recently aligned to use `1.13.3` cert manager for SRE clusters and e2e tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
