### PR TITLE
chore: Bump 'Wait for image build' `timeoutSeconds` default

### DIFF
--- a/.github/actions/wait-for-image-build/action.yaml
+++ b/.github/actions/wait-for-image-build/action.yaml
@@ -10,7 +10,7 @@ inputs:
   timeoutSeconds:
     description: The number of seconds to wait for the status check to complete.
     required: false
-    default: "900"
+    default: "1200"
   intervalSeconds:
     description: The number of seconds to wait before each poll of the GitHub API.
     required: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Should fix flaky tests which time out after migrating to ADO build pipeline

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
