### PR TITLE
chore: Increase cert key size to '4096'

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -334,6 +334,7 @@ func createSkrWebhookManager(mgr ctrl.Manager, skrContextFactory remote.SkrConte
 		AdditionalDNSNames:  strings.Split(flagVar.AdditionalDNSNames, ","),
 		Duration:            flagVar.SelfSignedCertDuration,
 		RenewBefore:         flagVar.SelfSignedCertRenewBefore,
+		KeySize:             flagVar.SelfSignedCertKeySize,
 	}
 	gatewayConfig := watcher.GatewayConfig{
 		IstioGatewayName:          flagVar.IstioGatewayName,

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,4 +54,3 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
----

--- a/config/watcher/certificate_setup.yaml
+++ b/config/watcher/certificate_setup.yaml
@@ -25,6 +25,7 @@ spec:
       operator.kyma-project.io/managed-by: "lifecycle-manager"
   privateKey:
     algorithm: RSA
+    size: 4096
   issuerRef:
     name: klm-watcher-selfsigned
     kind: ClusterIssuer

--- a/config/watcher/certificate_setup.yaml
+++ b/config/watcher/certificate_setup.yaml
@@ -24,6 +24,7 @@ spec:
     labels:
       operator.kyma-project.io/managed-by: "lifecycle-manager"
   privateKey:
+    rotationPolicy: Always
     algorithm: RSA
     size: 4096
   issuerRef:

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -45,6 +45,7 @@ const (
 	DefaultSelfSignedCertDuration                         time.Duration = 90 * 24 * time.Hour
 	DefaultSelfSignedCertRenewBefore                      time.Duration = 60 * 24 * time.Hour
 	DefaultSelfSignedCertificateRenewBuffer                             = 24 * time.Hour
+	DefaultSelfSignedCertKeySize                                        = 4096
 	DefaultRemoteSyncNamespace                                          = "kyma-system"
 	DefaultMetricsAddress                                               = ":8080"
 	DefaultProbeAddress                                                 = ":8081"
@@ -62,9 +63,10 @@ const (
 )
 
 var (
-	errMissingWatcherImageTag      = errors.New("runtime watcher image tag is not provided")
-	errWatcherDirNotExist          = errors.New("failed to locate watcher resource manifest folder")
-	errLeaderElectionTimeoutConfig = errors.New("configured leader-election-renew-deadline must be less than leader-election-lease-duration")
+	errMissingWatcherImageTag         = errors.New("runtime watcher image tag is not provided")
+	errWatcherDirNotExist             = errors.New("failed to locate watcher resource manifest folder")
+	errLeaderElectionTimeoutConfig    = errors.New("configured leader-election-renew-deadline must be less than leader-election-lease-duration")
+	errInvalidSelfSignedCertKeyLenght = errors.New("invalid self-signed-cert-key-size: must be 4096")
 )
 
 //nolint:funlen // defines all program flags
@@ -198,6 +200,8 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.SelfSignedCertRenewBuffer, "self-signed-cert-renew-buffer",
 		DefaultSelfSignedCertificateRenewBuffer,
 		"The buffer duration to wait before confirm self-signed certificate not renewed")
+	flag.IntVar(&flagVar.SelfSignedCertKeySize, "self-signed-cert-key-size", DefaultSelfSignedCertKeySize,
+		"The key size for the self-signed certificate")
 	flag.BoolVar(&flagVar.IsKymaManaged, "is-kyma-managed", false, "indicates whether Kyma is managed")
 	flag.StringVar(&flagVar.DropStoredVersion, "drop-stored-version", DefaultDropStoredVersion,
 		"The API version to be dropped from the storage versions")
@@ -275,6 +279,7 @@ type FlagVar struct {
 	SelfSignedCertDuration                 time.Duration
 	SelfSignedCertRenewBefore              time.Duration
 	SelfSignedCertRenewBuffer              time.Duration
+	SelfSignedCertKeySize                  int
 	DropStoredVersion                      string
 	DropCrdStoredVersionMap                string
 	UseWatcherDevRegistry                  bool
@@ -298,6 +303,14 @@ func (f FlagVar) Validate() error {
 
 	if f.LeaderElectionRenewDeadline >= f.LeaderElectionLeaseDuration {
 		return fmt.Errorf("%w (%.1f[s])", errLeaderElectionTimeoutConfig, f.LeaderElectionLeaseDuration.Seconds())
+	}
+
+	if !map[int]bool{
+		2048: false, // 2048 is a valid value for cert-manager, but explicitly prohibited as not compliant to security requirements
+		4096: true,
+		8192: false, // see https://github.com/kyma-project/lifecycle-manager/issues/1793
+	}[f.SelfSignedCertKeySize] {
+		return errInvalidSelfSignedCertKeyLenght
 	}
 
 	return nil

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -194,6 +194,11 @@ func Test_ConstantFlags(t *testing.T) {
 			expectedValue: (24 * time.Hour).String(),
 		},
 		{
+			constName:     "DefaultSelfSignedCertKeySize",
+			constValue:    strconv.Itoa(int(DefaultSelfSignedCertKeySize)),
+			expectedValue: "4096",
+		},
+		{
 			constName:     "DefaultMetricsAddress",
 			constValue:    DefaultMetricsAddress,
 			expectedValue: ":8080",

--- a/pkg/watcher/certificate_manager.go
+++ b/pkg/watcher/certificate_manager.go
@@ -21,9 +21,6 @@ import (
 )
 
 const (
-	// private key will only be generated if one does not already exist in the target `spec.secretName`.
-	privateKeyRotationPolicy = "Never"
-
 	DomainAnnotation = shared.SKRDomainAnnotation
 
 	caCertKey        = "ca.crt"
@@ -66,6 +63,7 @@ type CertificateConfig struct {
 	Duration           time.Duration
 	RenewBefore        time.Duration
 	RenewBuffer        time.Duration
+	KeySize            int
 }
 
 type CertificateSecret struct {
@@ -206,9 +204,10 @@ func (c *CertificateManager) patchCertificate(ctx context.Context,
 				certmanagerv1.UsageKeyEncipherment,
 			},
 			PrivateKey: &certmanagerv1.CertificatePrivateKey{
-				RotationPolicy: privateKeyRotationPolicy,
+				RotationPolicy: certmanagerv1.RotationPolicyAlways,
 				Encoding:       certmanagerv1.PKCS1,
 				Algorithm:      certmanagerv1.RSAKeyAlgorithm,
+				Size:           c.config.KeySize,
 			},
 		},
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- increases root cert key size to 4096
- increases client cert key size to 4096
  - also makes this configurable by flag and prevent invalid / (currently) not supported values
- sets rotation policy to Always

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- closes https://github.com/kyma-project/lifecycle-manager/issues/1771
