### PR TITLE
chore: Prevent E2E tests from failing fast

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -25,6 +25,7 @@ jobs:
     name: E2E
     needs: wait-for-image-build
     strategy:
+      fail-fast: false
       matrix:
         e2e-test:
           - watcher-enqueue


### PR DESCRIPTION
We often have one E2E test failing which cancels all other ongoing executions of E2E tests. Since our E2E tests are independent of each other, I would propose to not fail them fast. It would be good to know if only one test fails or multiple are affected by a change. And when re-running all tests, we have increased exposure to flakyness when re-running all tests.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures