### PR TITLE
fix: Filter kube_deployment_status_replicas_unavailable metric by value

### DIFF
--- a/config/grafana/watcher.json
+++ b/config/grafana/watcher.json
@@ -69,7 +69,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,
@@ -168,7 +168,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,
@@ -246,11 +246,11 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(group by (shoot) (kube_deployment_status_replicas_unavailable{deployment=\"skr-webhook\"})) OR on() vector(0)",
+          "expr": "count(group by (shoot) (kube_deployment_status_replicas_unavailable{deployment=\"skr-webhook\"} == 1)) OR on() vector(0)",
           "format": "heatmap",
           "instant": true,
           "interval": "",
@@ -390,7 +390,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -493,7 +493,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "targets": [
         {
           "exemplar": true,
@@ -652,7 +652,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -746,7 +746,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -840,7 +840,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -934,7 +934,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1028,7 +1028,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1122,7 +1122,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.29",
+      "pluginVersion": "7.5.33",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Check value of `kube_deployment_status_replicas_unavailable` and `kube_deployment_status_replicas_available` metrics in watcher components dashboard

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
