### PR TITLE
chore: Rename moduletl usage in e2e

### DIFF
--- a/.github/actions/deploy-template-operator/action.yml
+++ b/.github/actions/deploy-template-operator/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: |
         make build-manifests
-        module create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml
@@ -72,7 +72,7 @@ runs:
         kustomize edit add patch --path warning_patch.yaml --kind Deployment
         popd
         make build-manifests
-        module create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml
@@ -93,7 +93,7 @@ runs:
         kustomize edit add patch --path warning_patch.yaml --kind StatefulSet
         popd
         make build-statefulset-manifests
-        module create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./module-config.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml
@@ -125,7 +125,7 @@ runs:
         kustomize edit add patch --path image_patch.yaml --kind Deployment
         popd
         make build-manifests
-        module create --module-config-file ./misconfigured-module-config.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./misconfigured-module-config.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml
@@ -143,7 +143,7 @@ runs:
         kustomize edit add patch --path image_patch.yaml --kind StatefulSet
         popd
         make build-statefulset-manifests
-        module create --module-config-file ./misconfigured-module-config.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./misconfigured-module-config.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml
@@ -160,7 +160,7 @@ runs:
         security: sec-scanners-config.yaml
         annotations:
           operator.kyma-project.io/doc-url: https://kyma-project.io" >> module-config-no-cr.yaml
-        module create --module-config-file ./module-config-no-cr.yaml --registry http://localhost:5111 --insecure
+        modulectl create --module-config-file ./module-config-no-cr.yaml --registry http://localhost:5111 --insecure
         sed -i 's/localhost:5111/k3d-kcp-registry.localhost:5000/g' ./template.yaml
         kubectl get crds
         kubectl apply -f template.yaml

--- a/.github/actions/install-modulectl/action.yml
+++ b/.github/actions/install-modulectl/action.yml
@@ -14,4 +14,3 @@ runs:
         chmod +x modulectl-linux
         mv modulectl-linux /usr/local/bin/modulectl
         echo "PATH=/usr/local/bin/modulectl" >> $GITHUB_OUTPUT
-        ln -s /usr/local/bin/modulectl /usr/local/bin/module


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove the linking of modulectl for cmd exec in e2e 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
