### PR TITLE
chore: No reconcile on Delete and Generic events

### DIFF
--- a/internal/controller/istiogatewaysecret/setup.go
+++ b/internal/controller/istiogatewaysecret/setup.go
@@ -62,6 +62,8 @@ func (r *Reconciler) setupWithManager(mgr ctrl.Manager, opts ctrlruntime.Options
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return isRootSecret(e.ObjectNew)
 		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 
 	if err := ctrl.NewControllerManagedBy(mgr).

--- a/unit-test-coverage.yaml
+++ b/unit-test-coverage.yaml
@@ -1,5 +1,5 @@
 packages:
-  internal/controller/istiogatewaysecret: 33
+  internal/controller/istiogatewaysecret: 31
   internal/crd: 92.1
   internal/descriptor/cache: 92.3
   internal/descriptor/provider: 66.7


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Since predicate funcs default to returning true, they need to be explicitly overwritten with return false if we don't want to reconcile on `Delete` and `Generic` events.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
