### PR TITLE
fix: Race condition in drop stored versions

### DIFF
--- a/internal/crd/storage_version_dropper.go
+++ b/internal/crd/storage_version_dropper.go
@@ -15,12 +15,11 @@ import (
 
 const resourceVersionPairCount = 2
 
-func DropStoredVersion(kcpClient client.Client, versionsToBeDropped string) {
+func DropStoredVersion(ctx context.Context, kcpClient client.Client, versionsToBeDropped string) {
 	logger := ctrl.Log.WithName("storage-version-migration")
 	versionsToBeDroppedMap := ParseStorageVersionsMap(versionsToBeDropped)
 	logger.V(log.DebugLevel).Info(fmt.Sprintf("Handling dropping stored versions for, %v",
 		versionsToBeDroppedMap))
-	ctx := context.TODO()
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 	if err := kcpClient.List(ctx, crdList); err != nil {
 		logger.V(log.InfoLevel).Error(err, "unable to list CRDs")

--- a/internal/crd/storage_version_dropper_test.go
+++ b/internal/crd/storage_version_dropper_test.go
@@ -64,7 +64,7 @@ func TestDropStoredVersion(t *testing.T) {
 	scheme := machineryruntime.NewScheme()
 	_ = apiextensionsv1.AddToScheme(scheme)
 	fakeClientBuilder := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(currentCrds...).Build()
-	crd.DropStoredVersion(fakeClientBuilder, versionToBeDropped)
+	crd.DropStoredVersion(context.TODO(), fakeClientBuilder, versionToBeDropped)
 
 	var updatedCRD apiextensionsv1.CustomResourceDefinition
 	err := fakeClientBuilder.Get(context.TODO(), client.ObjectKey{Name: "Manifest"}, &updatedCRD)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fixes security scan reports wrt. race conditions for `mgr`, `err` and `setupLog` in the goroutine for dropping stored versions
- aligns the goroutine for scheduling the metrics cleanup with the findings above
  - just to be sure, we also wait for the cache to sync

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.com/kyma-project/lifecycle-manager/pull/1403#issuecomment-2031756813

**Comments**

No additional tests as the helpers (`crd.DropStoredVersion`, `kymaMetrics.CleanupNonExistingKymaCrsMetrics`) are already tested. Not sure if worth trying to test the setup in main.

---

Routines execute as expected:

```sh
[...]
{"level":"LEVEL(-2)","date":"2024-04-03T13:49:13.750383456Z","logger":"storage-version-migration","caller":"crd/storage_version_dropper.go:21","msg":"Handling dropping stored versions for, map[Kyma:v1beta1 Manifest:v1beta1 ModuleTemplate:v1beta1 Watcher:v1beta1]","context":{}}
{"level":"INFO","date":"2024-04-03T13:49:13.750443873Z","logger":"controller-runtime.certwatcher","caller":"certwatcher/certwatcher.go:161","msg":"Updated current TLS certificate","context":{}}
{"level":"LEVEL(-2)","date":"2024-04-03T13:49:13.750666877Z","logger":"setup","caller":"cmd/main.go:238","msg":"scheduled job for cleaning up metrics","context":{}}
[...]
```
