### PR TITLE
chore: Move klm-metrics-rolebinding to kcp-system namespace

### DIFF
--- a/config/rbac/namespace_bindings/metrics_role_binding.yaml
+++ b/config/rbac/namespace_bindings/metrics_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-rolebinding
-  namespace: kyma-system
+  namespace: kcp-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/e2e/rbac_privileges_test.go
+++ b/tests/e2e/rbac_privileges_test.go
@@ -34,7 +34,7 @@ var _ = Describe("RBAC Privileges", func() {
 			kcpSystemKlmRoleBindings, err := ListKlmRoleBindings(controlPlaneClient, ctx, "klm-controller-manager",
 				"kcp-system")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(kcpSystemKlmRoleBindings.Items).To(HaveLen(3))
+			Expect(kcpSystemKlmRoleBindings.Items).To(HaveLen(4))
 
 			leaderElectionRoleRules := []apirbacv1.PolicyRule{
 				{
@@ -171,6 +171,15 @@ var _ = Describe("RBAC Privileges", func() {
 			Expect(GetRoleBindingwithClusterRolePolicyRules(ctx, controlPlaneClient, "klm-manager-role-manifest",
 				kcpSystemKlmRoleBindings)).To(Equal(manifestRoleRules))
 
+			metricsReaderRoleRules := []apirbacv1.PolicyRule{
+				{
+					NonResourceURLs: []string{"/metrics"},
+					Verbs:           []string{"get"},
+				},
+			}
+			Expect(GetRoleBindingwithClusterRolePolicyRules(ctx, controlPlaneClient, "klm-metrics-reader",
+				kcpSystemKlmRoleBindings)).To(Equal(metricsReaderRoleRules))
+
 			By("And KLM Service Account has the correct RoleBindings in istio-system namespaces")
 			istioSystemKlmRoleBindings, err := ListKlmRoleBindings(controlPlaneClient, ctx, "klm-controller-manager",
 				"istio-system")
@@ -184,19 +193,10 @@ var _ = Describe("RBAC Privileges", func() {
 			kymaSystemKlmRoleBindings, err := ListKlmRoleBindings(controlPlaneClient, ctx, "klm-controller-manager",
 				"kyma-system")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(kymaSystemKlmRoleBindings.Items).To(HaveLen(2))
+			Expect(kymaSystemKlmRoleBindings.Items).To(HaveLen(1))
 
 			Expect(GetRoleBindingwithClusterRolePolicyRules(ctx, controlPlaneClient, "klm-manager-role",
 				kymaSystemKlmRoleBindings)).To(Equal(klmManagerRoleRules))
-
-			metricsReaderRoleRules := []apirbacv1.PolicyRule{
-				{
-					NonResourceURLs: []string{"/metrics"},
-					Verbs:           []string{"get"},
-				},
-			}
-			Expect(GetRoleBindingwithClusterRolePolicyRules(ctx, controlPlaneClient, "klm-metrics-reader",
-				kymaSystemKlmRoleBindings)).To(Equal(metricsReaderRoleRules))
 		})
 	})
 })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- moves the `klm-metrics-rolebinding` from `kyma-system` to `kcp-system` namespace
  - `kyma-system` namespace should not hold any resources on KCP

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- related to our helm setup where we already fixed this