### PR TITLE
chore: Remove `r.WatcherVSNamespace` from `WatcherReconciler`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,11 +373,10 @@ func setupKcpWatcherReconciler(mgr ctrl.Manager, options ctrlruntime.Options, fl
 	options.MaxConcurrentReconciles = flagVar.MaxConcurrentWatcherReconciles
 
 	if err := (&controller.WatcherReconciler{
-		Client:             mgr.GetClient(),
-		EventRecorder:      mgr.GetEventRecorderFor(shared.OperatorName),
-		WatcherVSNamespace: flagVar.IstioGatewayNamespace,
-		Scheme:             mgr.GetScheme(),
-		RestConfig:         mgr.GetConfig(),
+		Client:        mgr.GetClient(),
+		EventRecorder: mgr.GetEventRecorderFor(shared.OperatorName),
+		Scheme:        mgr.GetScheme(),
+		RestConfig:    mgr.GetConfig(),
 		RequeueIntervals: queue.RequeueIntervals{
 			Success: flagVar.WatcherRequeueSuccessInterval,
 			Busy:    flags.DefaultKymaRequeueBusyInterval,

--- a/internal/controller/watcher_controller.go
+++ b/internal/controller/watcher_controller.go
@@ -51,7 +51,6 @@ type WatcherReconciler struct {
 	record.EventRecorder
 	IstioClient           *istio.Client
 	VirtualServiceFactory istio.VirtualServiceFactory
-	WatcherVSNamespace    string
 	RestConfig            *rest.Config
 	Scheme                *machineryruntime.Scheme
 	queue.RequeueIntervals
@@ -130,7 +129,7 @@ func (r *WatcherReconciler) stateHandling(ctx context.Context, watcherCR *v1beta
 }
 
 func (r *WatcherReconciler) handleDeletingState(ctx context.Context, watcherCR *v1beta2.Watcher) (ctrl.Result, error) {
-	err := r.IstioClient.DeleteVirtualService(ctx, watcherCR.GetName(), r.WatcherVSNamespace)
+	err := r.IstioClient.DeleteVirtualService(ctx, watcherCR.GetName(), watcherCR.GetNamespace())
 	if err != nil {
 		vsConfigDelErr := fmt.Errorf("failed to delete virtual service (config): %w", err)
 		return r.updateWatcherState(ctx, watcherCR, shared.StateError, vsConfigDelErr)
@@ -157,7 +156,7 @@ func (r *WatcherReconciler) handleProcessingState(ctx context.Context,
 		return r.updateWatcherState(ctx, watcherCR, shared.StateError, err)
 	}
 
-	virtualSvcRemote, err := r.IstioClient.GetVirtualService(ctx, watcherCR.Name, r.WatcherVSNamespace)
+	virtualSvcRemote, err := r.IstioClient.GetVirtualService(ctx, watcherCR.GetName(), watcherCR.GetNamespace())
 	if client.IgnoreNotFound(err) != nil {
 		return r.updateWatcherState(ctx, watcherCR, shared.StateError, err)
 	}

--- a/tests/integration/controller/withwatcher/suite_with_watcher_test.go
+++ b/tests/integration/controller/withwatcher/suite_with_watcher_test.go
@@ -225,12 +225,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controller.WatcherReconciler{
-		Client:             k8sManager.GetClient(),
-		WatcherVSNamespace: kcpSystemNs,
-		RestConfig:         k8sManager.GetConfig(),
-		EventRecorder:      k8sManager.GetEventRecorderFor(controller.WatcherControllerName),
-		Scheme:             k8sclientscheme.Scheme,
-		RequeueIntervals:   intervals,
+		Client:           k8sManager.GetClient(),
+		RestConfig:       k8sManager.GetConfig(),
+		EventRecorder:    k8sManager.GetEventRecorderFor(controller.WatcherControllerName),
+		Scheme:           k8sclientscheme.Scheme,
+		RequeueIntervals: intervals,
 	}).SetupWithManager(
 		k8sManager, ctrlruntime.Options{
 			MaxConcurrentReconciles: 1,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- since `Watcher` is now the owner of `VirtualService`, their namespaces are coupled as [K8s requires owner and dependent to be in the same namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications). Hence, we can get rid of the `WatcherVSNamespace` attribute in `WatcherReconciler`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- small follow-up to https://github.com/kyma-project/lifecycle-manager/pull/1349
