### PR TITLE
fix: Revert "feat: Add Manifest Reconcile Duration Metric (#1321)"

### DIFF
--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -93,9 +92,6 @@ func newResourcesCondition(obj Object) apimetav1.Condition {
 
 //nolint:funlen,cyclop,gocognit // Declarative pkg will be removed soon
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	reconcileStart := time.Now()
-	defer r.Metrics.ObserveReconcileDuration(reconcileStart, req.NamespacedName.Name)
-
 	obj, ok := r.prototype.DeepCopyObject().(Object)
 	if !ok {
 		r.Metrics.RecordRequeueReason(metrics.ManifestTypeCast, queue.UnexpectedRequeue)

--- a/pkg/testutils/metrics.go
+++ b/pkg/testutils/metrics.go
@@ -12,8 +12,6 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
 )
 
-const reMatchCount = `"} (\d+)`
-
 var ErrMetricNotFound = errors.New("metric was not found")
 
 func GetKymaStateMetricCount(ctx context.Context, kymaName, state string) (int, error) {
@@ -29,7 +27,8 @@ func GetKymaStateMetricCount(ctx context.Context, kymaName, state string) (int, 
 func getKymaStateMetricRegex(kymaName, state string) *regexp.Regexp {
 	return regexp.MustCompile(
 		metrics.MetricKymaState + `{instance_id="[^"]+",kyma_name="` + kymaName +
-			`",shoot="[^"]+",state="` + state + reMatchCount)
+			`",shoot="[^"]+",state="` + state +
+			`"} (\d+)`)
 }
 
 func AssertKymaStateMetricNotFound(ctx context.Context, kymaName, state string) error {
@@ -56,7 +55,8 @@ func GetRequeueReasonCount(ctx context.Context,
 	}
 	re := regexp.MustCompile(
 		metrics.MetricRequeueReason + `{requeue_reason="` + requeueReason +
-			`",requeue_type="` + requeueType + reMatchCount)
+			`",requeue_type="` + requeueType +
+			`"}` + ` (\d+)`)
 	return parseCount(re, bodyString)
 }
 
@@ -69,23 +69,10 @@ func IsManifestRequeueReasonCountIncreased(ctx context.Context, requeueReason, r
 	}
 	re := regexp.MustCompile(
 		metrics.MetricRequeueReason + `{requeue_reason="` + requeueReason +
-			`",requeue_type="` + requeueType + reMatchCount)
+			`",requeue_type="` + requeueType +
+			`"}` + ` (\d+)`)
 	count, err := parseCount(re, bodyString)
 	return count >= 1, err
-}
-
-func IsManifestReconcileDurationCountNonZero(ctx context.Context, manifestName string) (bool,
-	error,
-) {
-	bodyString, err := getMetricsBody(ctx)
-	if err != nil {
-		return false, err
-	}
-	re := regexp.MustCompile(
-		metrics.MetricReconcileDuration + `_count{` + metrics.MetricLabelModule +
-			`="` + manifestName + reMatchCount)
-	count, err := parseCount(re, bodyString)
-	return count > 0, err
 }
 
 func GetModuleStateMetricCount(ctx context.Context, kymaName, moduleName, state string) (int, error) {
@@ -96,7 +83,8 @@ func GetModuleStateMetricCount(ctx context.Context, kymaName, moduleName, state 
 	re := regexp.MustCompile(
 		metrics.MetricModuleState + `{instance_id="[^"]+",kyma_name="` + kymaName +
 			`",module_name="` + moduleName +
-			`",shoot="[^"]+",state="` + state + reMatchCount)
+			`",shoot="[^"]+",state="` + state +
+			`"} (\d+)`)
 	return parseCount(re, bodyString)
 }
 

--- a/tests/e2e/kyma_metrics_test.go
+++ b/tests/e2e/kyma_metrics_test.go
@@ -61,16 +61,6 @@ var _ = Describe("Manage Module Metrics", Ordered, func() {
 				Should(BeTrue())
 		})
 
-		It("Then Related Manifest Duration Metric Is Non Zero", func() {
-			manifest, err := GetManifest(ctx, controlPlaneClient, kyma.GetName(), kyma.GetNamespace(), module.Name)
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(IsManifestReconcileDurationCountNonZero).
-				WithContext(ctx).
-				WithArguments(manifest.Name).
-				Should(BeTrue())
-		})
-
 		It("When Kyma Module is disabled", func() {
 			Eventually(DisableModule).
 				WithContext(ctx).


### PR DESCRIPTION
This reverts commit 2b64c7b77d8b58cbc4ce340aef8eb0068dbbd190.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Reverting the changes because the histogram metric generates huge amount of data 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1069 