### PR TITLE
feat: Add k8s version option to e2e

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
-      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.27.10' }}
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.27' }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -97,9 +97,19 @@ jobs:
       - name: Install k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
       - name: Provision SKR cluster
-        run: k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'
+        run: |
+          k3d cluster create skr \
+            -p 10080:80@loadbalancer \
+            -p 10443:443@loadbalancer \
+            --k3s-arg '--disable=traefik@server:0'
       - name: Provision KCP cluster
-        run: k3d cluster create kcp -p 9443:443@loadbalancer -p 9080:80@loadbalancer -p 9081:8080@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0' --registry-create k3d-registry.localhost:0.0.0.0:5111
+        run: |
+          k3d cluster create kcp \
+            -p 9443:443@loadbalancer \
+            -p 9080:80@loadbalancer \
+            -p 9081:8080@loadbalancer \
+            --registry-create k3d-kcp-registry:5111 \
+            --k3s-arg '--disable=traefik@server:0'
       - name: Update Kubeconfigs
         run: k3d kubeconfig merge -a -d
       - name: Export required Kubeconfig Env vars

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
-      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.28.6' }}
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.27.10' }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
-      K8S_VERSION: ${{ github.event.inputs.k8s_version || 1.28.6 }}
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.28.6' }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       k8s_version:
-        description: "Run with specific Kubernetes version"
+        description: "With Kubernetes version"
         required: false
 jobs:
   wait-for-img:
@@ -56,16 +56,13 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
-      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.28.6' }}
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || 1.28.6 }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest
       KLM_IMAGE_REPO: prod
       GOSUMDB: off
     steps:
-      - name: Print k8s version
-        run: | 
-          echo "Running e2e with Kubernetes and kubectl version: ${K8S_VERSION}"
       - name: Install prerequisites
         run: |
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
@@ -100,9 +97,7 @@ jobs:
       - name: Install k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
       - name: Provision SKR cluster
-        run: |
-          k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'
-          echo k3d --version
+        run: k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'
       - name: Provision KCP cluster
         run: |
           kyma provision k3d --name=kcp -p 9443:443@loadbalancer -p 9080:80@loadbalancer -p 9081:8080@loadbalancer --ci --registry-port 5111

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -101,6 +101,7 @@ jobs:
           k3d cluster create skr \
             -p 10080:80@loadbalancer \
             -p 10443:443@loadbalancer \
+            --image rancher/k3s:v$K8S_VERSION-k3s2 \
             --k3s-arg '--disable=traefik@server:0'
       - name: Provision KCP cluster
         run: |
@@ -108,6 +109,7 @@ jobs:
             -p 9443:443@loadbalancer \
             -p 9080:80@loadbalancer \
             -p 9081:8080@loadbalancer \
+            --image rancher/k3s:v$K8S_VERSION-k3s2 \
             --registry-create k3d-kcp-registry:5111 \
             --k3s-arg '--disable=traefik@server:0'
       - name: Update Kubeconfigs

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
-      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.27' }}
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.28.6' }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest
@@ -68,8 +68,8 @@ jobs:
           echo "Running e2e with Kubernetes and kubectl version: ${K8S_VERSION}"
       - name: Install prerequisites
         run: |
-          curl -fsSL https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
           sudo apt install kubectl -y
       - name: Checkout lifecycle-manager

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -65,10 +65,10 @@ jobs:
     steps:
       - name: Print k8s version
         run: | 
-          echo "Running e2e with Kubernetes and kubectl version: $K8S_VERSION"
+          echo "Running e2e with Kubernetes and kubectl version: ${K8S_VERSION}"
       - name: Install prerequisites
         run: |
-          curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
           echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
           sudo apt install kubectl -y
@@ -98,8 +98,7 @@ jobs:
           tar xzf cmctl.tar.gz
           sudo mv cmctl /usr/local/bin
       - name: Install k3d
-        run: |
-          wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
+        run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
       - name: Provision SKR cluster
         run: |
           k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -99,8 +99,7 @@ jobs:
       - name: Provision SKR cluster
         run: k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'
       - name: Provision KCP cluster
-        run: |
-          kyma provision k3d --name=kcp -p 9443:443@loadbalancer -p 9080:80@loadbalancer -p 9081:8080@loadbalancer --ci --registry-port 5111
+        run: k3d cluster create kcp -p 9443:443@loadbalancer -p 9080:80@loadbalancer -p 9081:8080@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0' --registry-create k3d-registry.localhost:0.0.0.0:5111
       - name: Update Kubeconfigs
         run: k3d kubeconfig merge -a -d
       - name: Export required Kubeconfig Env vars

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: "Run with specific Kubernetes version"
+        required: false
 jobs:
   wait-for-img:
     name: "Wait for Image Build"
@@ -51,16 +56,20 @@ jobs:
     timeout-minutes: 20
     env:
       K3D_VERSION: v5.4.7
+      K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.27.10' }}
       ISTIO_VERSION: 1.17.1
       CM_VERSION: v1.13.3
       KLM_VERSION_TAG: latest
       KLM_IMAGE_REPO: prod
       GOSUMDB: off
     steps:
+      - name: Print k8s version
+        run: | 
+          echo "Running e2e with Kubernetes and kubectl version: $K8S_VERSION"
       - name: Install prerequisites
         run: |
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
           sudo apt install kubectl -y
       - name: Checkout lifecycle-manager
@@ -89,10 +98,12 @@ jobs:
           tar xzf cmctl.tar.gz
           sudo mv cmctl /usr/local/bin
       - name: Install k3d
-        run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
+        run: |
+          wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
       - name: Provision SKR cluster
         run: |
-          k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --k3s-arg '--disable=traefik@server:0'
+          k3d cluster create skr -p 10080:80@loadbalancer -p 10443:443@loadbalancer --image rancher/k3s:v$K8S_VERSION-k3s2 --k3s-arg '--disable=traefik@server:0'
+          echo k3d --version
       - name: Provision KCP cluster
         run: |
           kyma provision k3d --name=kcp -p 9443:443@loadbalancer -p 9080:80@loadbalancer -p 9081:8080@loadbalancer --ci --registry-port 5111

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install prerequisites
         run: |
           curl -fsSL https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/Release.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$K8S_VERSION/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt update -y
           sudo apt install kubectl -y
       - name: Checkout lifecycle-manager


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `workflow_dispatch` with optional input for Kubernetes version
- Set default version 1.27.10
- Create k3d cluster with either default or optional version for rancher image
- Available rancher imgs can be found here: https://hub.docker.com/r/rancher/k3s/tags

**Related issue(s)**
* https://github.com/kyma-project/lifecycle-manager/issues/1295
