### PR TITLE
feat: Remove kyma.spec.modules[].version from api

### DIFF
--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -80,7 +80,9 @@ type Module struct {
 	// ModuleTemplate based on this specific version.
 	// The Version and Channel are mutually exclusive options.
 	// The regular expression come from here: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	Version string `json:"-"`
+        // json:"-" to disable installation of specific versions until decided to roll this out
+        // see https://github.com/kyma-project/lifecycle-manager/issues/1847
+        Version string `json:"-"`
 
 	// RemoteModuleTemplateRef is deprecated and will no longer have any functionality.
 	// It will be removed in the upcoming API version.

--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -71,7 +71,6 @@ type Module struct {
 
 	// Channel is the desired channel of the Module. If this changes or is set, it will be used to resolve a new
 	// ModuleTemplate based on the new resolved resources.
-	// The Version and Channel are mutually exclusive options.
 	// +kubebuilder:validation:Pattern:=^[a-z]+$
 	// +kubebuilder:validation:MaxLength:=32
 	// +kubebuilder:validation:MinLength:=3
@@ -81,8 +80,7 @@ type Module struct {
 	// ModuleTemplate based on this specific version.
 	// The Version and Channel are mutually exclusive options.
 	// The regular expression come from here: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	// +kubebuilder:validation:Pattern:=`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
-	Version string `json:"version,omitempty"`
+	Version string `json:"-"`
 
 	// RemoteModuleTemplateRef is deprecated and will no longer have any functionality.
 	// It will be removed in the upcoming API version.

--- a/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -64,7 +64,6 @@ spec:
                       description: |-
                         Channel is the desired channel of the Module. If this changes or is set, it will be used to resolve a new
                         ModuleTemplate based on the new resolved resources.
-                        The Version and Channel are mutually exclusive options.
                       maxLength: 32
                       minLength: 3
                       pattern: ^[a-z]+$
@@ -97,14 +96,6 @@ spec:
                       description: |-
                         RemoteModuleTemplateRef is deprecated and will no longer have any functionality.
                         It will be removed in the upcoming API version.
-                      type: string
-                    version:
-                      description: |-
-                        Version is the desired version of the Module. If this changes or is set, it will be used to resolve a new
-                        ModuleTemplate based on this specific version.
-                        The Version and Channel are mutually exclusive options.
-                        The regular expression come from here: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-                      pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
                       type: string
                   required:
                   - name
@@ -506,7 +497,6 @@ spec:
                       description: |-
                         Channel is the desired channel of the Module. If this changes or is set, it will be used to resolve a new
                         ModuleTemplate based on the new resolved resources.
-                        The Version and Channel are mutually exclusive options.
                       maxLength: 32
                       minLength: 3
                       pattern: ^[a-z]+$
@@ -539,14 +529,6 @@ spec:
                       description: |-
                         RemoteModuleTemplateRef is deprecated and will no longer have any functionality.
                         It will be removed in the upcoming API version.
-                      type: string
-                    version:
-                      description: |-
-                        Version is the desired version of the Module. If this changes or is set, it will be used to resolve a new
-                        ModuleTemplate based on this specific version.
-                        The Version and Channel are mutually exclusive options.
-                        The regular expression come from here: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-                      pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
                       type: string
                   required:
                   - name

--- a/tests/e2e/module_install_by_version_test.go
+++ b/tests/e2e/module_install_by_version_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Module Install By Version", Ordered, func() {
 
 	Context("Given SKR Cluster", func() {
 		It("When Template-Operator Module is enabled on SKR Kyma CR in a specific version", func() {
+			Skip("Version attribute is disabled for now on the CRD level")
 			Eventually(EnableModule).
 				WithContext(ctx).
 				WithArguments(runtimeClient, defaultRemoteKymaName, RemoteNamespace, templateOperatorModule).
@@ -29,6 +30,7 @@ var _ = Describe("Module Install By Version", Ordered, func() {
 		})
 
 		It("Then Module CR exists", func() {
+			Skip("Version attribute is disabled for now on the CRD level")
 			Eventually(ModuleCRExists).
 				WithContext(ctx).
 				WithArguments(runtimeClient, moduleCR).

--- a/tests/e2e/module_install_by_version_test.go
+++ b/tests/e2e/module_install_by_version_test.go
@@ -21,14 +21,16 @@ var _ = Describe("Module Install By Version", Ordered, func() {
 	CleanupKymaAfterAll(kyma)
 
 	Context("Given SKR Cluster", func() {
-		Skip("When Template-Operator Module is enabled on SKR Kyma CR in a specific version", func() {
+		It("When Template-Operator Module is enabled on SKR Kyma CR in a specific version", func() {
+			Skip("Version attribute is disabled for now on the CRD level")
 			Eventually(EnableModule).
 				WithContext(ctx).
 				WithArguments(runtimeClient, defaultRemoteKymaName, RemoteNamespace, templateOperatorModule).
 				Should(Succeed())
 		})
 
-		Skip("Then Module CR exists", func() {
+		It("Then Module CR exists", func() {
+			Skip("Version attribute is disabled for now on the CRD level")
 			Eventually(ModuleCRExists).
 				WithContext(ctx).
 				WithArguments(runtimeClient, moduleCR).

--- a/tests/e2e/module_install_by_version_test.go
+++ b/tests/e2e/module_install_by_version_test.go
@@ -21,16 +21,14 @@ var _ = Describe("Module Install By Version", Ordered, func() {
 	CleanupKymaAfterAll(kyma)
 
 	Context("Given SKR Cluster", func() {
-		It("When Template-Operator Module is enabled on SKR Kyma CR in a specific version", func() {
-			Skip("Version attribute is disabled for now on the CRD level")
+		Skip("When Template-Operator Module is enabled on SKR Kyma CR in a specific version", func() {
 			Eventually(EnableModule).
 				WithContext(ctx).
 				WithArguments(runtimeClient, defaultRemoteKymaName, RemoteNamespace, templateOperatorModule).
 				Should(Succeed())
 		})
 
-		It("Then Module CR exists", func() {
-			Skip("Version attribute is disabled for now on the CRD level")
+		Skip("Then Module CR exists", func() {
 			Eventually(ModuleCRExists).
 				WithContext(ctx).
 				WithArguments(runtimeClient, moduleCR).

--- a/tests/integration/controller/kyma/kyma_module_enable_test.go
+++ b/tests/integration/controller/kyma/kyma_module_enable_test.go
@@ -17,7 +17,8 @@ var _ = Describe("Given kyma CR with invalid module enabled", Ordered, func() {
 			WithArguments(kcpClient, kyma).Should(Succeed())
 	})
 
-	Skip("When enable module with channel and version, expect module status in Error state", func() {
+	It("When enable module with channel and version, expect module status in Error state", func() {
+		Skip("Version attribute is disabled for now on the CRD level")
 		module := NewTestModuleWithChannelVersion("test", v1beta2.DefaultChannel, "1.0.0")
 		Eventually(givenKymaWithModule, Timeout, Interval).
 			WithArguments(kyma, module).Should(Succeed())

--- a/tests/integration/controller/kyma/kyma_module_enable_test.go
+++ b/tests/integration/controller/kyma/kyma_module_enable_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Given kyma CR with invalid module enabled", Ordered, func() {
 			WithArguments(kcpClient, kyma).Should(Succeed())
 	})
 
-	It("When enable module with channel and version, expect module status in Error state", func() {
+	Skip("When enable module with channel and version, expect module status in Error state", func() {
 		module := NewTestModuleWithChannelVersion("test", v1beta2.DefaultChannel, "1.0.0")
 		Eventually(givenKymaWithModule, Timeout, Interval).
 			WithArguments(kyma, module).Should(Succeed())

--- a/tests/integration/controller/kyma/kyma_module_version_test.go
+++ b/tests/integration/controller/kyma/kyma_module_version_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 var _ = Describe("Given invalid module version which is rejected by CRD validation rules", func() {
-	Skip("Version attribute is disabled on the CRD level")
 	DescribeTable(
 		"Test enable module", func(givenCondition func() error) {
+			Skip("Version attribute is disabled for now on the CRD level")
 			Eventually(givenCondition, Timeout, Interval).Should(Succeed())
 		},
 

--- a/tests/integration/controller/kyma/kyma_module_version_test.go
+++ b/tests/integration/controller/kyma/kyma_module_version_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ = Describe("Given invalid module version which is rejected by CRD validation rules", func() {
+	Skip("Version attribute is disabled on the CRD level")
 	DescribeTable(
 		"Test enable module", func(givenCondition func() error) {
 			Eventually(givenCondition, Timeout, Interval).Should(Succeed())


### PR DESCRIPTION
**Description**

Remove the `kyma.spec.modules[*].version` attribute from the API

When this is merged, if the user wants to enable the module using the specific version (see [here](https://github.com/kyma-project/lifecycle-manager/issues/1589)), the API server responds with: 

```
# kymas.operator.kyma-project.io "default" was not valid:
[...]: 
strict decoding error: unknown field "spec.modules[0].version"
```
Despite disabling the `version` attribute on the API level, the code for handling the attribute stays in the project so it's ready to be re-enabled anytime.

Changes proposed in this pull request:

- Remove the `kyma.spec.modules[*].version` attribute from the k8s API

**Related issue(s)**
#1817 