### PR TITLE
fix: Configure short leader election intervals for local testing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,7 +138,7 @@ func pprofStartServer(addr string, timeout time.Duration, setupLog logr.Logger) 
 	}
 }
 
-func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *machineryruntime.Scheme, setupLog logr.Logger) { //nolint: funlen // setupManager is a main function that sets up the manager
+func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *machineryruntime.Scheme, setupLog logr.Logger) { // nolint: funlen // setupManager is a main function that sets up the manager
 	config := ctrl.GetConfigOrDie()
 	config.QPS = float32(flagVar.ClientQPS)
 	config.Burst = flagVar.ClientBurst
@@ -154,6 +154,7 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 			LeaderElectionID:       "893110f7.kyma-project.io",
 			LeaseDuration:          &flagVar.LeaderElectionLeaseDuration,
 			RenewDeadline:          &flagVar.LeaderElectionRenewDeadline,
+			RetryPeriod:            &flagVar.LeaderElectionRetryPeriod,
 			Cache:                  cacheOptions,
 		},
 	)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,7 +138,7 @@ func pprofStartServer(addr string, timeout time.Duration, setupLog logr.Logger) 
 	}
 }
 
-func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *machineryruntime.Scheme, setupLog logr.Logger) { // nolint: funlen // setupManager is a main function that sets up the manager
+func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *machineryruntime.Scheme, setupLog logr.Logger) { //nolint: funlen // setupManager is a main function that sets up the manager
 	config := ctrl.GetConfigOrDie()
 	config.QPS = float32(flagVar.ClientQPS)
 	config.Burst = flagVar.ClientBurst

--- a/config/watcher_local_test/kustomization.yaml
+++ b/config/watcher_local_test/kustomization.yaml
@@ -37,6 +37,15 @@ patches:
     - op: add
       path: /spec/template/spec/containers/0/args/-
       value: --listener-port-overwrite=9443
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --leader-election-lease-duration=20s
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --leader-election-renew-deadline=15s
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --leader-election-retry-period=3s
     - op: replace
       path: /spec/template/spec/containers/0/imagePullPolicy
       value: Always

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -61,8 +61,8 @@ const (
 	DefaultWatcherResourceLimitsMemory                                  = "200Mi"
 	DefaultDropCrdStoredVersionMap                                      = "Manifest:v1beta1,Watcher:v1beta1,ModuleTemplate:v1beta1,Kyma:v1beta1"
 	DefaultMetricsCleanupIntervalInMinutes                              = 15
-	DefaultLeaderElectionLeaseDuration                                  = 20 * time.Second
-	DefaultLeaderElectionRenewDeadline                                  = 15 * time.Second
+	DefaultLeaderElectionLeaseDuration                                  = 180 * time.Second
+	DefaultLeaderElectionRenewDeadline                                  = 120 * time.Second
 	DefaultLeaderElectionRetryPeriod                                    = 3 * time.Second
 )
 

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -61,8 +61,9 @@ const (
 	DefaultWatcherResourceLimitsMemory                                  = "200Mi"
 	DefaultDropCrdStoredVersionMap                                      = "Manifest:v1beta1,Watcher:v1beta1,ModuleTemplate:v1beta1,Kyma:v1beta1"
 	DefaultMetricsCleanupIntervalInMinutes                              = 15
-	DefaultLeaderElectionLeaseDuration                                  = 180 * time.Second
-	DefaultLeaderElectionRenewDeadline                                  = 120 * time.Second
+	DefaultLeaderElectionLeaseDuration                                  = 20 * time.Second
+	DefaultLeaderElectionRenewDeadline                                  = 15 * time.Second
+	DefaultLeaderElectionRetryPeriod                                    = 3 * time.Second
 )
 
 var (
@@ -112,6 +113,9 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.LeaderElectionRenewDeadline, "leader-election-renew-deadline",
 		DefaultLeaderElectionRenewDeadline,
 		"Configures the 'RenewDeadline' option of the controller-runtime library used to run the controller manager process.")
+	flag.DurationVar(&flagVar.LeaderElectionRetryPeriod, "leader-election-retry-period",
+		DefaultLeaderElectionRetryPeriod,
+		"configures the 'RetryPeriod' option of the controller-runtime library used to run the controller manager process.")
 	flag.DurationVar(&flagVar.KymaRequeueSuccessInterval, "kyma-requeue-success-interval",
 		DefaultKymaRequeueSuccessInterval,
 		"determines the duration a Kyma in Ready state is enqueued for reconciliation.")
@@ -242,6 +246,7 @@ type FlagVar struct {
 	EnableLeaderElection                           bool
 	LeaderElectionLeaseDuration                    time.Duration
 	LeaderElectionRenewDeadline                    time.Duration
+	LeaderElectionRetryPeriod                      time.Duration
 	EnablePurgeFinalizer                           bool
 	EnableKcpWatcher                               bool
 	EnableWebhooks                                 bool

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -115,7 +115,7 @@ func DefineFlagVar() *FlagVar {
 		"Configures the 'RenewDeadline' option of the controller-runtime library used to run the controller manager process.")
 	flag.DurationVar(&flagVar.LeaderElectionRetryPeriod, "leader-election-retry-period",
 		DefaultLeaderElectionRetryPeriod,
-		"configures the 'RetryPeriod' option of the controller-runtime library used to run the controller manager process.")
+		"Configures the 'RetryPeriod' option of the controller-runtime library used to run the controller manager process.")
 	flag.DurationVar(&flagVar.KymaRequeueSuccessInterval, "kyma-requeue-success-interval",
 		DefaultKymaRequeueSuccessInterval,
 		"determines the duration a Kyma in Ready state is enqueued for reconciliation.")

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -253,12 +253,17 @@ func Test_ConstantFlags(t *testing.T) {
 		{
 			constName:     "DefaultLeaderElectionLeaseDuration",
 			constValue:    DefaultLeaderElectionLeaseDuration.String(),
-			expectedValue: (180 * time.Second).String(),
+			expectedValue: (20 * time.Second).String(),
 		},
 		{
 			constName:     "DefaultLeaderElectionRenewDeadline",
 			constValue:    DefaultLeaderElectionRenewDeadline.String(),
-			expectedValue: (120 * time.Second).String(),
+			expectedValue: (15 * time.Second).String(),
+		},
+		{
+			constName:     "DefaultLeaderElectionRetryPeriod",
+			constValue:    DefaultLeaderElectionRetryPeriod.String(),
+			expectedValue: (3 * time.Second).String(),
 		},
 	}
 	for _, testcase := range tests {

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -253,12 +253,12 @@ func Test_ConstantFlags(t *testing.T) {
 		{
 			constName:     "DefaultLeaderElectionLeaseDuration",
 			constValue:    DefaultLeaderElectionLeaseDuration.String(),
-			expectedValue: (20 * time.Second).String(),
+			expectedValue: (180 * time.Second).String(),
 		},
 		{
 			constName:     "DefaultLeaderElectionRenewDeadline",
 			constValue:    DefaultLeaderElectionRenewDeadline.String(),
-			expectedValue: (15 * time.Second).String(),
+			expectedValue: (120 * time.Second).String(),
 		},
 		{
 			constName:     "DefaultLeaderElectionRetryPeriod",


### PR DESCRIPTION
**Description**

- added retryPeriod as explicit flag
- updated configuration for local test setup to use shortened leader election intervals

**Related issue(s)**
resolves #1836 