### PR TITLE
chore: Use markdown-link-check@v1.0.15

### DIFF
--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Relates to version 1.0.15. Sha is used as this is this is the allow-listed value
       - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
+      - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'no'

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'no'

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,3 @@
 # Lifecycle Manager API
 
-To see Lifecycle Manager API documentation, go to the [Lifecycle Manager API](/docs/technical-reference/api/README.md) document in the `/docs` folder.
+To see Lifecycle Manager API documentation, go to the [Lifecycle Manager API](/docs/contributor/resources/README.md) document in the `/docs` folder.

--- a/docs/contributor/01-architecture.md
+++ b/docs/contributor/01-architecture.md
@@ -35,7 +35,7 @@ Apart from the custom resources, Lifecycle Manager uses also Kyma, Manifest, and
 * [Purge controller](../../internal/controller/purge/controller.go) - reconciles the Kyma CRs that are marked for deletion longer than the grace period, which means purging all the resources deployed by Lifecycle Manager in the target SKR cluster.
 * [Watcher controller](../../internal/controller/watcher/controller.go) - reconciles the Watcher CR which means creating Istio Virtual Service resources in KCP when a Watcher CR is created and removing the same resources when the Watcher CR is deleted. This is done to configure the routing of the messages that come from the watcher agent, installed on each Kyma runtime, and go to a listener agent deployed in KCP.
 
-For more details about Lifecycle Manager controllers, read the [Controllers](controllers.md) document.
+For more details about Lifecycle Manager controllers, read the [Controllers](./02-controllers.md) document.
 
 ## Read More
 

--- a/docs/contributor/02-controllers.md
+++ b/docs/contributor/02-controllers.md
@@ -33,7 +33,7 @@ it propagates changes from the ModuleTemplate CR to the Manifest CR. The mandato
 ## Manifest Controller
 
 [Manifest controller](../../internal/controller/manifest/controller.go) deals with the reconciliation and installation of data desired through a Manifest CR, a representation of a single module desired in a cluster.
-Since it mainly is a delegation to the [declarative reconciliation library](../../internal/declarative/README.md) with certain [internal implementation additions](../../internal/manifest/README.md), please look at the respective documentation for these parts to understand them more.
+Since it mainly is a delegation to the [declarative reconciliation library](../../internal/declarative/) with certain [internal implementation additions](../../internal/manifest/README.md), please look at the respective documentation for these parts to understand them more.
 
 ## Purge Controller
 

--- a/docs/contributor/04-local-test-setup.md
+++ b/docs/contributor/04-local-test-setup.md
@@ -25,11 +25,6 @@ This setup is deployed with the following security features enabled:
 * Strict mTLS connection between Kyma Control Plane (KCP) and SKR clusters
 * SAN Pinning (SAN of client TLS certificate needs to match the DNS annotation of a corresponding Kyma CR)
 
-> **NOTE:** If you want to use remote clusters instead of a local k3d setup or external registries, please refer to the following guides for the cluster and registry setup:
->
-> * [Provision cluster and OCI registry](provision-cluster-and-registry.md)
-> * [Create a test environment on Google Container Registry (GCR)](prepare-gcr-registry.md)
-
 ## Procedure
 
 ### KCP Cluster Setup

