### PR TITLE
chore: Align runtime-watcher registry and make configurable (#1868)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -322,7 +322,7 @@ func createSkrWebhookManager(mgr ctrl.Manager, skrContextFactory remote.SkrConte
 	caCertificateCache := watcher.NewCACertificateCache(flagVar.CaCertCacheTTL)
 	config := watcher.SkrWebhookManagerConfig{
 		SKRWatcherPath:         flagVar.WatcherResourcesPath,
-		SkrWatcherImage:        getWatcherImg(flagVar),
+		SkrWatcherImage:        flagVar.GetWatcherImage(),
 		SkrWebhookCPULimits:    flagVar.WatcherResourceLimitsCPU,
 		SkrWebhookMemoryLimits: flagVar.WatcherResourceLimitsMemory,
 		RemoteSyncNamespace:    flagVar.RemoteSyncNamespace,
@@ -353,18 +353,6 @@ func createSkrWebhookManager(mgr ctrl.Manager, skrContextFactory remote.SkrConte
 		config,
 		certConfig,
 		resolvedKcpAddr)
-}
-
-const (
-	watcherRegProd = "europe-docker.pkg.dev/kyma-project/prod/runtime-watcher-skr"
-	watcherRegDev  = "europe-docker.pkg.dev/kyma-project/dev/runtime-watcher"
-)
-
-func getWatcherImg(flagVar *flags.FlagVar) string {
-	if flagVar.UseWatcherDevRegistry {
-		return fmt.Sprintf("%s:%s", watcherRegDev, flagVar.WatcherImageTag)
-	}
-	return fmt.Sprintf("%s:%s", watcherRegProd, flagVar.WatcherImageTag)
 }
 
 func setupPurgeReconciler(mgr ctrl.Manager,

--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -18,7 +18,10 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=1.1.1
+        value: --skr-watcher-image-tag=1.1.4
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --enable-domain-name-pinning=true


### PR DESCRIPTION
Original PR https://github.com/kyma-project/lifecycle-manager/pull/1868 was merged to a feature branch so that we can run the E2E tests without the `pull_request_target` related issues. 

A test PR for running the E2E tests is here: https://github.com/kyma-project/lifecycle-manager/pull/1883

## Related Issues

- resolves https://github.com/kyma-project/lifecycle-manager/issues/1859
