### PR TITLE
chore: Bump k8s version for e2e to 1.29.6

### DIFF
--- a/.github/actions/get-configuration/action.yaml
+++ b/.github/actions/get-configuration/action.yaml
@@ -26,7 +26,7 @@ runs:
       id: define-variables
       shell: bash
       run: |
-        echo "k8s_version=${{ github.event.inputs.k8s_version || '1.28.7' }}" >> $GITHUB_OUTPUT
+        echo "k8s_version=${{ github.event.inputs.k8s_version || '1.29.6' }}" >> $GITHUB_OUTPUT
         echo "istio_version=1.20.3" >> $GITHUB_OUTPUT
         echo "k3d_version=5.6.0" >> $GITHUB_OUTPUT
         echo "cert_manager_version=1.15.0" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./.github/actions/wait-for-image-build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          statusName: pull-lifecycle-mgr-build
+          statusName: ${{ (github.event_name == 'pull_request') && 'pull-lifecycle-mgr-build' || 'main-lifecycle-mgr-build' }}
   e2e-integration:
     name: E2E
     needs: wait-for-image-build

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       LIFECYCLE_MANAGER: ${{ github.repository }}
       K3D_VERSION: v5.6.0
-      K8S_VERSION: v1.28.7
+      K8S_VERSION: v1.29.6
       KUSTOMIZE_VERSION: 5.3.0
       ISTIO_VERSION: 1.20.3
       GOSUMDB: off


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump k8s version to 1.29.6 for smoke and e2e test suites
- Introduce wait to img build on main builds for dispatch workflows

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
