### PR TITLE
feat: Add new Panel to display Modules in Error State

### DIFF
--- a/config/grafana/status.json
+++ b/config/grafana/status.json
@@ -19,13 +19,65 @@
   "links": [],
   "panels": [
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.5.33",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "group by (kyma_name, module_name, shoot) (lifecycle_mgr_module_state{state=\"Error\"})",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Modules in Error State",
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 4,
       "panels": [],
@@ -57,7 +109,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 9
       },
       "id": 10,
       "options": {
@@ -75,7 +127,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.31",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,
@@ -104,7 +156,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 2,
@@ -124,7 +176,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.31",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -232,7 +284,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "hiddenSeries": false,
       "id": 5,
@@ -252,7 +304,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.31",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -360,7 +412,7 @@
         "h": 10,
         "w": 18,
         "x": 0,
-        "y": 31
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 6,
@@ -380,7 +432,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.31",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -496,7 +548,7 @@
         "h": 10,
         "w": 6,
         "x": 18,
-        "y": 31
+        "y": 39
       },
       "id": 8,
       "options": {
@@ -511,7 +563,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.31",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
A new panel in the Plutono dashboard under `Lifecycle Manager Kyma Status` to display the Modules which are in `Error` state.

**Related issue(s)**
Resolves #1745
