### PR TITLE
fix: Set manifest to deleting state; Raise errors on unexpected manager conditions

### DIFF
--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -360,6 +360,10 @@ func (r *Reconciler) syncResources(ctx context.Context, clnt Client, manifest *v
 		}
 	}
 
+	if !manifest.GetDeletionTimestamp().IsZero() {
+		return r.setManifestState(manifest, shared.StateDeleting)
+	}
+
 	managerState, err := r.checkManagerState(ctx, clnt, target)
 	if err != nil {
 		manifest.SetStatus(status.WithState(shared.StateError).WithErr(err))
@@ -393,14 +397,9 @@ func (r *Reconciler) checkManagerState(ctx context.Context, clnt Client, target 
 	error,
 ) {
 	managerReadyCheck := r.CustomStateCheck
-
 	managerState, err := managerReadyCheck.GetState(ctx, clnt, target)
 	if err != nil {
 		return shared.StateError, err
-	}
-
-	if managerState == shared.StateProcessing {
-		return shared.StateProcessing, nil
 	}
 
 	return managerState, nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Updates the control flow in state check to return explicit errors on unexpected conditions, i.e., no manager found, fallthrough
- Updates the control flow in reconciler to exit early with state Deleting when manifest has a deletion timestamp

> The fallthrough case is not testable unfortunately. We may be able to get rid of it in the proposed further refactoring in the future.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- follow-up to https://github.com/kyma-project/lifecycle-manager/pull/1807
