### PR TITLE
feat: Plutono configuration for displaying Enabled Modules in KCP

### DIFF
--- a/config/grafana/status.json
+++ b/config/grafana/status.json
@@ -34,7 +34,7 @@
     },
     {
       "datasource": null,
-      "description": "This panel provides information on Which modules are enabled on the KCP and the number of their respective instances.",
+      "description": "This panel provides information on which modules are enabled on the KCP and their respective instance counts.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -47,10 +47,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 250
               }
             ]
           }

--- a/config/grafana/status.json
+++ b/config/grafana/status.json
@@ -33,6 +33,66 @@
       "type": "row"
     },
     {
+      "datasource": null,
+      "description": "This panel provides information on Which modules are enabled on the KCP and the number of their respective instances.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 250
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.31",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (module_name) (lifecycle_mgr_module_state)",
+          "interval": "",
+          "legendFormat": "{{module_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Enabled Modules",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -48,7 +108,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 11
       },
       "hiddenSeries": false,
       "id": 2,
@@ -68,7 +128,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.31",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -176,7 +236,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 21
       },
       "hiddenSeries": false,
       "id": 5,
@@ -196,7 +256,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.31",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -304,7 +364,7 @@
         "h": 10,
         "w": 18,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 6,
@@ -324,7 +384,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.31",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -440,7 +500,7 @@
         "h": 10,
         "w": 6,
         "x": 18,
-        "y": 21
+        "y": 31
       },
       "id": 8,
       "options": {
@@ -455,7 +515,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.31",
       "targets": [
         {
           "exemplar": true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Added the configuration for the Plutono dashboard under the `Kyma State Overview` to include the new view, which contains all the enabled modules and their respective active instances.

**Related issue(s)**
Resolves #1528
