### PR TITLE
chore: Remove watched-by label from manifest resources

### DIFF
--- a/internal/declarative/v2/default_transforms.go
+++ b/internal/declarative/v2/default_transforms.go
@@ -39,11 +39,10 @@ func KymaComponentTransform(_ context.Context, obj Object, resources []*unstruct
 	return nil
 }
 
-func WatchedByManagedByOwnedBy(_ context.Context, obj Object, resources []*unstructured.Unstructured) error {
+func ManagedByOwnedBy(_ context.Context, obj Object, resources []*unstructured.Unstructured) error {
 	for _, resource := range resources {
 		resource.SetLabels(collections.MergeMaps(resource.GetLabels(), map[string]string{
-			shared.WatchedByLabel: shared.WatchedByLabelValue,
-			shared.ManagedBy:      shared.ManagedByLabelValue,
+			shared.ManagedBy: shared.ManagedByLabelValue,
 		}))
 
 		resource.SetAnnotations(collections.MergeMaps(resource.GetAnnotations(), map[string]string{

--- a/internal/declarative/v2/default_transforms_test.go
+++ b/internal/declarative/v2/default_transforms_test.go
@@ -45,7 +45,7 @@ func Test_defaultTransforms(t *testing.T) {
 		},
 		{
 			"empty WatchedByManagedByOwnedBy",
-			declarativev2.WatchedByManagedByOwnedBy,
+			declarativev2.ManagedByOwnedBy,
 			[]*unstructured.Unstructured{},
 			func(testingT assert.TestingT, err error, i ...interface{}) bool {
 				require.NoError(t, err)
@@ -88,7 +88,7 @@ func Test_defaultTransforms(t *testing.T) {
 		},
 		{
 			"simple WatchedByManagedByOwnedBy",
-			declarativev2.WatchedByManagedByOwnedBy,
+			declarativev2.ManagedByOwnedBy,
 			[]*unstructured.Unstructured{{Object: map[string]any{}}},
 			func(testingT assert.TestingT, err error, i ...interface{}) bool {
 				require.NoError(t, err)
@@ -99,12 +99,9 @@ func Test_defaultTransforms(t *testing.T) {
 				assert.NotNil(testingT, unstruct.GetLabels())
 				assert.NotNil(testingT, unstruct.GetAnnotations())
 				assert.Contains(testingT, unstruct.GetLabels(), shared.ManagedBy)
-				assert.Contains(testingT, unstruct.GetLabels(), shared.WatchedByLabel)
 				assert.Contains(testingT, unstruct.GetAnnotations(), shared.OwnedByAnnotation)
 				assert.Equal(testingT, shared.ManagedByLabelValue,
 					unstruct.GetLabels()[shared.ManagedBy])
-				assert.Equal(testingT, shared.WatchedByLabelValue,
-					unstruct.GetLabels()[shared.WatchedByLabel])
 				return true
 			},
 		},

--- a/internal/declarative/v2/options.go
+++ b/internal/declarative/v2/options.go
@@ -23,7 +23,7 @@ const (
 func DefaultOptions() *Options {
 	return (&Options{}).Apply(
 		WithPostRenderTransform(
-			WatchedByManagedByOwnedBy,
+			ManagedByOwnedBy,
 			KymaComponentTransform,
 			DisclaimerTransform,
 		),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removes the `watched-by` label from the "rawManifest" resources. Label stays only on the KymaCR in the SKR

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- resolves https://github.com/kyma-project/lifecycle-manager/issues/1822
