### PR TITLE
feat: Support `internal` and `beta` flags in new module metadata

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -133,6 +133,7 @@
         "mandatory-module-metrics",
         "misconfigured-kyma-secret",
         "ocm-compatible-module-template",
+        "modulereleasemeta-sync",
       ]
     },
     {

--- a/api/v1beta2/modulereleasemeta_types.go
+++ b/api/v1beta2/modulereleasemeta_types.go
@@ -31,6 +31,14 @@ type ModuleReleaseMetaSpec struct {
 	// +listType=map
 	// +listMapKey=channel
 	Channels []ChannelVersionAssignment `json:"channels"`
+
+	// Beta indicates if the module is in beta state. Beta modules are only available for beta Kymas.
+	// +kubebuilder:default:=false
+	Beta bool `json:"beta,omitempty"`
+
+	// Internal indicates if the module is internal. Internal modules are only available for internal Kymas.
+	// +kubebuilder:default:=false
+	Internal bool `json:"internal,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -58,4 +66,12 @@ type ChannelVersionAssignment struct {
 //nolint:gochecknoinits // registers ModuleReleaseMeta CRD on startup
 func init() {
 	SchemeBuilder.Register(&ModuleReleaseMeta{}, &ModuleReleaseMetaList{})
+}
+
+func (m ModuleReleaseMeta) IsBeta() bool {
+	return m.Spec.Beta
+}
+
+func (m ModuleReleaseMeta) IsInternal() bool {
+	return m.Spec.Internal
 }

--- a/api/v1beta2/moduletemplate_types.go
+++ b/api/v1beta2/moduletemplate_types.go
@@ -188,7 +188,7 @@ func init() {
 	SchemeBuilder.Register(&ModuleTemplate{}, &ModuleTemplateList{})
 }
 
-// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// https://github.com/kyma-project/lifecycle-manager/issues/2096
 // Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) SyncEnabled(betaEnabled, internalEnabled bool) bool {
 	if m.HasSyncDisabled() {
@@ -210,7 +210,7 @@ func (m *ModuleTemplate) SyncEnabled(betaEnabled, internalEnabled bool) bool {
 	return true
 }
 
-// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// https://github.com/kyma-project/lifecycle-manager/issues/2096
 // Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) IsInternal() bool {
 	if isInternal, found := m.Labels[shared.InternalLabel]; found {
@@ -254,7 +254,7 @@ func (m *ModuleTemplate) GetVersion() (*semver.Version, error) {
 	return version, nil
 }
 
-// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// https://github.com/kyma-project/lifecycle-manager/issues/2096
 // Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) IsBeta() bool {
 	if isBeta, found := m.Labels[shared.BetaLabel]; found {
@@ -267,7 +267,7 @@ func (m *ModuleTemplate) IsMandatory() bool {
 	return m.Spec.Mandatory
 }
 
-// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2090
+// https://github.com/kyma-project/lifecycle-manager/issues/2090
 // Will be deprecated.
 func (m *ModuleTemplate) HasSyncDisabled() bool {
 	if isSync, found := m.Labels[shared.SyncLabel]; found {

--- a/api/v1beta2/moduletemplate_types.go
+++ b/api/v1beta2/moduletemplate_types.go
@@ -188,8 +188,10 @@ func init() {
 	SchemeBuilder.Register(&ModuleTemplate{}, &ModuleTemplateList{})
 }
 
+// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) SyncEnabled(betaEnabled, internalEnabled bool) bool {
-	if m.syncDisabled() {
+	if m.HasSyncDisabled() {
 		return false
 	}
 
@@ -208,13 +210,8 @@ func (m *ModuleTemplate) SyncEnabled(betaEnabled, internalEnabled bool) bool {
 	return true
 }
 
-func (m *ModuleTemplate) syncDisabled() bool {
-	if isSync, found := m.Labels[shared.SyncLabel]; found {
-		return strings.ToLower(isSync) == shared.DisableLabelValue
-	}
-	return false
-}
-
+// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) IsInternal() bool {
 	if isInternal, found := m.Labels[shared.InternalLabel]; found {
 		return strings.ToLower(isInternal) == shared.EnableLabelValue
@@ -257,6 +254,8 @@ func (m *ModuleTemplate) GetVersion() (*semver.Version, error) {
 	return version, nil
 }
 
+// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// Remove this function after the migration to the new ModuleTemplate format is completed.
 func (m *ModuleTemplate) IsBeta() bool {
 	if isBeta, found := m.Labels[shared.BetaLabel]; found {
 		return strings.ToLower(isBeta) == shared.EnableLabelValue
@@ -266,4 +265,13 @@ func (m *ModuleTemplate) IsBeta() bool {
 
 func (m *ModuleTemplate) IsMandatory() bool {
 	return m.Spec.Mandatory
+}
+
+// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2090
+// Will be deprecated.
+func (m *ModuleTemplate) HasSyncDisabled() bool {
+	if isSync, found := m.Labels[shared.SyncLabel]; found {
+		return strings.ToLower(isSync) == shared.DisableLabelValue
+	}
+	return false
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,6 +311,7 @@ func setupKymaReconciler(mgr ctrl.Manager, descriptorProvider *provider.CachedDe
 		IsManagedKyma:       flagVar.IsKymaManaged,
 		Metrics:             kymaMetrics,
 		ModuleMetrics:       moduleMetrics,
+		RemoteCatalog:       remote.NewRemoteCatalogFromKyma(mgr.GetClient(), skrContextFactory, flagVar.RemoteSyncNamespace),
 	}).SetupWithManager(
 		mgr, options, kyma.SetupOptions{
 			ListenerAddr:                 flagVar.KymaListenerAddr,

--- a/config/crd/bases/operator.kyma-project.io_modulereleasemetas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_modulereleasemetas.yaml
@@ -45,6 +45,11 @@ spec:
             description: ModuleReleaseMetaSpec defines the channel-version assignments
               for a module.
             properties:
+              beta:
+                default: false
+                description: Beta indicates if the module is in beta state. Beta modules
+                  are only available for beta Kymas.
+                type: boolean
               channels:
                 description: Channels is the list of module channels with their corresponding
                   versions.
@@ -70,6 +75,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - channel
                 x-kubernetes-list-type: map
+              internal:
+                default: false
+                description: Internal indicates if the module is internal. Internal
+                  modules are only available for internal Kymas.
+                type: boolean
               moduleName:
                 description: ModuleName is the name of the Module.
                 maxLength: 64

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -77,25 +77,25 @@ func newRemoteCatalog(kcpClient client.Client, skrContextFactory SkrContextProvi
 }
 
 func (c *RemoteCatalog) SyncModuleCatalog(ctx context.Context, kyma *v1beta2.Kyma) error {
-	moduleReleaseMetas := &[]v1beta2.ModuleReleaseMeta{}
-	if err := c.GetModuleReleaseMetasToSync(ctx, moduleReleaseMetas, kyma); err != nil {
+	moduleReleaseMetas := []v1beta2.ModuleReleaseMeta{}
+	if err := c.GetModuleReleaseMetasToSync(ctx, &moduleReleaseMetas, kyma); err != nil {
 		return err
 	}
 
-	moduleTemplates := &[]v1beta2.ModuleTemplate{}
-	if err := c.GetModuleTemplatesToSync(ctx, moduleTemplates, moduleReleaseMetas); err != nil {
+	moduleTemplates := []v1beta2.ModuleTemplate{}
+	if err := c.GetModuleTemplatesToSync(ctx, &moduleTemplates, &moduleReleaseMetas); err != nil {
 		return err
 	}
 
 	// https://github.com/kyma-project/lifecycle-manager/issues/2096
 	// Remove this block after the migration to the new ModuleTemplate format is completed.
-	oldModuleTemplate := &[]v1beta2.ModuleTemplate{}
-	if err := c.GetOldModuleTemplatesToSync(ctx, oldModuleTemplate, kyma); err != nil {
+	oldModuleTemplate := []v1beta2.ModuleTemplate{}
+	if err := c.GetOldModuleTemplatesToSync(ctx, &oldModuleTemplate, kyma); err != nil {
 		return err
 	}
-	*moduleTemplates = append(*moduleTemplates, *oldModuleTemplate...)
+	moduleTemplates = append(moduleTemplates, oldModuleTemplate...)
 
-	return c.sync(ctx, kyma.GetNamespacedName(), moduleTemplates, moduleReleaseMetas)
+	return c.sync(ctx, kyma.GetNamespacedName(), &moduleTemplates, &moduleReleaseMetas)
 }
 
 func (c *RemoteCatalog) sync(

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -168,6 +168,13 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
 	}
 
+	return c.FilterModuleTemplatesToSync(moduleTemplateList.Items, moduleReleaseMetas), nil
+}
+
+func (c *RemoteCatalog) FilterModuleTemplatesToSync(
+	moduleTemplates []v1beta2.ModuleTemplate,
+	moduleReleaseMetas []v1beta2.ModuleReleaseMeta,
+) []v1beta2.ModuleTemplate {
 	moduleTemplatesToSync := map[string]bool{}
 	for _, moduleReleaseMeta := range moduleReleaseMetas {
 		for _, channel := range moduleReleaseMeta.Spec.Channels {
@@ -175,8 +182,8 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 		}
 	}
 
-	moduleTemplates := []v1beta2.ModuleTemplate{}
-	for _, moduleTemplate := range moduleTemplateList.Items {
+	filteredModuleTemplates := []v1beta2.ModuleTemplate{}
+	for _, moduleTemplate := range moduleTemplates {
 		if moduleTemplate.IsMandatory() {
 			continue
 		}
@@ -186,11 +193,11 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 		}
 
 		if _, found := moduleTemplatesToSync[moduleTemplate.Name]; found {
-			moduleTemplates = append(moduleTemplates, moduleTemplate)
+			filteredModuleTemplates = append(filteredModuleTemplates, moduleTemplate)
 		}
 	}
 
-	return moduleTemplates, nil
+	return filteredModuleTemplates
 }
 
 // https://github.com/kyma-project/lifecycle-manager/issues/2096

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -87,7 +87,7 @@ func (c *RemoteCatalog) SyncModuleCatalog(ctx context.Context, kyma *v1beta2.Kym
 		return err
 	}
 
-	// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+	// https://github.com/kyma-project/lifecycle-manager/issues/2096
 	// Remove this block after the migration to the new ModuleTemplate format is completed.
 	oldModuleTemplate, err := c.GetOldModuleTemplatesToSync(ctx, kyma)
 	if err != nil {
@@ -193,7 +193,7 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 	return moduleTemplates, nil
 }
 
-// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// https://github.com/kyma-project/lifecycle-manager/issues/2096
 // Remove this function after the migration to the new ModuleTemplate format is completed.
 func (c *RemoteCatalog) GetOldModuleTemplatesToSync(
 	ctx context.Context,

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -82,7 +82,7 @@ func (c *RemoteCatalog) SyncModuleCatalog(ctx context.Context, kyma *v1beta2.Kym
 		return err
 	}
 
-	moduleTemplates, err := c.GetModuleTemplatesToSync(ctx, &moduleReleaseMetas)
+	moduleTemplates, err := c.GetModuleTemplatesToSync(ctx, moduleReleaseMetas)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
 // it must be referenced by a ModuleReleaseMeta that is synced.
 func (c *RemoteCatalog) GetModuleTemplatesToSync(
 	ctx context.Context,
-	moduleReleaseMetas *[]v1beta2.ModuleReleaseMeta,
+	moduleReleaseMetas []v1beta2.ModuleReleaseMeta,
 ) ([]v1beta2.ModuleTemplate, error) {
 	moduleTemplateList := &v1beta2.ModuleTemplateList{}
 	if err := c.kcpClient.List(ctx, moduleTemplateList, &client.ListOptions{}); err != nil {
@@ -169,7 +169,7 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 	}
 
 	moduleTemplatesToSync := map[string]bool{}
-	for _, moduleReleaseMeta := range *moduleReleaseMetas {
+	for _, moduleReleaseMeta := range moduleReleaseMetas {
 		for _, channel := range moduleReleaseMeta.Spec.Channels {
 			moduleTemplatesToSync[fmt.Sprintf("%s-%s", moduleReleaseMeta.Spec.ModuleName, channel.Version)] = true
 		}

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -138,7 +138,7 @@ func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
 	kyma *v1beta2.Kyma,
 ) ([]v1beta2.ModuleReleaseMeta, error) {
 	moduleReleaseMetaList := &v1beta2.ModuleReleaseMetaList{}
-	if err := c.kcpClient.List(ctx, moduleReleaseMetaList, &client.ListOptions{}); err != nil {
+	if err := c.kcpClient.List(ctx, moduleReleaseMetaList); err != nil {
 		return nil, fmt.Errorf("failed to list ModuleReleaseMetas: %w", err)
 	}
 
@@ -164,7 +164,7 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 	moduleReleaseMetas []v1beta2.ModuleReleaseMeta,
 ) ([]v1beta2.ModuleTemplate, error) {
 	moduleTemplateList := &v1beta2.ModuleTemplateList{}
-	if err := c.kcpClient.List(ctx, moduleTemplateList, &client.ListOptions{}); err != nil {
+	if err := c.kcpClient.List(ctx, moduleTemplateList); err != nil {
 		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
 	}
 
@@ -200,7 +200,7 @@ func (c *RemoteCatalog) GetOldModuleTemplatesToSync(
 	kyma *v1beta2.Kyma,
 ) ([]v1beta2.ModuleTemplate, error) {
 	moduleTemplateList := &v1beta2.ModuleTemplateList{}
-	if err := c.kcpClient.List(ctx, moduleTemplateList, &client.ListOptions{}); err != nil {
+	if err := c.kcpClient.List(ctx, moduleTemplateList); err != nil {
 		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
 	}
 

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -178,7 +178,7 @@ func (c *RemoteCatalog) FilterModuleTemplatesToSync(
 	moduleTemplatesToSync := map[string]bool{}
 	for _, moduleReleaseMeta := range moduleReleaseMetas {
 		for _, channel := range moduleReleaseMeta.Spec.Channels {
-			moduleTemplatesToSync[fmt.Sprintf("%s-%s", moduleReleaseMeta.Spec.ModuleName, channel.Version)] = true
+			moduleTemplatesToSync[formatModuleName(moduleReleaseMeta.Spec.ModuleName, channel.Version)] = true
 		}
 	}
 
@@ -192,7 +192,7 @@ func (c *RemoteCatalog) FilterModuleTemplatesToSync(
 			continue
 		}
 
-		if _, found := moduleTemplatesToSync[moduleTemplate.Name]; found {
+		if _, found := moduleTemplatesToSync[formatModuleName(moduleTemplate.Spec.ModuleName, moduleTemplate.Spec.Version)]; found {
 			filteredModuleTemplates = append(filteredModuleTemplates, moduleTemplate)
 		}
 	}
@@ -223,4 +223,8 @@ func (c *RemoteCatalog) GetOldModuleTemplatesToSync(
 	}
 
 	return moduleTemplates, nil
+}
+
+func formatModuleName(moduleName, version string) string {
+	return fmt.Sprintf("%s-%s", moduleName, version)
 }

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -76,7 +76,29 @@ func newRemoteCatalog(kcpClient client.Client, skrContextFactory SkrContextProvi
 	return res
 }
 
-func (c *RemoteCatalog) Sync(
+func (c *RemoteCatalog) SyncModuleCatalog(ctx context.Context, kyma *v1beta2.Kyma) error {
+	moduleReleaseMetas, err := c.GetModuleReleaseMetasToSync(ctx, kyma)
+	if err != nil {
+		return err
+	}
+
+	moduleTemplates, err := c.GetModuleTemplatesToSync(ctx, &moduleReleaseMetas)
+	if err != nil {
+		return err
+	}
+
+	// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+	// Remove this block after the migration to the new ModuleTemplate format is completed.
+	oldModuleTemplate, err := c.GetOldModuleTemplatesToSync(ctx, kyma)
+	if err != nil {
+		return err
+	}
+	moduleTemplates = append(moduleTemplates, oldModuleTemplate...)
+
+	return c.sync(ctx, kyma.GetNamespacedName(), moduleTemplates, moduleReleaseMetas)
+}
+
+func (c *RemoteCatalog) sync(
 	ctx context.Context,
 	kyma types.NamespacedName,
 	kcpModules []v1beta2.ModuleTemplate,
@@ -84,7 +106,7 @@ func (c *RemoteCatalog) Sync(
 ) error {
 	skrContext, err := c.skrContextFactory.Get(kyma)
 	if err != nil {
-		return fmt.Errorf("failed to get SkrContext to update remote catalog: %w", err)
+		return fmt.Errorf("failed to get SKR context: %w", err)
 	}
 
 	moduleTemplates := c.moduleTemplateSyncAPIFactoryFn(c.kcpClient, skrContext.Client, &c.settings)
@@ -102,9 +124,96 @@ func (c *RemoteCatalog) Delete(
 ) error {
 	skrContext, err := c.skrContextFactory.Get(kyma)
 	if err != nil {
-		return fmt.Errorf("failed to get SkrContext for deleting RemoteCatalog: %w", err)
+		return fmt.Errorf("failed to get SKR context: %w", err)
 	}
 
 	moduleTemplates := c.moduleTemplateSyncAPIFactoryFn(c.kcpClient, skrContext.Client, &c.settings)
 	return moduleTemplates.DeleteAllManaged(ctx)
+}
+
+// GetModuleReleaseMetasToSync returns a list of ModuleReleaseMetas that should be synced to the SKR.
+// A ModuleReleaseMeta that is Beta or Internal is synced only if the Kyma is also Beta or Internal.
+func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
+	ctx context.Context,
+	kyma *v1beta2.Kyma,
+) ([]v1beta2.ModuleReleaseMeta, error) {
+	moduleReleaseMetaList := &v1beta2.ModuleReleaseMetaList{}
+	if err := c.kcpClient.List(ctx, moduleReleaseMetaList, &client.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to list ModuleReleaseMetas: %w", err)
+	}
+
+	filteredModuleReleaseMetas := []v1beta2.ModuleReleaseMeta{}
+	for _, moduleReleaseMeta := range moduleReleaseMetaList.Items {
+		if moduleReleaseMeta.IsBeta() && !kyma.IsBeta() {
+			continue
+		}
+		if moduleReleaseMeta.IsInternal() && !kyma.IsInternal() {
+			continue
+		}
+		filteredModuleReleaseMetas = append(filteredModuleReleaseMetas, moduleReleaseMeta)
+	}
+
+	return filteredModuleReleaseMetas, nil
+}
+
+// GetModuleTemplatesToSync returns a list of ModuleTemplates that should be synced to the SKR.
+// A ModuleTemplate is synced if it is not mandatory and does not have sync disabled. In addition,
+// it must be referenced by a ModuleReleaseMeta that is synced.
+func (c *RemoteCatalog) GetModuleTemplatesToSync(
+	ctx context.Context,
+	moduleReleaseMetas *[]v1beta2.ModuleReleaseMeta,
+) ([]v1beta2.ModuleTemplate, error) {
+	moduleTemplateList := &v1beta2.ModuleTemplateList{}
+	if err := c.kcpClient.List(ctx, moduleTemplateList, &client.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
+	}
+
+	moduleTemplatesToSync := map[string]bool{}
+	for _, moduleReleaseMeta := range *moduleReleaseMetas {
+		for _, channel := range moduleReleaseMeta.Spec.Channels {
+			moduleTemplatesToSync[fmt.Sprintf("%s-%s", moduleReleaseMeta.Spec.ModuleName, channel.Version)] = true
+		}
+	}
+
+	moduleTemplates := []v1beta2.ModuleTemplate{}
+	for _, moduleTemplate := range moduleTemplateList.Items {
+		if moduleTemplate.IsMandatory() {
+			continue
+		}
+
+		if moduleTemplate.HasSyncDisabled() {
+			continue
+		}
+
+		if _, found := moduleTemplatesToSync[moduleTemplate.Name]; found {
+			moduleTemplates = append(moduleTemplates, moduleTemplate)
+		}
+	}
+
+	return moduleTemplates, nil
+}
+
+// TODO: https://github.com/kyma-project/lifecycle-manager/issues/2096
+// Remove this function after the migration to the new ModuleTemplate format is completed.
+func (c *RemoteCatalog) GetOldModuleTemplatesToSync(
+	ctx context.Context,
+	kyma *v1beta2.Kyma,
+) ([]v1beta2.ModuleTemplate, error) {
+	moduleTemplateList := &v1beta2.ModuleTemplateList{}
+	if err := c.kcpClient.List(ctx, moduleTemplateList, &client.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
+	}
+
+	moduleTemplates := []v1beta2.ModuleTemplate{}
+	for _, moduleTemplate := range moduleTemplateList.Items {
+		if moduleTemplate.Spec.Channel == "" {
+			continue
+		}
+
+		if moduleTemplate.SyncEnabled(kyma.IsBeta(), kyma.IsInternal()) {
+			moduleTemplates = append(moduleTemplates, moduleTemplate)
+		}
+	}
+
+	return moduleTemplates, nil
 }

--- a/internal/remote/remote_catalog.go
+++ b/internal/remote/remote_catalog.go
@@ -77,32 +77,32 @@ func newRemoteCatalog(kcpClient client.Client, skrContextFactory SkrContextProvi
 }
 
 func (c *RemoteCatalog) SyncModuleCatalog(ctx context.Context, kyma *v1beta2.Kyma) error {
-	moduleReleaseMetas := []v1beta2.ModuleReleaseMeta{}
-	if err := c.GetModuleReleaseMetasToSync(ctx, &moduleReleaseMetas, kyma); err != nil {
+	moduleReleaseMetas, err := c.GetModuleReleaseMetasToSync(ctx, kyma)
+	if err != nil {
 		return err
 	}
 
-	moduleTemplates := []v1beta2.ModuleTemplate{}
-	if err := c.GetModuleTemplatesToSync(ctx, &moduleTemplates, &moduleReleaseMetas); err != nil {
+	moduleTemplates, err := c.GetModuleTemplatesToSync(ctx, moduleReleaseMetas)
+	if err != nil {
 		return err
 	}
 
 	// https://github.com/kyma-project/lifecycle-manager/issues/2096
 	// Remove this block after the migration to the new ModuleTemplate format is completed.
-	oldModuleTemplate := []v1beta2.ModuleTemplate{}
-	if err := c.GetOldModuleTemplatesToSync(ctx, &oldModuleTemplate, kyma); err != nil {
+	oldModuleTemplate, err := c.GetOldModuleTemplatesToSync(ctx, kyma)
+	if err != nil {
 		return err
 	}
 	moduleTemplates = append(moduleTemplates, oldModuleTemplate...)
 
-	return c.sync(ctx, kyma.GetNamespacedName(), &moduleTemplates, &moduleReleaseMetas)
+	return c.sync(ctx, kyma.GetNamespacedName(), moduleTemplates, moduleReleaseMetas)
 }
 
 func (c *RemoteCatalog) sync(
 	ctx context.Context,
 	kyma types.NamespacedName,
-	kcpModules *[]v1beta2.ModuleTemplate,
-	kcpModuleReleaseMeta *[]v1beta2.ModuleReleaseMeta,
+	kcpModules []v1beta2.ModuleTemplate,
+	kcpModuleReleaseMeta []v1beta2.ModuleReleaseMeta,
 ) error {
 	skrContext, err := c.skrContextFactory.Get(kyma)
 	if err != nil {
@@ -112,8 +112,8 @@ func (c *RemoteCatalog) sync(
 	moduleTemplates := c.moduleTemplateSyncAPIFactoryFn(c.kcpClient, skrContext.Client, &c.settings)
 	moduleReleaseMetas := c.moduleReleaseMetaSyncAPIFactoryFn(c.kcpClient, skrContext.Client, &c.settings)
 
-	mtErr := moduleTemplates.SyncToSKR(ctx, *kcpModules)
-	mrmErr := moduleReleaseMetas.SyncToSKR(ctx, *kcpModuleReleaseMeta)
+	mtErr := moduleTemplates.SyncToSKR(ctx, kcpModules)
+	mrmErr := moduleReleaseMetas.SyncToSKR(ctx, kcpModuleReleaseMeta)
 
 	return errors.Join(mtErr, mrmErr)
 }
@@ -135,14 +135,14 @@ func (c *RemoteCatalog) Delete(
 // A ModuleReleaseMeta that is Beta or Internal is synced only if the Kyma is also Beta or Internal.
 func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
 	ctx context.Context,
-	moduleReleaseMetas *[]v1beta2.ModuleReleaseMeta,
 	kyma *v1beta2.Kyma,
-) error {
+) ([]v1beta2.ModuleReleaseMeta, error) {
 	moduleReleaseMetaList := &v1beta2.ModuleReleaseMetaList{}
 	if err := c.kcpClient.List(ctx, moduleReleaseMetaList); err != nil {
-		return fmt.Errorf("failed to list ModuleReleaseMetas: %w", err)
+		return nil, fmt.Errorf("failed to list ModuleReleaseMetas: %w", err)
 	}
 
+	moduleReleaseMetas := []v1beta2.ModuleReleaseMeta{}
 	for _, moduleReleaseMeta := range moduleReleaseMetaList.Items {
 		if moduleReleaseMeta.IsBeta() && !kyma.IsBeta() {
 			continue
@@ -150,10 +150,10 @@ func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
 		if moduleReleaseMeta.IsInternal() && !kyma.IsInternal() {
 			continue
 		}
-		*moduleReleaseMetas = append(*moduleReleaseMetas, moduleReleaseMeta)
+		moduleReleaseMetas = append(moduleReleaseMetas, moduleReleaseMeta)
 	}
 
-	return nil
+	return moduleReleaseMetas, nil
 }
 
 // GetModuleTemplatesToSync returns a list of ModuleTemplates that should be synced to the SKR.
@@ -161,21 +161,21 @@ func (c *RemoteCatalog) GetModuleReleaseMetasToSync(
 // it must be referenced by a ModuleReleaseMeta that is synced.
 func (c *RemoteCatalog) GetModuleTemplatesToSync(
 	ctx context.Context,
-	moduleTemplates *[]v1beta2.ModuleTemplate,
-	moduleReleaseMetas *[]v1beta2.ModuleReleaseMeta,
-) error {
+	moduleReleaseMetas []v1beta2.ModuleReleaseMeta,
+) ([]v1beta2.ModuleTemplate, error) {
 	moduleTemplateList := &v1beta2.ModuleTemplateList{}
 	if err := c.kcpClient.List(ctx, moduleTemplateList); err != nil {
-		return fmt.Errorf("failed to list ModuleTemplates: %w", err)
+		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
 	}
 
 	moduleTemplatesToSync := map[string]bool{}
-	for _, moduleReleaseMeta := range *moduleReleaseMetas {
+	for _, moduleReleaseMeta := range moduleReleaseMetas {
 		for _, channel := range moduleReleaseMeta.Spec.Channels {
 			moduleTemplatesToSync[fmt.Sprintf("%s-%s", moduleReleaseMeta.Spec.ModuleName, channel.Version)] = true
 		}
 	}
 
+	moduleTemplates := []v1beta2.ModuleTemplate{}
 	for _, moduleTemplate := range moduleTemplateList.Items {
 		if moduleTemplate.IsMandatory() {
 			continue
@@ -186,34 +186,34 @@ func (c *RemoteCatalog) GetModuleTemplatesToSync(
 		}
 
 		if _, found := moduleTemplatesToSync[moduleTemplate.Name]; found {
-			*moduleTemplates = append(*moduleTemplates, moduleTemplate)
+			moduleTemplates = append(moduleTemplates, moduleTemplate)
 		}
 	}
 
-	return nil
+	return moduleTemplates, nil
 }
 
 // https://github.com/kyma-project/lifecycle-manager/issues/2096
 // Remove this function after the migration to the new ModuleTemplate format is completed.
 func (c *RemoteCatalog) GetOldModuleTemplatesToSync(
 	ctx context.Context,
-	moduleTemplates *[]v1beta2.ModuleTemplate,
 	kyma *v1beta2.Kyma,
-) error {
+) ([]v1beta2.ModuleTemplate, error) {
 	moduleTemplateList := &v1beta2.ModuleTemplateList{}
 	if err := c.kcpClient.List(ctx, moduleTemplateList); err != nil {
-		return fmt.Errorf("failed to list ModuleTemplates: %w", err)
+		return nil, fmt.Errorf("failed to list ModuleTemplates: %w", err)
 	}
 
+	moduleTemplates := []v1beta2.ModuleTemplate{}
 	for _, moduleTemplate := range moduleTemplateList.Items {
 		if moduleTemplate.Spec.Channel == "" {
 			continue
 		}
 
 		if moduleTemplate.SyncEnabled(kyma.IsBeta(), kyma.IsInternal()) {
-			*moduleTemplates = append(*moduleTemplates, moduleTemplate)
+			moduleTemplates = append(moduleTemplates, moduleTemplate)
 		}
 	}
 
-	return nil
+	return moduleTemplates, nil
 }

--- a/internal/remote/remote_catalog_test.go
+++ b/internal/remote/remote_catalog_test.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kyma-project/lifecycle-manager/api"
-	"github.com/kyma-project/lifecycle-manager/api/shared"
-	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/kyma-project/lifecycle-manager/internal/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +11,11 @@ import (
 	machineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kyma-project/lifecycle-manager/api"
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/internal/remote"
 )
 
 func Test_GetModuleReleaseMetasToSync_ReturnsError_ForErrorClient(t *testing.T) {
@@ -152,7 +153,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaInternalNonSyncDisabledNonMa
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 2)
-	assert.Equal(t, "old-internal-module-regular", mts[0].ObjectMeta.Name)
+	assert.Equal(t, "old-internal-module-fast", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "old-module-regular", mts[1].ObjectMeta.Name)
 }
 
@@ -166,8 +167,8 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaInternalNonSyncDisabledNonManda
 	require.NoError(t, err)
 	assert.Len(t, mts, 4)
 	assert.Equal(t, "old-beta-module-regular", mts[0].ObjectMeta.Name)
-	assert.Equal(t, "old-internal-beta-module-regular", mts[1].ObjectMeta.Name)
-	assert.Equal(t, "old-internal-module-regular", mts[2].ObjectMeta.Name)
+	assert.Equal(t, "old-internal-beta-module-fast", mts[1].ObjectMeta.Name)
+	assert.Equal(t, "old-internal-module-fast", mts[2].ObjectMeta.Name)
 	assert.Equal(t, "old-module-regular", mts[3].ObjectMeta.Name)
 }
 
@@ -232,19 +233,19 @@ func fakeClient() client.Client {
 		withBetaEnabled().
 		build()
 	mt9 := newModuleTemplateBuilder().
-		withName("old-internal-module-regular").
-		withChannel("regular").
+		withName("old-internal-module-fast").
+		withChannel("fast").
 		withInternalEnabled().
 		build()
 	mt10 := newModuleTemplateBuilder().
-		withName("old-internal-beta-module-regular").
-		withChannel("regular").
+		withName("old-internal-beta-module-fast").
+		withChannel("fast").
 		withBetaEnabled().
 		withInternalEnabled().
 		build()
 	mt11 := newModuleTemplateBuilder().
-		withName("old-sync-disabled-module-regular").
-		withChannel("regular").
+		withName("old-sync-disabled-module-experimental").
+		withChannel("experimental").
 		withSyncDisabled().
 		build()
 	mt12 := newModuleTemplateBuilder().

--- a/internal/remote/remote_catalog_test.go
+++ b/internal/remote/remote_catalog_test.go
@@ -1,0 +1,368 @@
+package remote_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/lifecycle-manager/api"
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/internal/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	machineryruntime "k8s.io/apimachinery/pkg/runtime"
+	machineryutilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaNonInternalMRM_ForNonBetaNonInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().build()
+
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mrms, 1)
+	assert.Equal(t, "regular-module", mrms[0].Spec.ModuleName)
+}
+
+func Test_GetModuleReleaseMetasToSync_ReturnsBetaNonInternalMRM_ForBetaNonInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withBetaEnabled().build()
+
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mrms, 2)
+	assert.Equal(t, "beta-module", mrms[0].Spec.ModuleName)
+	assert.Equal(t, "regular-module", mrms[1].Spec.ModuleName)
+}
+
+func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaInternalMRM_ForNonBetaInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withInternalEnabled().build()
+
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mrms, 2)
+	assert.Equal(t, "internal-module", mrms[0].Spec.ModuleName)
+	assert.Equal(t, "regular-module", mrms[1].Spec.ModuleName)
+}
+
+func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
+
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mrms, 4)
+	assert.Equal(t, "beta-module", mrms[0].Spec.ModuleName)
+	assert.Equal(t, "internal-beta-module", mrms[1].Spec.ModuleName)
+	assert.Equal(t, "internal-module", mrms[2].Spec.ModuleName)
+	assert.Equal(t, "regular-module", mrms[3].Spec.ModuleName)
+}
+
+func Test_GetModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMandatoryNotSyncDisabled(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+
+	mts, err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), []v1beta2.ModuleReleaseMeta{
+		*newModuleReleaseMetaBuilder().
+			withName("regular-module").
+			withChannelVersion("regular", "1.0.0").
+			withChannelVersion("fast", "2.0.0").
+			withChannelVersion("sync-disabled", "3.0.0").
+			withChannelVersion("mandatory", "4.0.0").
+			build(),
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, mts, 2)
+	assert.Equal(t, "regular-module-1.0.0", mts[0].ObjectMeta.Name)
+	assert.Equal(t, "regular-module-2.0.0", mts[1].ObjectMeta.Name)
+}
+
+func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaNonInternalNonSyncDisabledNonMandatoryMTs_ForNonBetaNonInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().build()
+
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mts, 1)
+	assert.Equal(t, "old-module-regular", mts[0].ObjectMeta.Name)
+}
+
+func Test_GetOldModuleTemplatesToSync_ReturnsBetaNonInternalNonSyncDisabledNonMandatoryMTs_ForBetaNonInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withBetaEnabled().build()
+
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mts, 2)
+	assert.Equal(t, "old-beta-module-regular", mts[0].ObjectMeta.Name)
+	assert.Equal(t, "old-module-regular", mts[1].ObjectMeta.Name)
+}
+
+func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaInternalNonSyncDisabledNonMandatoryMTs_ForNonBetaInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withInternalEnabled().build()
+
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mts, 2)
+	assert.Equal(t, "old-internal-module-regular", mts[0].ObjectMeta.Name)
+	assert.Equal(t, "old-module-regular", mts[1].ObjectMeta.Name)
+}
+
+func Test_GetOldModuleTemplatesToSync_ReturnsBetaInternalNonSyncDisabledNonMandatoryMTs_ForBetaInternalKyma(t *testing.T) {
+	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
+	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
+
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.Len(t, mts, 4)
+	assert.Equal(t, "old-beta-module-regular", mts[0].ObjectMeta.Name)
+	assert.Equal(t, "old-internal-beta-module-regular", mts[1].ObjectMeta.Name)
+	assert.Equal(t, "old-internal-module-regular", mts[2].ObjectMeta.Name)
+	assert.Equal(t, "old-module-regular", mts[3].ObjectMeta.Name)
+}
+
+func fakeClient() client.Client {
+	mrm1 := newModuleReleaseMetaBuilder().
+		withName("regular-module").
+		withChannelVersion("regular", "1.0.0").
+		withChannelVersion("fast", "2.0.0").
+		withChannelVersion("sync-disabled", "3.0.0").
+		withChannelVersion("mandatory", "4.0.0").
+		build()
+	mrm2 := newModuleReleaseMetaBuilder().
+		withName("beta-module").
+		withChannelVersion("regular", "1.0.0").
+		withChannelVersion("fast", "2.0.0").
+		withBetaEnabled().
+		build()
+	mrm3 := newModuleReleaseMetaBuilder().
+		withName("internal-module").
+		withChannelVersion("regular", "1.0.0").
+		withChannelVersion("fast", "2.0.0").
+		withInternalEnabled().
+		build()
+	mrm4 := newModuleReleaseMetaBuilder().
+		withName("internal-beta-module").
+		withChannelVersion("regular", "1.0.0").
+		withChannelVersion("fast", "2.0.0").
+		withBetaEnabled().
+		withInternalEnabled().
+		build()
+
+	mt1 := newModuleTemplateBuilder().
+		withName("regular-module-1.0.0").
+		build()
+	mt2 := newModuleTemplateBuilder().
+		withName("regular-module-2.0.0").
+		build()
+	mt3 := newModuleTemplateBuilder().
+		withName("regular-module-3.0.0").
+		withSyncDisabled().
+		build()
+	mt4 := newModuleTemplateBuilder().
+		withName("regular-module-4.0.0").
+		withMandatoryEnabled().
+		build()
+	mt5 := newModuleTemplateBuilder().
+		withName("not-referenced-module-1.0.0").
+		build()
+	mt6 := newModuleTemplateBuilder().
+		withName("not-referenced-module-2.0.0").
+		build()
+
+	// https://github.com/kyma-project/lifecycle-manager/issues/2096
+	// Remove these after the migration to the new ModuleTemplate format is completed.
+	mt7 := newModuleTemplateBuilder().
+		withName("old-module-regular").
+		withChannel("regular").
+		build()
+	mt8 := newModuleTemplateBuilder().
+		withName("old-beta-module-regular").
+		withChannel("regular").
+		withBetaEnabled().
+		build()
+	mt9 := newModuleTemplateBuilder().
+		withName("old-internal-module-regular").
+		withChannel("regular").
+		withInternalEnabled().
+		build()
+	mt10 := newModuleTemplateBuilder().
+		withName("old-internal-beta-module-regular").
+		withChannel("regular").
+		withBetaEnabled().
+		withInternalEnabled().
+		build()
+	mt11 := newModuleTemplateBuilder().
+		withName("old-sync-disabled-module-regular").
+		withChannel("regular").
+		withSyncDisabled().
+		build()
+	mt12 := newModuleTemplateBuilder().
+		withName("old-mandatory-module").
+		withChannel("regular").
+		withMandatoryEnabled().
+		build()
+
+	mrms := &v1beta2.ModuleReleaseMetaList{
+		Items: []v1beta2.ModuleReleaseMeta{
+			*mrm1,
+			*mrm2,
+			*mrm3,
+			*mrm4,
+		},
+	}
+
+	mts := &v1beta2.ModuleTemplateList{
+		Items: []v1beta2.ModuleTemplate{
+			*mt1,
+			*mt2,
+			*mt3,
+			*mt4,
+			*mt5,
+			*mt6,
+			*mt7,
+			*mt8,
+			*mt9,
+			*mt10,
+			*mt11,
+			*mt12,
+		},
+	}
+
+	scheme := machineryruntime.NewScheme()
+	machineryutilruntime.Must(api.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithLists(mrms, mts).Build()
+}
+
+type moduleReleaseMetaBuilder struct {
+	moduleReleaseMeta *v1beta2.ModuleReleaseMeta
+}
+
+func newModuleReleaseMetaBuilder() *moduleReleaseMetaBuilder {
+	return &moduleReleaseMetaBuilder{
+		moduleReleaseMeta: &v1beta2.ModuleReleaseMeta{
+			Spec: v1beta2.ModuleReleaseMetaSpec{
+				Channels: []v1beta2.ChannelVersionAssignment{},
+			},
+		},
+	}
+}
+
+func (b *moduleReleaseMetaBuilder) build() *v1beta2.ModuleReleaseMeta {
+	return b.moduleReleaseMeta
+}
+
+func (b *moduleReleaseMetaBuilder) withName(module string) *moduleReleaseMetaBuilder {
+	b.moduleReleaseMeta.ObjectMeta.Name = module
+	b.moduleReleaseMeta.Spec.ModuleName = module
+	return b
+}
+
+func (b *moduleReleaseMetaBuilder) withChannelVersion(channel, version string) *moduleReleaseMetaBuilder {
+	b.moduleReleaseMeta.Spec.Channels = append(
+		b.moduleReleaseMeta.Spec.Channels,
+		v1beta2.ChannelVersionAssignment{Channel: channel, Version: version},
+	)
+	return b
+}
+
+func (b *moduleReleaseMetaBuilder) withBetaEnabled() *moduleReleaseMetaBuilder {
+	b.moduleReleaseMeta.Spec.Beta = true
+	return b
+}
+
+func (b *moduleReleaseMetaBuilder) withInternalEnabled() *moduleReleaseMetaBuilder {
+	b.moduleReleaseMeta.Spec.Internal = true
+	return b
+}
+
+type moduleTemplateBuilder struct {
+	moduleTemplate *v1beta2.ModuleTemplate
+}
+
+func newModuleTemplateBuilder() *moduleTemplateBuilder {
+	return &moduleTemplateBuilder{
+		moduleTemplate: &v1beta2.ModuleTemplate{
+			ObjectMeta: apimetav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		},
+	}
+}
+
+func (b *moduleTemplateBuilder) build() *v1beta2.ModuleTemplate {
+	return b.moduleTemplate
+}
+
+func (b *moduleTemplateBuilder) withName(name string) *moduleTemplateBuilder {
+	b.moduleTemplate.ObjectMeta.Name = name
+	return b
+}
+
+func (b *moduleTemplateBuilder) withChannel(channel string) *moduleTemplateBuilder {
+	b.moduleTemplate.Spec.Channel = channel
+	return b
+}
+
+func (b *moduleTemplateBuilder) withSyncDisabled() *moduleTemplateBuilder {
+	b.moduleTemplate.ObjectMeta.Labels[shared.SyncLabel] = shared.DisableLabelValue
+	return b
+}
+
+func (b *moduleTemplateBuilder) withMandatoryEnabled() *moduleTemplateBuilder {
+	b.moduleTemplate.Spec.Mandatory = true
+	b.moduleTemplate.ObjectMeta.Labels[shared.IsMandatoryModule] = shared.EnableLabelValue
+	return b
+}
+
+func (b *moduleTemplateBuilder) withBetaEnabled() *moduleTemplateBuilder {
+	b.moduleTemplate.ObjectMeta.Labels[shared.BetaLabel] = shared.EnableLabelValue
+	return b
+}
+
+func (b *moduleTemplateBuilder) withInternalEnabled() *moduleTemplateBuilder {
+	b.moduleTemplate.ObjectMeta.Labels[shared.InternalLabel] = shared.EnableLabelValue
+	return b
+}
+
+type kymaBuilder struct {
+	kyma *v1beta2.Kyma
+}
+
+func newKymaBuilder() *kymaBuilder {
+	return &kymaBuilder{
+		kyma: &v1beta2.Kyma{
+			ObjectMeta: apimetav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		},
+	}
+}
+
+func (b *kymaBuilder) build() *v1beta2.Kyma {
+	return b.kyma
+}
+
+func (b *kymaBuilder) withBetaEnabled() *kymaBuilder {
+	b.kyma.Labels[shared.BetaLabel] = shared.EnableLabelValue
+	return b
+}
+
+func (b *kymaBuilder) withInternalEnabled() *kymaBuilder {
+	b.kyma.Labels[shared.InternalLabel] = shared.EnableLabelValue
+	return b
+}

--- a/internal/remote/remote_catalog_test.go
+++ b/internal/remote/remote_catalog_test.go
@@ -35,7 +35,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaNonInternalMRM_ForNonBetaNon
 	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mrms, 1)
+	require.Len(t, mrms, 1)
 	assert.Equal(t, "regular-module", mrms[0].Spec.ModuleName)
 }
 
@@ -46,7 +46,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaNonInternalMRM_ForBetaNonIntern
 	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mrms, 2)
+	require.Len(t, mrms, 2)
 	assert.Equal(t, "beta-module", mrms[0].Spec.ModuleName)
 	assert.Equal(t, "regular-module", mrms[1].Spec.ModuleName)
 }
@@ -58,7 +58,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaInternalMRM_ForNonBetaIntern
 	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mrms, 2)
+	require.Len(t, mrms, 2)
 	assert.Equal(t, "internal-module", mrms[0].Spec.ModuleName)
 	assert.Equal(t, "regular-module", mrms[1].Spec.ModuleName)
 }
@@ -70,7 +70,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma
 	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mrms, 4)
+	require.Len(t, mrms, 4)
 	assert.Equal(t, "beta-module", mrms[0].Spec.ModuleName)
 	assert.Equal(t, "internal-beta-module", mrms[1].Spec.ModuleName)
 	assert.Equal(t, "internal-module", mrms[2].Spec.ModuleName)
@@ -100,7 +100,7 @@ func Test_GetModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMandato
 	})
 
 	require.NoError(t, err)
-	assert.Len(t, mts, 2)
+	require.Len(t, mts, 2)
 	assert.Equal(t, "regular-module-1.0.0", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "regular-module-2.0.0", mts[1].ObjectMeta.Name)
 }
@@ -118,7 +118,7 @@ func Test_FilterModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMand
 			build(),
 	})
 
-	assert.Len(t, mts, 2)
+	require.Len(t, mts, 2)
 	assert.Equal(t, "regular-module-1.0.0", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "regular-module-2.0.0", mts[1].ObjectMeta.Name)
 }
@@ -139,7 +139,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaNonInternalNonSyncDisabledNo
 	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mts, 1)
+	require.Len(t, mts, 1)
 	assert.Equal(t, "old-module-regular", mts[0].ObjectMeta.Name)
 }
 
@@ -150,7 +150,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaNonInternalNonSyncDisabledNonMa
 	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mts, 2)
+	require.Len(t, mts, 2)
 	assert.Equal(t, "old-beta-module-regular", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "old-module-regular", mts[1].ObjectMeta.Name)
 }
@@ -162,7 +162,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaInternalNonSyncDisabledNonMa
 	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mts, 2)
+	require.Len(t, mts, 2)
 	assert.Equal(t, "old-internal-module-fast", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "old-module-regular", mts[1].ObjectMeta.Name)
 }
@@ -174,7 +174,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaInternalNonSyncDisabledNonManda
 	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
-	assert.Len(t, mts, 4)
+	require.Len(t, mts, 4)
 	assert.Equal(t, "old-beta-module-regular", mts[0].ObjectMeta.Name)
 	assert.Equal(t, "old-internal-beta-module-fast", mts[1].ObjectMeta.Name)
 	assert.Equal(t, "old-internal-module-fast", mts[2].ObjectMeta.Name)
@@ -224,23 +224,35 @@ func moduleReleaseMetas() v1beta2.ModuleReleaseMetaList {
 func moduleTemplates() v1beta2.ModuleTemplateList {
 	mt1 := newModuleTemplateBuilder().
 		withName("regular-module-1.0.0").
+		withModuleName("regular-module").
+		withVersion("1.0.0").
 		build()
 	mt2 := newModuleTemplateBuilder().
 		withName("regular-module-2.0.0").
+		withModuleName("regular-module").
+		withVersion("2.0.0").
 		build()
 	mt3 := newModuleTemplateBuilder().
 		withName("regular-module-3.0.0").
+		withModuleName("regular-module").
+		withVersion("3.0.0").
 		withSyncDisabled().
 		build()
 	mt4 := newModuleTemplateBuilder().
 		withName("regular-module-4.0.0").
+		withModuleName("regular-module").
+		withVersion("4.0.0").
 		withMandatoryEnabled().
 		build()
 	mt5 := newModuleTemplateBuilder().
 		withName("not-referenced-module-1.0.0").
+		withModuleName("not-referenced-module").
+		withVersion("1.0.0").
 		build()
 	mt6 := newModuleTemplateBuilder().
 		withName("not-referenced-module-2.0.0").
+		withModuleName("not-referenced-module").
+		withVersion("2.0.0").
 		build()
 
 	// https://github.com/kyma-project/lifecycle-manager/issues/2096
@@ -368,6 +380,16 @@ func (b *moduleTemplateBuilder) build() *v1beta2.ModuleTemplate {
 
 func (b *moduleTemplateBuilder) withName(name string) *moduleTemplateBuilder {
 	b.moduleTemplate.ObjectMeta.Name = name
+	return b
+}
+
+func (b *moduleTemplateBuilder) withVersion(version string) *moduleTemplateBuilder {
+	b.moduleTemplate.Spec.Version = version
+	return b
+}
+
+func (b *moduleTemplateBuilder) withModuleName(module string) *moduleTemplateBuilder {
+	b.moduleTemplate.Spec.ModuleName = module
 	return b
 }
 

--- a/internal/remote/remote_catalog_test.go
+++ b/internal/remote/remote_catalog_test.go
@@ -22,7 +22,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsError_ForErrorClient(t *testing.T) 
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(newErrorClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().build()
 
-	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &[]v1beta2.ModuleReleaseMeta{}, kyma)
+	_, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list ModuleReleaseMetas")
@@ -32,8 +32,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaNonInternalMRM_ForNonBetaNon
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().build()
 
-	mrms := []v1beta2.ModuleReleaseMeta{}
-	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 1)
@@ -44,8 +43,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaNonInternalMRM_ForBetaNonIntern
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().build()
 
-	mrms := []v1beta2.ModuleReleaseMeta{}
-	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 2)
@@ -57,8 +55,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaInternalMRM_ForNonBetaIntern
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withInternalEnabled().build()
 
-	mrms := []v1beta2.ModuleReleaseMeta{}
-	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 2)
@@ -70,8 +67,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
 
-	mrms := []v1beta2.ModuleReleaseMeta{}
-	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
+	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 4)
@@ -84,7 +80,7 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma
 func Test_GetModuleTemplatesToSync_ReturnsError_ForErrorClient(t *testing.T) {
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(newErrorClient(), nil, "kyma-system")
 
-	err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), &[]v1beta2.ModuleTemplate{}, &[]v1beta2.ModuleReleaseMeta{})
+	_, err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), []v1beta2.ModuleReleaseMeta{})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list ModuleTemplates")
@@ -93,8 +89,7 @@ func Test_GetModuleTemplatesToSync_ReturnsError_ForErrorClient(t *testing.T) {
 func Test_GetModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMandatoryNotSyncDisabled(t *testing.T) {
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 
-	mts := []v1beta2.ModuleTemplate{}
-	err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), &mts, &[]v1beta2.ModuleReleaseMeta{
+	mts, err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), []v1beta2.ModuleReleaseMeta{
 		*newModuleReleaseMetaBuilder().
 			withName("regular-module").
 			withChannelVersion("regular", "1.0.0").
@@ -113,7 +108,7 @@ func Test_GetModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMandato
 func Test_GetOldModuleTemplatesToSync_ReturnsError_ForErrorClient(t *testing.T) {
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(newErrorClient(), nil, "kyma-system")
 
-	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &[]v1beta2.ModuleTemplate{}, newKymaBuilder().build())
+	_, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), newKymaBuilder().build())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to list ModuleTemplates")
@@ -123,8 +118,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaNonInternalNonSyncDisabledNo
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().build()
 
-	mts := []v1beta2.ModuleTemplate{}
-	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 1)
@@ -135,8 +129,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaNonInternalNonSyncDisabledNonMa
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().build()
 
-	mts := []v1beta2.ModuleTemplate{}
-	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 2)
@@ -148,8 +141,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaInternalNonSyncDisabledNonMa
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withInternalEnabled().build()
 
-	mts := []v1beta2.ModuleTemplate{}
-	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 2)
@@ -161,8 +153,7 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaInternalNonSyncDisabledNonManda
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
 
-	mts := []v1beta2.ModuleTemplate{}
-	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
+	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 4)

--- a/internal/remote/remote_catalog_test.go
+++ b/internal/remote/remote_catalog_test.go
@@ -21,7 +21,8 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaNonInternalMRM_ForNonBetaNon
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().build()
 
-	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+	mrms := []v1beta2.ModuleReleaseMeta{}
+	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 1)
@@ -32,7 +33,8 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaNonInternalMRM_ForBetaNonIntern
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().build()
 
-	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+	mrms := []v1beta2.ModuleReleaseMeta{}
+	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 2)
@@ -44,7 +46,8 @@ func Test_GetModuleReleaseMetasToSync_ReturnsNonBetaInternalMRM_ForNonBetaIntern
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withInternalEnabled().build()
 
-	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+	mrms := []v1beta2.ModuleReleaseMeta{}
+	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 2)
@@ -56,7 +59,8 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
 
-	mrms, err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), kyma)
+	mrms := []v1beta2.ModuleReleaseMeta{}
+	err := remoteCatalog.GetModuleReleaseMetasToSync(context.Background(), &mrms, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mrms, 4)
@@ -69,7 +73,8 @@ func Test_GetModuleReleaseMetasToSync_ReturnsBetaInternalMRM_ForBetaInternalKyma
 func Test_GetModuleTemplatesToSync_ReturnsMTsThatAreReferencedInMRMAndNotMandatoryNotSyncDisabled(t *testing.T) {
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 
-	mts, err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), []v1beta2.ModuleReleaseMeta{
+	mts := []v1beta2.ModuleTemplate{}
+	err := remoteCatalog.GetModuleTemplatesToSync(context.Background(), &mts, &[]v1beta2.ModuleReleaseMeta{
 		*newModuleReleaseMetaBuilder().
 			withName("regular-module").
 			withChannelVersion("regular", "1.0.0").
@@ -89,7 +94,8 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaNonInternalNonSyncDisabledNo
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().build()
 
-	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+	mts := []v1beta2.ModuleTemplate{}
+	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 1)
@@ -100,7 +106,8 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaNonInternalNonSyncDisabledNonMa
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().build()
 
-	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+	mts := []v1beta2.ModuleTemplate{}
+	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 2)
@@ -112,7 +119,8 @@ func Test_GetOldModuleTemplatesToSync_ReturnsNonBetaInternalNonSyncDisabledNonMa
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withInternalEnabled().build()
 
-	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+	mts := []v1beta2.ModuleTemplate{}
+	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 2)
@@ -124,7 +132,8 @@ func Test_GetOldModuleTemplatesToSync_ReturnsBetaInternalNonSyncDisabledNonManda
 	remoteCatalog := remote.NewRemoteCatalogFromKyma(fakeClient(), nil, "kyma-system")
 	kyma := newKymaBuilder().withBetaEnabled().withInternalEnabled().build()
 
-	mts, err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), kyma)
+	mts := []v1beta2.ModuleTemplate{}
+	err := remoteCatalog.GetOldModuleTemplatesToSync(context.Background(), &mts, kyma)
 
 	require.NoError(t, err)
 	assert.Len(t, mts, 4)

--- a/pkg/testutils/modulereleasemeta.go
+++ b/pkg/testutils/modulereleasemeta.go
@@ -60,6 +60,36 @@ func GetModuleReleaseMeta(ctx context.Context, moduleName, namespace string,
 	return mrm, nil
 }
 
+func SetModuleReleaseMetaBeta(ctx context.Context, beta bool, moduleName, namespace string, clnt client.Client) error {
+	mrm, err := GetModuleReleaseMeta(ctx, moduleName, namespace, clnt)
+	if err != nil {
+		return fmt.Errorf("failed to fetch modulereleasemeta, %w", err)
+	}
+
+	mrm.Spec.Beta = beta
+
+	if err := clnt.Update(ctx, mrm); err != nil {
+		return fmt.Errorf("failed to update modulereleasemeta, %w", err)
+	}
+
+	return nil
+}
+
+func SetModuleReleaseMetaInternal(ctx context.Context, internal bool, moduleName, namespace string, clnt client.Client) error {
+	mrm, err := GetModuleReleaseMeta(ctx, moduleName, namespace, clnt)
+	if err != nil {
+		return fmt.Errorf("failed to fetch modulereleasemeta, %w", err)
+	}
+
+	mrm.Spec.Internal = internal
+
+	if err := clnt.Update(ctx, mrm); err != nil {
+		return fmt.Errorf("failed to update modulereleasemeta, %w", err)
+	}
+
+	return nil
+}
+
 func ModuleReleaseMetaExists(ctx context.Context, moduleName, namespace string, clnt client.Client) error {
 	if _, err := GetModuleReleaseMeta(ctx, moduleName, namespace, clnt); err != nil {
 		if util.IsNotFound(err) {

--- a/pkg/testutils/moduletemplate.go
+++ b/pkg/testutils/moduletemplate.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -42,8 +43,12 @@ func ModuleTemplateExists(ctx context.Context,
 ) error {
 	moduleTemplate, err := GetModuleTemplate(ctx, clnt, module, defaultChannel, namespace)
 	if moduleTemplate == nil || errors.Is(err, templatelookup.ErrNoTemplatesInListResult) {
+		fmt.Println("======= ModuleTemplateExists doesn't exist=======")
 		return ErrNotFound
 	}
+
+	fmt.Println("======= ModuleTemplateExists =======")
+	fmt.Println(json.MarshalIndent(moduleTemplate, "", "  "))
 
 	return nil
 }

--- a/pkg/testutils/moduletemplate.go
+++ b/pkg/testutils/moduletemplate.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -43,13 +42,25 @@ func ModuleTemplateExists(ctx context.Context,
 ) error {
 	moduleTemplate, err := GetModuleTemplate(ctx, clnt, module, defaultChannel, namespace)
 	if moduleTemplate == nil || errors.Is(err, templatelookup.ErrNoTemplatesInListResult) {
-		fmt.Println("======= ModuleTemplateExists doesn't exist=======")
 		return ErrNotFound
 	}
 
-	fmt.Println("======= ModuleTemplateExists =======")
-	fmt.Println(json.MarshalIndent(moduleTemplate, "", "  "))
+	return nil
+}
 
+func ModuleTemplateExistsByName(ctx context.Context,
+	clnt client.Client,
+	moduleName string,
+	namespace string,
+) error {
+	if err := clnt.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      moduleName,
+	}, &v1beta2.ModuleTemplate{}); err != nil {
+		if util.IsNotFound(err) {
+			return ErrNotFound
+		}
+	}
 	return nil
 }
 

--- a/tests/e2e/modulereleasemeta_sync_test.go
+++ b/tests/e2e/modulereleasemeta_sync_test.go
@@ -1,8 +1,11 @@
 package e2e_test
 
 import (
+	"context"
+
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 
@@ -209,15 +212,27 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 				Should(Equal(ErrNotFound))
 
 			By("Then the Template Operator v2 ModuleTemplate exists in the KCP Cluster")
-			Eventually(ModuleTemplateExists).
+			Eventually(func(ctx context.Context, clnt client.Client, moduleName, namespace string) error {
+				mrm := &v1beta2.ModuleReleaseMeta{}
+				return clnt.Get(ctx, client.ObjectKey{
+					Namespace: namespace,
+					Name:      moduleName,
+				}, mrm)
+			}).
 				WithContext(ctx).
-				WithArguments(kcpClient, module, v1beta2.DefaultChannel, ControlPlaneNamespace).
+				WithArguments(kcpClient, module.Name, ControlPlaneNamespace).
 				Should(Succeed())
 
 			By("And Template Operator v2 ModuleTemplate no longer exists on the SKR Cluster")
-			Eventually(ModuleTemplateExists).
+			Eventually(func(ctx context.Context, clnt client.Client, moduleName, namespace string) error {
+				mrm := &v1beta2.ModuleReleaseMeta{}
+				return clnt.Get(ctx, client.ObjectKey{
+					Namespace: namespace,
+					Name:      moduleName,
+				}, mrm)
+			}).
 				WithContext(ctx).
-				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
+				WithArguments(skrClient, module.Name, RemoteNamespace).
 				Should(Equal(ErrNotFound))
 		})
 	})

--- a/tests/e2e/modulereleasemeta_sync_test.go
+++ b/tests/e2e/modulereleasemeta_sync_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
@@ -49,6 +50,82 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 			Eventually(ModuleReleaseMetaContainsCorrectChannelVersion).
 				WithContext(ctx).
 				WithArguments(module.Name, RemoteNamespace, v1beta2.DefaultChannel, v1Version, skrClient).
+				Should(Succeed())
+		})
+
+		It("When the ModuleReleaseMeta is set to beta", func() {
+			Eventually(SetModuleReleaseMetaBeta).
+				WithContext(ctx).
+				WithArguments(true, module.Name, ControlPlaneNamespace, kcpClient).
+				Should(Succeed())
+
+			By("Then the ModuleReleaseMeta no longer exists on the SKR Cluster")
+			Eventually(ModuleReleaseMetaExists).
+				WithContext(ctx).
+				WithArguments(module.Name, RemoteNamespace, skrClient).
+				Should(Equal(ErrNotFound))
+
+			By("And the Template Operator v1 ModuleTemplate no longer exists in the SKR Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
+				Should(Equal(ErrNotFound))
+		})
+
+		It("When the Kyma is set to beta", func() {
+			Eventually(UpdateKymaLabel).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace, shared.BetaLabel, shared.EnableLabelValue).
+				Should(Succeed())
+
+			By("Then the ModuleReleaseMeta exists on the SKR Cluster")
+			Eventually(ModuleReleaseMetaExists).
+				WithContext(ctx).
+				WithArguments(module.Name, RemoteNamespace, skrClient).
+				Should(Succeed())
+
+			By("And the Template Operator v1 ModuleTemplate exists in the SKR Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
+				Should(Succeed())
+		})
+
+		It("When the ModuleReleaseMeta is set to internal", func() {
+			Eventually(SetModuleReleaseMetaInternal).
+				WithContext(ctx).
+				WithArguments(true, module.Name, ControlPlaneNamespace, kcpClient).
+				Should(Succeed())
+
+			By("Then the ModuleReleaseMeta no longer exists on the SKR Cluster")
+			Eventually(ModuleReleaseMetaExists).
+				WithContext(ctx).
+				WithArguments(module.Name, RemoteNamespace, skrClient).
+				Should(Equal(ErrNotFound))
+
+			By("And the Template Operator v1 ModuleTemplate no longer exists in the SKR Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
+				Should(Equal(ErrNotFound))
+		})
+
+		It("When the Kyma is set to internal", func() {
+			Eventually(UpdateKymaLabel).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace, shared.InternalLabel, shared.EnableLabelValue).
+				Should(Succeed())
+
+			By("Then the ModuleReleaseMeta exists on the SKR Cluster")
+			Eventually(ModuleReleaseMetaExists).
+				WithContext(ctx).
+				WithArguments(module.Name, RemoteNamespace, skrClient).
+				Should(Succeed())
+
+			By("And the Template Operator v1 ModuleTemplate exists in the SKR Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
 				Should(Succeed())
 		})
 
@@ -129,6 +206,18 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 			Eventually(ModuleReleaseMetaExists).
 				WithContext(ctx).
 				WithArguments(module.Name, RemoteNamespace, skrClient).
+				Should(Equal(ErrNotFound))
+
+			By("Then the Template Operator v2 ModuleTemplate exists in the KCP Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(kcpClient, module, v1beta2.DefaultChannel, ControlPlaneNamespace).
+				Should(Succeed())
+
+			By("And Template Operator v2 ModuleTemplate no longer exists on the SKR Cluster")
+			Eventually(ModuleTemplateExists).
+				WithContext(ctx).
+				WithArguments(skrClient, module, v1beta2.DefaultChannel, RemoteNamespace).
 				Should(Equal(ErrNotFound))
 		})
 	})

--- a/tests/integration/controller/kcp/suite_test.go
+++ b/tests/integration/controller/kcp/suite_test.go
@@ -152,6 +152,7 @@ var _ = BeforeSuite(func() {
 		IsManagedKyma:       true,
 		Metrics:             metrics.NewKymaMetrics(metrics.NewSharedMetrics()),
 		ModuleMetrics:       metrics.NewModuleMetrics(),
+		RemoteCatalog:       remote.NewRemoteCatalogFromKyma(kcpClient, testSkrContextFactory, flags.DefaultRemoteSyncNamespace),
 	}).SetupWithManager(mgr, ctrlruntime.Options{},
 		kyma.SetupOptions{ListenerAddr: UseRandomPort})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/integration/controller/withwatcher/suite_test.go
+++ b/tests/integration/controller/withwatcher/suite_test.go
@@ -216,6 +216,7 @@ var _ = BeforeSuite(func() {
 		InKCPMode:           true,
 		Metrics:             metrics.NewKymaMetrics(metrics.NewSharedMetrics()),
 		ModuleMetrics:       metrics.NewModuleMetrics(),
+		RemoteCatalog:       remote.NewRemoteCatalogFromKyma(kcpClient, testSkrContextFactory, flags.DefaultRemoteSyncNamespace),
 	}).SetupWithManager(mgr, ctrlruntime.Options{}, kyma.SetupOptions{ListenerAddr: listenerAddr})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/unit-test-coverage.yaml
+++ b/unit-test-coverage.yaml
@@ -14,7 +14,7 @@ packages:
   internal/manifest/modulecr: 51.1
   internal/istio: 63.3
   internal/pkg/resources: 91.7
-  internal/remote: 13.2
+  internal/remote: 20.2
   internal/util/collections: 86
   pkg/templatelookup: 77.1
   pkg/gatewaysecret: 22.6


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

~~🚧 to be verified if we can also extend our integration tests~~ will be done as a separate PR
**Description**

Changes proposed in this pull request:

- introduces `beta` and `internal` flags to ModuleReleaseMeta
- respects the `beta` and `internal` flags when syncing ModuleReleaseMeta and its referenced modules to the SKR
- keeps the sync of ModuleTemplates using old format in it's current way
  - can be removed once we migrated fully
- determination of what to sync fully covered in unit tests
- E2E test for syncing module release meta extended with the new cases

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- resolves https://github.com/kyma-project/lifecycle-manager/issues/2059
