### PR TITLE
fix: Modules should be in error state when SKR cluster is deleted

### DIFF
--- a/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
+++ b/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
@@ -63,7 +63,7 @@ runs:
       if: ${{ matrix.e2e-test == 'module-upgrade-channel-switch' ||
         matrix.e2e-test == 'modulereleasemeta-module-upgrade-new-version' ||
         matrix.e2e-test == 'modulereleasemeta-upgrade-under-deletion' ||
-        matrix.e2e-test == 'modulereleasemeta-sync'
+        matrix.e2e-test == 'modulereleasemeta-sync' ||
         matrix.e2e-test == 'module-status-on-skr-connection-lost'
         }}
       shell: bash

--- a/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
+++ b/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
@@ -64,6 +64,7 @@ runs:
         matrix.e2e-test == 'modulereleasemeta-module-upgrade-new-version' ||
         matrix.e2e-test == 'modulereleasemeta-upgrade-under-deletion' ||
         matrix.e2e-test == 'modulereleasemeta-sync'
+        matrix.e2e-test == 'module-status-on-skr-connection-lost'
         }}
       shell: bash
       run: |

--- a/.github/workflows/test-e2e-with-modulereleasemeta.yml
+++ b/.github/workflows/test-e2e-with-modulereleasemeta.yml
@@ -63,6 +63,7 @@ jobs:
           - rbac-privileges
           - modulereleasemeta-with-obsolete-moduletemplate
           - modulereleasemeta-sync
+          - module-status-on-skr-connection-lost
           - modulereleasemeta-watch-trigger
 
     runs-on: ubuntu-latest

--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -137,6 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err != nil {
 			r.SkrContextFactory.InvalidateCache(kyma.GetNamespacedName())
 			r.Metrics.RecordRequeueReason(metrics.SyncContextRetrieval, queue.UnexpectedRequeue)
+			setModuleStatusesToError(kyma, util.NestedErrorMessage(err))
 			return r.requeueWithError(ctx, kyma, err)
 		}
 	}
@@ -672,4 +673,14 @@ func needUpdateForMandatoryModuleLabel(moduleTemplate v1beta2.ModuleTemplate) bo
 	}
 
 	return false
+}
+
+func setModuleStatusesToError(kyma *v1beta2.Kyma, optMessage string) {
+	moduleStatuses := kyma.Status.Modules
+	for i := range moduleStatuses {
+		moduleStatuses[i].State = shared.StateError
+		if optMessage != "" {
+			moduleStatuses[i].Message = optMessage
+		}
+	}
 }

--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -676,12 +676,12 @@ func needUpdateForMandatoryModuleLabel(moduleTemplate v1beta2.ModuleTemplate) bo
 	return false
 }
 
