### PR TITLE
chore: Revert "feat: Introduce `managed` flag to KymaCR `.spec.modules` (#1652)"

### DIFF
--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -85,11 +85,6 @@ type Module struct {
 
 	// +kubebuilder:default:=CreateAndDelete
 	CustomResourcePolicy `json:"customResourcePolicy,omitempty"`
-
-	// Managed is determining whether the module is managed or not. If the module is unmanaged, the user is responsible
-	// for the lifecycle of the module.
-	// +kubebuilder:default:=true
-	Managed bool `json:"managed"`
 }
 
 // CustomResourcePolicy determines how a ModuleTemplate should be parsed. When CustomResourcePolicy is set to

--- a/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -84,12 +84,6 @@ spec:
                       - CreateAndDelete
                       - Ignore
                       type: string
-                    managed:
-                      default: true
-                      description: |-
-                        Managed is determining whether the module is managed or not. If the module is unmanaged, the user is responsible
-                        for the lifecycle of the module.
-                      type: boolean
                     name:
                       description: |-
                         Name is a unique identifier of the module.
@@ -107,7 +101,6 @@ spec:
                         It will be removed in the upcoming API version.
                       type: string
                   required:
-                  - managed
                   - name
                   type: object
                 type: array
@@ -527,12 +520,6 @@ spec:
                       - CreateAndDelete
                       - Ignore
                       type: string
-                    managed:
-                      default: true
-                      description: |-
-                        Managed is determining whether the module is managed or not. If the module is unmanaged, the user is responsible
-                        for the lifecycle of the module.
-                      type: boolean
                     name:
                       description: |-
                         Name is a unique identifier of the module.
@@ -550,7 +537,6 @@ spec:
                         It will be removed in the upcoming API version.
                       type: string
                   required:
-                  - managed
                   - name
                   type: object
                 type: array

--- a/docs/technical-reference/api/kyma-cr.md
+++ b/docs/technical-reference/api/kyma-cr.md
@@ -100,38 +100,11 @@ The module mentioned above can be referenced in one of the following ways:
       - name: kyma-project.io/module/sample
     ```
 
-### **.spec.modules[].managed**
-
-For each module, it must be defined whether it is `managed` or `unmanaged`.
-If it is `managed`, Lifecycle Manager takes care of the module's lifecycle (creating, updating, deleting).
-If it is `unmanaged`, Lifecycle Manager ignores the module and the users must take care of the lifecycle themselves.
-To define this, the **managed** flag must be either `true` or `false`.
-By default, the **managed** flag is set to `true` and the module is therefore `managed` by Lifecycle Manager.
-
-```yaml
-spec:
-  channel: regular
-  modules:
-  - name: module-name-from-label
-    managed: true
-```
-
 ### **.spec.modules[].customResourcePolicy**
 
-A module may be initialized with preconfigured default data.
-To control the configuration, use the **customResourcePolicy** flag.
-The value can either be `CreateAndDelete` or `Ignore`.
+In addition to this very flexible way of referencing modules, there is also another flag that can be important for users requiring more flexibility during module initialization. The `customResourcePolicy` flag is used to define one of `CreateAndDelete` and `Ignore`.
 While `CreateAndDelete` causes the ModuleTemplate CR's **.spec.data** to be created and deleted to initialize a module with preconfigured defaults, `Ignore` can be used to only initialize the operator without initializing any default data.
 This allows users to be fully flexible in regard to when and how to initialize their module.
-By default, the **customResourcePolicy** flag is `CreateAndDelete` which makes the module preconfigured.
-
-```yaml
-spec:
-  channel: regular
-  modules:
-  - name: module-name-from-label
-    customResourcePolicy: CreateAndDelete
-```
 
 ### **.status.state**
 


### PR DESCRIPTION


This reverts commit b71285ff894f3407d15f493dcd01196beb3dbd3e.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- reverting the introduction of the field so that we can create a feature branch for the whole deletion mode feature
- reverting before branching of (and re-introeducing the field in the new branch) because otherwise we would get some troubles when rebasing the feature branch in the future to catch up in main

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- resolves https://github.com/kyma-project/lifecycle-manager/issues/1566
