### PR TITLE
chore: Remove inapplicable `kubebuiler:subresource:status` markers

### DIFF
--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -122,7 +122,6 @@ func (kyma *Kyma) GetModuleStatusMap() map[string]*ModuleStatus {
 }
 
 // KymaStatus defines the observed state of Kyma
-// +kubebuilder:subresource:status
 type KymaStatus struct {
 	// State signifies current state of Kyma.
 	// Value can be one of ("Ready", "Processing", "Error", "Deleting").

--- a/api/v1beta2/watcher_types.go
+++ b/api/v1beta2/watcher_types.go
@@ -79,7 +79,6 @@ type Service struct {
 }
 
 // WatcherStatus defines the observed state of Watcher.
-// +kubebuilder:subresource:status
 type WatcherStatus struct {
 	// State signifies current state of a Watcher.
 	// Value can be one of ("Ready", "Processing", "Error", "Deleting", "Warning")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removes inapplicable `kubebuiler:subresource:status` markers from `WatcherStatus` and `KymaStatus`
  - kubebuilder assigns a clear meaning behind subresource:status (see [here](https://book.kubebuilder.io/reference/generating-crd.html?highlight=subresource#subresources), and [here](https://book-v1.book.kubebuilder.io/basics/status_subresource))
  - the proper `kubebuilder:subresource:status` markers for Kyma and Watcher are [here](https://github.com/kyma-project/lifecycle-manager/blob/main/api/v1beta2/kyma_types.go#L30) and [here](https://github.com/kyma-project/lifecycle-manager/blob/main/api/v1beta2/watcher_types.go#L101)
  - applying them again on the `XXXStatus struct` seems unintended and does not yield any changes in the generated CRDs (re-ran `make manifests` and [`subresources` field](https://github.com/kyma-project/lifecycle-manager/blob/main/config/crd/bases/operator.kyma-project.io_kymas.yaml#L859-L860) in generated CRD remain unchanged)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.com/kyma-project/lifecycle-manager/pull/1418#discussion_r1537405350
