### PR TITLE
chore: Sum count to avoid having multiple gauges

### DIFF
--- a/config/grafana/status.json
+++ b/config/grafana/status.json
@@ -16,7 +16,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 14,
   "links": [],
   "panels": [
     {
@@ -460,7 +459,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "lifecycle_mgr_mandatory_modules",
+          "expr": "sum(lifecycle_mgr_mandatory_modules)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When KLM restarts, then we have multiple Gauges which is not needed.

Before:
<img width="825" alt="Screenshot 2024-03-27 at 13 23 50" src="https://github.com/kyma-project/lifecycle-manager/assets/48282931/9114ea18-3251-4cbc-beca-acd2588ce8ca">


After: 
<img width="229" alt="Screenshot 2024-03-27 at 13 23 28" src="https://github.com/kyma-project/lifecycle-manager/assets/48282931/511e802a-c445-4785-92fe-471b9a201330">

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