-func setModuleStatusesToError(kyma *v1beta2.Kyma, optMessage string) {
+func setModuleStatusesToError(kyma *v1beta2.Kyma, message string) {
 	moduleStatuses := kyma.Status.Modules
 	for i := range moduleStatuses {
 		moduleStatuses[i].State = shared.StateError
-		if optMessage != "" {
-			moduleStatuses[i].Message = optMessage
+		if message != "" {
+			moduleStatuses[i].Message = message
 		}
 	}
 }

--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -124,6 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		skrContext, err := r.SkrContextFactory.Get(kyma.GetNamespacedName())
 		if err != nil {
 			r.Metrics.RecordRequeueReason(metrics.SyncContextRetrieval, queue.UnexpectedRequeue)
+			setModuleStatusesToError(kyma, err.Error())
 			return r.requeueWithError(ctx, kyma, err)
 		}
 

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -246,14 +246,14 @@ func (r *Runner) setupModule(module *common.Module, kyma *v1beta2.Kyma) error {
 func (r *Runner) SyncModuleStatus(ctx context.Context, kyma *v1beta2.Kyma, modules common.Modules,
 	kymaMetrics *metrics.KymaMetrics, moduleMetrics *metrics.ModuleMetrics,
 ) {
-	updateModuleStatusFromExistingModules(modules, kyma)
+	UpdateModuleStatusFromExistingModules(kyma, modules)
 	DeleteNoLongerExistingModuleStatus(ctx, kyma, r.getModule, kymaMetrics.RemoveModuleStateMetrics,
 		moduleMetrics.RemoveModuleCRWarningCondition)
 }
 
-func updateModuleStatusFromExistingModules(
-	modules common.Modules,
+func UpdateModuleStatusFromExistingModules(
 	kyma *v1beta2.Kyma,
+	modules common.Modules,
 ) {
 	moduleStatusMap := kyma.GetModuleStatusMap()
 

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -246,12 +246,12 @@ func (r *Runner) setupModule(module *common.Module, kyma *v1beta2.Kyma) error {
 func (r *Runner) SyncModuleStatus(ctx context.Context, kyma *v1beta2.Kyma, modules common.Modules,
 	kymaMetrics *metrics.KymaMetrics, moduleMetrics *metrics.ModuleMetrics,
 ) {
-	UpdateModuleStatusFromExistingModules(kyma, modules)
+	updateModuleStatusFromExistingModules(kyma, modules)
 	DeleteNoLongerExistingModuleStatus(ctx, kyma, r.getModule, kymaMetrics.RemoveModuleStateMetrics,
 		moduleMetrics.RemoveModuleCRWarningCondition)
 }
 
-func UpdateModuleStatusFromExistingModules(
+func updateModuleStatusFromExistingModules(
 	kyma *v1beta2.Kyma,
 	modules common.Modules,
 ) {

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -59,3 +59,17 @@ func isNoSuchHostError(err error) bool {
 	}
 	return false
 }
+
+// NestedErrorMessage returns the error message of the wrapped error, if it exists. Otherwise, it returns an empty string.
+func NestedErrorMessage(err error) string {
+	res := ""
+
+	if err == nil {
+		return res
+	}
+	if uwErr := errors.Unwrap(err); uwErr != nil {
+		res = uwErr.Error()
+	}
+
+	return res
+}

--- a/scripts/tests/add_skr_host_to_coredns.sh
+++ b/scripts/tests/add_skr_host_to_coredns.sh
@@ -12,7 +12,7 @@ until [ $FOUND -eq 1 ]; do
         echo "Timeout reached. host.k3d.internal address not found."
         exit 1
     fi
-    CURRENT_ENTRIES=$(kubectl get configmap coredns -n kube-system -o yaml | yq eval '.data.NodeHosts' -)
+    CURRENT_ENTRIES=$(kubectl get configmap coredns -n kube-system -o yaml | yq -r '.data.NodeHosts' -)
     if echo "$CURRENT_ENTRIES" | grep -q "host.k3d.internal"; then
         HOST_IP_ADDRESS=$(echo "$CURRENT_ENTRIES" | grep "host.k3d.internal" | awk '{print $1}')
         FOUND=1
@@ -22,10 +22,10 @@ until [ $FOUND -eq 1 ]; do
     fi
 done
 
-NEW_ENTRY="$HOST_IP_ADDRESS $NEW_SKR_HOSTNAME"
+NEW_ENTRY="$HOST_IP_ADDRESS ${NEW_SKR_HOSTNAME}\n"
 
 kubectl get configmap coredns -n kube-system -o yaml | \
-  yq eval '.data.NodeHosts += "'"${NEW_ENTRY}"'"' - | \
+  yq ".data.NodeHosts += \"${NEW_ENTRY}\"" - | \
   kubectl apply -f -
 
 kubectl rollout restart -n kube-system deployment coredns

--- a/scripts/tests/add_skr_host_to_coredns.sh
+++ b/scripts/tests/add_skr_host_to_coredns.sh
@@ -12,7 +12,7 @@ until [ $FOUND -eq 1 ]; do
         echo "Timeout reached. host.k3d.internal address not found."
         exit 1
     fi
-    CURRENT_ENTRIES=$(kubectl get configmap coredns -n kube-system -o yaml | yq -r '.data.NodeHosts' -)
+    CURRENT_ENTRIES=$(kubectl get configmap coredns -n kube-system -o yaml | yq eval '.data.NodeHosts' -)
     if echo "$CURRENT_ENTRIES" | grep -q "host.k3d.internal"; then
         HOST_IP_ADDRESS=$(echo "$CURRENT_ENTRIES" | grep "host.k3d.internal" | awk '{print $1}')
         FOUND=1
@@ -22,10 +22,10 @@ until [ $FOUND -eq 1 ]; do
     fi
 done
 
-NEW_ENTRY="$HOST_IP_ADDRESS ${NEW_SKR_HOSTNAME}\n"
+NEW_ENTRY="$HOST_IP_ADDRESS $NEW_SKR_HOSTNAME"
 
 kubectl get configmap coredns -n kube-system -o yaml | \
-  yq ".data.NodeHosts += \"${NEW_ENTRY}\"" - | \
+  yq eval '.data.NodeHosts += "'"${NEW_ENTRY}"'"' - | \
   kubectl apply -f -
 
 kubectl rollout restart -n kube-system deployment coredns

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -151,9 +151,12 @@ ocm-compatible-module-template:
 modulereleasemeta-with-obsolete-moduletemplate:
 	go test -timeout 20m -ginkgo.v -ginkgo.focus "ModuleReleaseMeta With Obsolete ModuleTemplate"
 
-
 modulereleasemeta-watch-trigger:
 	go test -timeout 20m -ginkgo.v -ginkgo.focus "ModuleReleaseMeta Watch Trigger"
   
 modulereleasemeta-sync:
 	go test -timeout 20m -ginkgo.v -ginkgo.focus "ModuleReleaseMeta Sync"
+
+module-status-on-skr-connection-lost:
+	go test -timeout 20m -ginkgo.v -ginkgo.focus "KCP Kyma Module status on SKR connection lost"
+

--- a/tests/e2e/skr_connection_lost_test.go
+++ b/tests/e2e/skr_connection_lost_test.go
@@ -46,12 +46,8 @@ var _ = Describe("KCP Kyma Module status on SKR connection lost", Ordered, func(
 		})
 
 		It("When SKR Cluster is removed", func() {
-			cmd := exec.Command("sh", "../../scripts/tests/remove_skr_host_from_coredns.sh")
+			cmd := exec.Command("k3d", "cluster", "stop", "skr")
 			out, err := cmd.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred())
-			GinkgoWriter.Printf(string(out))
-			cmd = exec.Command("k3d", "cluster", "rm", "skr")
-			out, err = cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf(string(out))
 		})

--- a/tests/e2e/skr_connection_lost_test.go
+++ b/tests/e2e/skr_connection_lost_test.go
@@ -66,7 +66,7 @@ var _ = Describe("KCP Kyma Module status on SKR connection lost", Ordered, func(
 		It("And KCP Kyma CR status.modules are in \"Error\" State", func() {
 			Eventually(CheckModuleState).
 				WithContext(ctx).
-				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name, shared.StateReady).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name, shared.StateError).
 				Should(Succeed())
 		})
 	})

--- a/tests/e2e/skr_connection_lost_test.go
+++ b/tests/e2e/skr_connection_lost_test.go
@@ -1,0 +1,73 @@
+package e2e_test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+)
+
+var _ = Describe("KCP Kyma Module status on SKR connection lost", Ordered, func() {
+	kyma := NewKymaWithSyncLabel("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	module := NewTemplateOperator(v1beta2.DefaultChannel)
+	moduleCR := NewTestModuleCR(RemoteNamespace)
+
+	InitEmptyKymaBeforeAll(kyma)
+
+	Context("Given SKR Cluster", func() {
+		It("When Kyma Module is enabled on SKR Cluster", func() {
+			Eventually(EnableModule).
+				WithContext(ctx).
+				WithArguments(skrClient, defaultRemoteKymaName, RemoteNamespace, module).
+				Should(Succeed())
+			Eventually(ModuleCRExists).
+				WithContext(ctx).
+				WithArguments(skrClient, moduleCR).
+				Should(Succeed())
+		})
+
+		It("Then KCP Kyma CR is in \"Ready\" State", func() {
+			Eventually(KymaIsInState).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), kcpClient, shared.StateReady).
+				Should(Succeed())
+		})
+
+		It("And KCP Kyma CR status.modules are in \"Ready\" State", func() {
+			Eventually(CheckModuleState).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name, shared.StateReady).
+				Should(Succeed())
+		})
+
+		It("When SKR Cluster is removed", func() {
+			cmd := exec.Command("sh", "../../scripts/tests/remove_skr_host_from_coredns.sh")
+			out, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf(string(out))
+			cmd = exec.Command("k3d", "cluster", "rm", "skr")
+			out, err = cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf(string(out))
+		})
+
+		It("Then KCP Kyma CR is in \"Error\" State", func() {
+			Eventually(KymaIsInState).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), kcpClient, shared.StateError).
+				Should(Succeed())
+		})
+
+		It("And KCP Kyma CR status.modules are in \"Error\" State", func() {
+			Eventually(CheckModuleState).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name, shared.StateReady).
+				Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
**Description**

I decided to just set the state of all modules to "error" on SKR context initialization error, instead of reading the status of each module from the related `Manifest` CR.
I think it is correct action in all cases.
It would be incorrect if there's a permanent condition that prevents SKR context initialization (cluster deleted? wrong secret?) AND at the same time the manifest for a module would be NOT in an error state.
A simpler explanation: this approach would be incorrect if the Kyma reconciler cannot access SKR, but Manifest reconciler can (or it doesn't need to, but it sets a status different than "error")
Because such a situation is very unlikely, I decided to go with simpler solution to preserve resources (memory/cpu/network)

Changes proposed in this pull request:

- Set the state of all modules to "error" on SKR context initialization error
- Add e2e test for the "cluster deleted" scenario

**Related issue(s)**
Fixes: #2024 