### PR TITLE
fix: Use the wait for image action for smoke test pipeline

### DIFF
--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -4,23 +4,15 @@ on:
   pull_request:
     branches: [ "main" ]
 jobs:
-  wait-for-img:
-    name: "Wait for Image Build"
+  wait-for-image-build:
+    name: Wait for image build
     runs-on: ubuntu-latest
     steps:
-      - uses: autotelic/action-wait-for-status-check@v1
-        id: wait-for-build
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/wait-for-image-build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Context for which we should look for the matching status
-          statusName: ${{ (github.event_name == 'pull_request') && 'pull-lifecycle-mgr-build' || 'main-lifecycle-mgr-build' }}
-          timeoutSeconds: 600
-          intervalSeconds: 10
-      - name: Exit If Failing Build Requirement
-        if: steps.wait-for-build.outputs.state != 'success'
-        run: |
-          echo "Image build did not succeed, skipping Smoke Test!"
-          exit 1
+          statusName: pull-lifecycle-mgr-build
 
   kustomize:
     strategy:
@@ -50,7 +42,7 @@ jobs:
       matrix:
         cli-stability: ["unstable"]
         target: ["default", "control-plane"]
-    needs: [kustomize,wait-for-img]
+    needs: [kustomize,wait-for-image-build]
     name: "kyma (${{ matrix.cli-stability }}) alpha deploy -k config/${{ matrix.target }}"
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use the wait for build action in the smoke test GitHub workflow
