### PR TITLE
chore: Bump golang consistently to 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.3-alpine as builder
+FROM golang:1.22.4-alpine as builder
 
 WORKDIR /lifecycle-manager
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/api
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager
 
-go 1.22.2
+go 1.22.4
 
 replace github.com/kyma-project/lifecycle-manager/api => ./api
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bumps golang consistently between go config and docker image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- supersedes: https://github.com/kyma-project/lifecycle-manager/pull/1608
