### PR TITLE
chore: Change `watched-by` label value from `lifecycle-manager` to `kyma`

### DIFF
--- a/api/shared/operator_labels.go
+++ b/api/shared/operator_labels.go
@@ -23,7 +23,8 @@ const (
 	OperatorName         = "lifecycle-manager"
 	// WatchedByLabel defines a redirect to a controller that should be getting a notification
 	// if this resource is changed.
-	WatchedByLabel = OperatorGroup + Separator + "watched-by"
+	WatchedByLabel      = OperatorGroup + Separator + "watched-by"
+	WatchedByLabelValue = "kyma"
 	// PurposeLabel defines the purpose of the resource, i.e. Secrets which will be used to certificate management.
 	PurposeLabel = OperatorGroup + Separator + "purpose"
 	CertManager  = "klm-watcher-cert-manager"

--- a/config/watcher/operator_v1beta2_watcher.yaml
+++ b/config/watcher/operator_v1beta2_watcher.yaml
@@ -6,7 +6,7 @@ metadata:
     "operator.kyma-project.io/managed-by": "lifecycle-manager"
 spec:
   labelsToWatch:
-    "operator.kyma-project.io/watched-by": "lifecycle-manager"
+    "operator.kyma-project.io/watched-by": "kyma"
   resourceToWatch:
     group: operator.kyma-project.io
     version: "*"

--- a/internal/declarative/v2/default_transforms.go
+++ b/internal/declarative/v2/default_transforms.go
@@ -62,8 +62,7 @@ func watchedByOwnedBy(_ context.Context, obj Object, resources []*unstructured.U
 		if lbls == nil {
 			lbls = make(map[string]string)
 		}
-		// legacy managed by value
-		lbls[shared.WatchedByLabel] = OperatorName
+		lbls[shared.WatchedByLabel] = shared.WatchedByLabelValue
 
 		annotations := resource.GetAnnotations()
 		if annotations == nil {

--- a/internal/remote/skr_context.go
+++ b/internal/remote/skr_context.go
@@ -209,7 +209,7 @@ func (s *SkrContext) syncWatcherLabelsAnnotations(controlPlaneKyma, remoteKyma *
 		remoteKyma.Labels = make(map[string]string)
 	}
 
-	remoteKyma.Labels[shared.WatchedByLabel] = shared.OperatorName
+	remoteKyma.Labels[shared.WatchedByLabel] = shared.WatchedByLabelValue
 
 	if remoteKyma.Annotations == nil {
 		remoteKyma.Annotations = make(map[string]string)

--- a/tests/integration/controller/kcp/helper_test.go
+++ b/tests/integration/controller/kcp/helper_test.go
@@ -95,7 +95,7 @@ func watcherLabelsAnnotationsExist(clnt client.Client, remoteKyma *v1beta2.Kyma,
 	if err != nil {
 		return err
 	}
-	if remoteKyma.Labels[shared.WatchedByLabel] != shared.OperatorName {
+	if remoteKyma.Labels[shared.WatchedByLabel] != shared.WatchedByLabelValue {
 		return ErrWatcherLabelMissing
 	}
 	if remoteKyma.Annotations[shared.OwnedByAnnotation] != fmt.Sprintf(shared.OwnedByFormat,


### PR DESCRIPTION
**Description**

- changes `watched-by` label value from `lifecycle-manager` to `kyma`

See Test PR to feature branch with this change for test verification (still stuffering from the `pull_request_target` problem): https://github.com/kyma-project/lifecycle-manager/pull/1891

**Related issue(s)**
Resolves #1822