### PR TITLE
chore: Add immediate requeues to MRM sync test

### DIFF
--- a/pkg/testutils/kyma.go
+++ b/pkg/testutils/kyma.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/pkg/status"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
 	"github.com/kyma-project/lifecycle-manager/pkg/watcher"
 )
@@ -231,6 +232,15 @@ func UpdateKymaLabel(
 		return fmt.Errorf("update kyma: %w", err)
 	}
 	return nil
+}
+
+// ImmediatelyRequeueKyma adds a dummy label to the Kyma CR to trigger a requeue.
+func ImmediatelyRequeueKyma(
+	ctx context.Context,
+	clnt client.Client,
+	kymaName, kymaNamespace string,
+) error {
+	return UpdateKymaLabel(ctx, clnt, kymaName, kymaNamespace, "operator.kyma-project.io/dummy-label", random.Name())
 }
 
 func GetKyma(ctx context.Context, clnt client.Client, name, namespace string) (*v1beta2.Kyma, error) {

--- a/tests/e2e/modulereleasemeta_sync_test.go
+++ b/tests/e2e/modulereleasemeta_sync_test.go
@@ -27,6 +27,11 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 				WithArguments(kcpClient, module, v1beta2.DefaultChannel, ControlPlaneNamespace).
 				Should(Succeed())
 
+			Eventually(ImmediatelyRequeueKyma).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace).
+				Should(Succeed())
+
 			By("And the Template Operator v1 ModuleTemplate exists in the SKR Cluster")
 			Eventually(ModuleTemplateExists).
 				WithContext(ctx).
@@ -60,6 +65,10 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 			Eventually(SetModuleReleaseMetaBeta).
 				WithContext(ctx).
 				WithArguments(true, module.Name, ControlPlaneNamespace, kcpClient).
+				Should(Succeed())
+			Eventually(ImmediatelyRequeueKyma).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace).
 				Should(Succeed())
 
 			By("Then the ModuleReleaseMeta no longer exists on the SKR Cluster")
@@ -98,6 +107,10 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 			Eventually(SetModuleReleaseMetaInternal).
 				WithContext(ctx).
 				WithArguments(true, module.Name, ControlPlaneNamespace, kcpClient).
+				Should(Succeed())
+			Eventually(ImmediatelyRequeueKyma).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace).
 				Should(Succeed())
 
 			By("Then the ModuleReleaseMeta no longer exists on the SKR Cluster")
@@ -157,6 +170,10 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 				WithContext(ctx).
 				WithArguments(kcpClient, module.Name, ControlPlaneNamespace, v1beta2.DefaultChannel, NewerVersion).
 				Should(Succeed())
+			Eventually(ImmediatelyRequeueKyma).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace).
+				Should(Succeed())
 
 			By("Then the Template Operator v2 ModuleTemplate exists in the KCP Cluster")
 			Eventually(ModuleTemplateExists).
@@ -197,6 +214,10 @@ var _ = Describe("ModuleReleaseMeta Sync", Ordered, func() {
 			Eventually(DeleteModuleReleaseMeta).
 				WithContext(ctx).
 				WithArguments(module.Name, ControlPlaneNamespace, kcpClient).
+				Should(Succeed())
+			Eventually(ImmediatelyRequeueKyma).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.Name, kyma.Namespace).
 				Should(Succeed())
 
 			By("Then the ModuleReleaseMeta no longer exists on the KCP Cluster")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Immediately requeue Kyma in `modulereleasemeta_sync` test to avoid timeouts
- As discussed in https://github.com/kyma-project/lifecycle-manager/issues/2127, we rely on regular requeue intervals in production

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/lifecycle-manager/issues/2127