### PR TITLE
fix: Correct inaccurate log message in purge cleanup

### DIFF
--- a/internal/controller/purge_controller.go
+++ b/internal/controller/purge_controller.go
@@ -155,7 +155,7 @@ func (r *PurgeReconciler) handlePurge(ctx context.Context, kyma *v1beta2.Kyma, r
 
 	handledResources, err := r.performCleanup(ctx, remoteClient)
 	if len(handledResources) > 0 {
-		logger.Info("Removed purge finalizer for resources " + strings.Join(handledResources, ", "))
+		logger.Info(fmt.Sprintf("Removed all finalizers for Kyma %s related resources %s", kyma.GetName(), strings.Join(handledResources, ", ")))
 	}
 	if err != nil {
 		return r.handleCleanupError(ctx, kyma, err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fixes an inaccurate log message
  - we are removing all finalizers from the resources, not only the purge finalizer
- also added the Kyma name explicitly to the message for easier overview
  - could also be seen from the context in the full log, but this will give it at one glance

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- follow-up to https://github.com/kyma-project/lifecycle-manager/pull/1392