--- a/docs/contributor/05-api-changelog.md
+++ b/docs/contributor/05-api-changelog.md
@@ -11,7 +11,7 @@ The v1beta1 to v1beta2 version change introduced the following changes to Lifecy
 The main change introduced to the Kyma CRD is the removal of the  **.spec.sync** attribute. As a result, the v1beta1 **.spec.sync** sub-attributes handling changes as described:
 
 * **.sync.enabled** - replaced by the `operator.kyma-project.io/sync` label in a Kyma CR. For details, read the [Kyma CR synchronization labels](kyma-cr.md#operatorkyma-projectio-labels) document.
-* **.sync.moduleCatalog** - replaced by a combination the `operator.kyma-project.io/sync`, `operator.kyma-project.io/internal`, and `operator.kyma-project.io/beta` labels in Kyma and ModuleTemplate CRs. For details, read the [Kyma CR synchronization labels](kyma-cr.md#operatorkyma-projectio-labels) document.
+* **.sync.moduleCatalog** - replaced by a combination the `operator.kyma-project.io/sync`, `operator.kyma-project.io/internal`, and `operator.kyma-project.io/beta` labels in Kyma and ModuleTemplate CRs. For details, read the [Kyma CR synchronization labels](./resources/01-kyma.md#operatorkyma-projectio-labels) document.
 * **.sync.namespace** - replaced with a `sync-namespace` command-line flag for Lifecycle Manager. It means that a user can no longer configure the Namespace synchronized with a particular Kyma CR. The Namespace is the same for all Kyma CRs in a given Lifecycle Manager instance, and a user can't change it.
 * **.sync.noModuleCopy** - removed. Currently, the **.spec.modules[]** for a remote Kyma CR is always initialized as empty.
 

--- a/docs/contributor/05-api-changelog.md
+++ b/docs/contributor/05-api-changelog.md
@@ -10,7 +10,7 @@ The v1beta1 to v1beta2 version change introduced the following changes to Lifecy
 
 The main change introduced to the Kyma CRD is the removal of the  **.spec.sync** attribute. As a result, the v1beta1 **.spec.sync** sub-attributes handling changes as described:
 
-* **.sync.enabled** - replaced by the `operator.kyma-project.io/sync` label in a Kyma CR. For details, read the [Kyma CR synchronization labels](kyma-cr.md#operatorkyma-projectio-labels) document.
+* **.sync.enabled** - replaced by the `operator.kyma-project.io/sync` label in a Kyma CR. For details, read the [Kyma CR synchronization labels](./resources/01-kyma.md#operatorkyma-projectio-labels) document.
 * **.sync.moduleCatalog** - replaced by a combination the `operator.kyma-project.io/sync`, `operator.kyma-project.io/internal`, and `operator.kyma-project.io/beta` labels in Kyma and ModuleTemplate CRs. For details, read the [Kyma CR synchronization labels](./resources/01-kyma.md#operatorkyma-projectio-labels) document.
 * **.sync.namespace** - replaced with a `sync-namespace` command-line flag for Lifecycle Manager. It means that a user can no longer configure the Namespace synchronized with a particular Kyma CR. The Namespace is the same for all Kyma CRs in a given Lifecycle Manager instance, and a user can't change it.
 * **.sync.noModuleCopy** - removed. Currently, the **.spec.modules[]** for a remote Kyma CR is always initialized as empty.

--- a/docs/contributor/resources/02-manifest.md
+++ b/docs/contributor/resources/02-manifest.md
@@ -47,7 +47,7 @@ looks for a Secret with the same `operator.kyma-project.io/kyma-name` label and 
 
 The config reference uses an image layer reference that contains configuration data that can be used to further
 influence any potential rendering process while the resources are processed by
-the [declarative library](../../../internal/declarative/README.md#resource-rendering). It is resolved through a
+the [declarative library](../../../internal/declarative/). It is resolved through a
 translation of the ModuleTemplate CR to the Manifest CR during
 the [resolution of the modules](../../../internal/manifest/parser/template_to_module.go) in the Kyma CR control loop.
 

--- a/docs/contributor/resources/02-manifest.md
+++ b/docs/contributor/resources/02-manifest.md
@@ -76,7 +76,7 @@ spec:
 
 ### **.spec.install**
 
-The installation layer contains the relevant data required to determine the resources for the [renderer during the manifest reconciliation](../../../internal/declarative/README.md#resource-rendering).
+The installation layer contains the relevant data required to determine the resources for the [renderer during the manifest reconciliation](../../../internal/declarative/).
 
 It is mapped from an access type layer in the descriptor:
 

--- a/docs/contributor/resources/README.md
+++ b/docs/contributor/resources/README.md
@@ -21,11 +21,11 @@ The v1beta2 API introduces three groups of modules:
 
 By default, without any labels configured on Kyma and ModuleTemplate CRs, a ModuleTemplate CR is synchronized with remote clusters.
 
-**NOTE:** The ModuleTemplate CRs synchronization is enabled only when Lifecycle Manager runs in the [control-plane mode](../running-modes.md). Lifecycle Manager running in the single-cluster mode, doesn't require any CR synchronization.
+**NOTE:** The ModuleTemplate CRs synchronization is enabled only when Lifecycle Manager runs in the control-plane mode. Lifecycle Manager running in the single-cluster mode, doesn't require any CR synchronization.
 
 **NOTE:** Disabling synchronization for already synchronized ModuleTemplates CRs doesn't remove them from remote clusters. The CRs remain as they are, but any subsequent changes to these ModuleTemplate CRs in the Control Plane are not synchronized.
 
-For more information, see [the Kyma CR synchronization labels](kyma-cr.md#operatorkyma-projectio-labels) and [the ModuleTemplate CR synchronization labels](moduleTemplate-cr.md#operatorkyma-projectio-labels).
+For more information, see [the Kyma CR synchronization labels](./01-kyma.md#operatorkyma-projectio-labels) and [the ModuleTemplate CR synchronization labels](./03-moduletemplate.md#operatorkyma-projectio-labels).
 
 ## Stability
 
@@ -38,4 +38,4 @@ See the list of CRs involved in Lifecycle Manager's workflow and their stability
 | v1beta2 | [Manifest](/api/v1beta2/manifest_types.go)                 | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
 | v1beta2 | [Watcher](/api/v1beta2/watcher_types.go)                   | Beta-Grade - no breaking changes without API incrementation. Use for automation and watch upstream as close as possible for deprecations or new versions. Alpha API is deprecated and converted via webhook. |
 
-For more information on changes introduced by an API version, see [API Changelog](../api-changelog.md).
+For more information on changes introduced by an API version, see [API Changelog](../05-api-changelog.md).

--- a/internal/controller/README.md
+++ b/internal/controller/README.md
@@ -1,5 +1,5 @@
 # Controllers used within Lifecycle Manager
 
 This package contains all controllers that can be registered within the Lifecycle Manager.
-For more details, read [Lifecycle Manager Controllers](/docs/technical-reference/controllers.md) in the `/docs` folder.
-For more information on how the API behaves after the controller finishes up the synchronization, please look at the [Lifecycle Manager API](/docs/technical-reference/api/README.md) document.
+For more details, read [Lifecycle Manager Controllers](/docs/contributor/02-controllers.md) in the `/docs` folder.
+For more information on how the API behaves after the controller finishes up the synchronization, please look at the [Lifecycle Manager API](/docs/contributor/resources/README.md) document.

--- a/internal/manifest/README.md
+++ b/internal/manifest/README.md
@@ -1,6 +1,6 @@
 # Internal Manifest Library
 
-This package contains internal reference coding that is used for translating and implementing the Manifest Reconciler parts that are not generically solved by the [declarative library](../declarative/README.md).
+This package contains internal reference coding that is used for translating and implementing the Manifest Reconciler parts that are not generically solved by the [declarative library](../declarative/).
 
 It contains various aspects to:
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -12,7 +12,7 @@ See the [Run the e2e tests locally](#run-the-e2e-tests-locally) section for deta
 
 ## Run the e2e tests locally
 
-1. Set up your local environment using steps 1 to 3 from [this guide](/docs/developer-tutorials/local-test-setup.md). Create a cluster, and install Istio CRDs and `cert-manager`. Skip all the remaining steps from the guide. 
+1. Set up your local environment using steps 1 to 3 from [this guide](/docs/contributor/04-local-test-setup.md). Create a cluster, and install Istio CRDs and `cert-manager`. Skip all the remaining steps from the guide. 
 2. Export the following  K8s configurations as environment variables:
     ```shell
     export KCP_KUBECONFIG=$(k3d kubeconfig write kcp-local)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

PR runs produced errors claiming that the action is not allowed `gaurav-nelson/github-action-markdown-link-check@v1 is not allowed to be used in kyma-project/lifecycle-manager. Actions in this workflow must be:`

- fixes the GH action to the allow-listed sha (corresponds to v1.0.15)
  - using `@v1.0.15` directly also didn't work
- fixes all links that have broken in the meantime

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
