### PR TITLE
chore: Add skr args input to setup test clusters action

### DIFF
--- a/.github/actions/setup-test-clusters/action.yaml
+++ b/.github/actions/setup-test-clusters/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         cluster_name: skr
         k8s_version: ${{ inputs.k8s_version }}
-        args: "-p 10080:80@loadbalancer;${{ inputs.additional_skr_args }}"
+        args: "-p 10080:80@loadbalancer;-p 10443:443@loadbalancer;${{ inputs.additional_skr_args }}"
     - uses: ./lifecycle-manager/.github/actions/create-k3d-cluster
       with:
         cluster_name: kcp

--- a/.github/actions/setup-test-clusters/action.yaml
+++ b/.github/actions/setup-test-clusters/action.yaml
@@ -7,6 +7,9 @@ inputs:
   cert_manager_version:
     description: The version of cert-manager to depoy. For example, 1.13.3.
     required: true
+  additional_skr_args:
+    description: Additional arguments to pass to the k3d create command for the SKR cluster separated by semicolon (;).
+    required: false
 runs:
   using: composite
   steps:
@@ -15,7 +18,7 @@ runs:
       with:
         cluster_name: skr
         k8s_version: ${{ inputs.k8s_version }}
-        args: "-p 10080:80@loadbalancer;-p 10443:443@loadbalancer"
+        args: "-p 10080:80@loadbalancer;-p 10443:443@loadbalancer;${{ inputs.additional_skr_args }}"
     - uses: ./lifecycle-manager/.github/actions/create-k3d-cluster
       with:
         cluster_name: kcp

--- a/.github/actions/setup-test-clusters/action.yaml
+++ b/.github/actions/setup-test-clusters/action.yaml
@@ -18,7 +18,7 @@ runs:
       with:
         cluster_name: skr
         k8s_version: ${{ inputs.k8s_version }}
-        args: "-p 10080:80@loadbalancer;-p 10443:443@loadbalancer;${{ inputs.additional_skr_args }}"
+        args: "-p 10080:80@loadbalancer;${{ inputs.additional_skr_args }}"
     - uses: ./lifecycle-manager/.github/actions/create-k3d-cluster
       with:
         cluster_name: kcp

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -78,7 +78,6 @@ jobs:
         with:
           k8s_version: ${{ steps.configuration.outputs.k8s_version }}
           cert_manager_version: ${{ steps.configuration.outputs.cert_manager_version }}
-          additional_skr_args: -p 10443:443@loadbalancer
 
       - name: Deploy lifecycle-manager
         uses: ./lifecycle-manager/.github/actions/deploy-lifecycle-manager-e2e

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -78,6 +78,7 @@ jobs:
         with:
           k8s_version: ${{ steps.configuration.outputs.k8s_version }}
           cert_manager_version: ${{ steps.configuration.outputs.cert_manager_version }}
+          additional_skr_args: -p 10443:443@loadbalancer
 
       - name: Deploy lifecycle-manager
         uses: ./lifecycle-manager/.github/actions/deploy-lifecycle-manager-e2e


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds an input to the setup test clusters action allowing to pass additional arguments for the SKR cluster creation
  - this is needed for re-use within watcher since in watcher we expose an additional set of ports

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- partially resolves kyma-project/lifecycle-manager#1224
