### PR TITLE
chore: Unwrap `apierrors.IsUnauthorized`

### DIFF
--- a/internal/controller/kyma_controller.go
+++ b/internal/controller/kyma_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"

--- a/internal/controller/kyma_controller.go
+++ b/internal/controller/kyma_controller.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
@@ -132,7 +134,7 @@ func (r *KymaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Prevent ETCD load bursts during secret rotation
-	if util.IsUnauthorized(err) {
+	if apierrors.IsUnauthorized(err) {
 		r.deleteRemoteClientCache(ctx, kyma)
 		r.Metrics.RecordRequeueReason(metrics.KymaUnauthorized, queue.UnexpectedRequeue)
 		return ctrl.Result{Requeue: true}, r.updateStatusWithError(ctx, kyma, err)

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -51,11 +51,3 @@ func IsConnectionRefusedOrUnauthorized(err error) bool {
 
 	return errors.Is(err, syscall.ECONNREFUSED) || apierrors.IsUnauthorized(err)
 }
-
-func IsUnauthorized(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return apierrors.IsUnauthorized(err)
-}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removes the custom `pkg/util/error.go#IsUnauthorized` function and uses `k8s.io/apimachinery/pkg/api/errors#IsUnauthorized` directly instead

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
