### PR TITLE
chore: Add version and name helpers to ModuleTemplate

### DIFF
--- a/api/v1beta2/moduletemplate_types_test.go
+++ b/api/v1beta2/moduletemplate_types_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_GetVersion(t *testing.T) {
+func Test_GetSemanticVersion(t *testing.T) {
 	const testVersion = "1.0.1"
 	const otherVersion = "0.0.1"
 	tests := []struct {
@@ -20,7 +21,7 @@ func Test_GetVersion(t *testing.T) {
 		expectedErr     string
 	}{
 		{
-			name: "Test GetVersion() by annotation (legacy)",
+			name: "Test GetSemanticVersion() by annotation (legacy)",
 			m: &v1beta2.ModuleTemplate{
 				ObjectMeta: apimetav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -31,7 +32,7 @@ func Test_GetVersion(t *testing.T) {
 			expectedVersion: testVersion,
 		},
 		{
-			name: "Test GetVersion() by explicit version in Spec",
+			name: "Test GetSemanticVersion() by explicit version in Spec",
 			m: &v1beta2.ModuleTemplate{
 				Spec: v1beta2.ModuleTemplateSpec{
 					Version: testVersion,
@@ -40,7 +41,7 @@ func Test_GetVersion(t *testing.T) {
 			expectedVersion: testVersion,
 		},
 		{
-			name: "Test GetVersion() with both version in Spec and annotation",
+			name: "Test GetSemanticVersion() with both version in Spec and annotation",
 			m: &v1beta2.ModuleTemplate{
 				ObjectMeta: apimetav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -75,32 +76,137 @@ func Test_GetVersion(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			actualVersion, err := testCase.m.GetVersion()
+			actualVersion, err := testCase.m.GetSemanticVersion()
 			if err != nil {
 				if actualVersion != nil {
-					t.Errorf("GetVersion(): Returned version should be nil when error is not nil")
+					t.Errorf("GetSemanticVersion(): Returned version should be nil when error is not nil")
 				}
 				if testCase.expectedErr == "" {
-					t.Errorf("GetVersion(): Unexpected error: %v", err)
+					t.Errorf("GetSemanticVersion(): Unexpected error: %v", err)
 				}
 				if !strings.Contains(err.Error(), testCase.expectedErr) {
-					t.Errorf("GetVersion(): Actual error = %v, expected error: %v", err, testCase.expectedErr)
+					t.Errorf("GetSemanticVersion(): Actual error = %v, expected error: %v", err, testCase.expectedErr)
 				}
 				return
 			}
 
 			if actualVersion == nil {
-				t.Errorf("GetVersion(): Returned version should not be nil when error is nil")
+				t.Errorf("GetSemanticVersion(): Returned version should not be nil when error is nil")
 			}
 
 			if testCase.expectedVersion == "" {
-				t.Errorf("GetVersion(): Expected version is empty but non-nil version is returned")
+				t.Errorf("GetSemanticVersion(): Expected version is empty but non-nil version is returned")
 			}
 
 			if actualVersion != nil && actualVersion.String() != testCase.expectedVersion {
-				t.Errorf("GetVersion(): actual version = %v, expected version: %v", actualVersion.String(),
+				t.Errorf("GetSemanticVersion(): actual version = %v, expected version: %v", actualVersion.String(),
 					testCase.expectedVersion)
 			}
+		})
+	}
+}
+
+func Test_GetVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		m               *v1beta2.ModuleTemplate
+		expectedVersion string
+	}{
+		{
+			name: "Test GetVersion() by annotation (legacy)",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Annotations: map[string]string{
+						shared.ModuleVersionAnnotation: "1.0.0-annotated",
+					},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{},
+			},
+			expectedVersion: "1.0.0-annotated",
+		},
+		{
+			name: "Test GetVersion() by spec.version",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{
+					Version: "2.0.0-spec",
+				},
+			},
+			expectedVersion: "2.0.0-spec",
+		},
+		{
+			name: "Test GetVersion() spec.moduleName has priority over annotation",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Annotations: map[string]string{
+						shared.ModuleVersionAnnotation: "1.0.0-annotated",
+					},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{
+					Version: "2.0.0-spec",
+				},
+			},
+			expectedVersion: "2.0.0-spec",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualVersion := testCase.m.GetVersion()
+			assert.Equal(t, testCase.expectedVersion, actualVersion)
+		})
+	}
+}
+func Test_GetModuleName(t *testing.T) {
+	tests := []struct {
+		name         string
+		m            *v1beta2.ModuleTemplate
+		expectedName string
+	}{
+		{
+			name: "Test GetModuleName() by label",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Labels: map[string]string{
+						shared.ModuleName: "labelled-module",
+					},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{},
+			},
+			expectedName: "labelled-module",
+		},
+		{
+			name: "Test GetModuleName() by spec.moduleName",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{
+					ModuleName: "spec-module",
+				},
+			},
+			expectedName: "spec-module",
+		},
+		{
+			name: "Test GetModuleName() spec.moduleName has priority over label",
+			m: &v1beta2.ModuleTemplate{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Labels: map[string]string{
+						shared.ModuleName: "labelled-module",
+					},
+				},
+				Spec: v1beta2.ModuleTemplateSpec{
+					ModuleName: "spec-module",
+				},
+			},
+			expectedName: "spec-module",
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualName := testCase.m.GetModuleName()
+			assert.Equal(t, testCase.expectedName, actualName)
 		})
 	}
 }

--- a/api/v1beta2/moduletemplate_types_test.go
+++ b/api/v1beta2/moduletemplate_types_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_GetSemanticVersion(t *testing.T) {
@@ -106,6 +106,7 @@ func Test_GetSemanticVersion(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func Test_GetVersion(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -158,6 +159,8 @@ func Test_GetVersion(t *testing.T) {
 		})
 	}
 }
+
+//nolint:dupl
 func Test_GetModuleName(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/api/v1beta2/moduletemplate_types_test.go
+++ b/api/v1beta2/moduletemplate_types_test.go
@@ -106,7 +106,7 @@ func Test_GetSemanticVersion(t *testing.T) {
 	}
 }
 
-//nolint:dupl
+//nolint:dupl  // similar but not duplicate
 func Test_GetVersion(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -160,7 +160,7 @@ func Test_GetVersion(t *testing.T) {
 	}
 }
 
-//nolint:dupl
+//nolint:dupl  // similar but not duplicate
 func Test_GetModuleName(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/descriptor/cache/key.go
+++ b/internal/descriptor/cache/key.go
@@ -9,7 +9,7 @@ import (
 type DescriptorKey string
 
 func GenerateDescriptorKey(template *v1beta2.ModuleTemplate) DescriptorKey {
-	version, err := template.GetVersion()
+	version, err := template.GetSemanticVersion()
 	if err == nil {
 		return DescriptorKey(fmt.Sprintf("%s:%s:%d:%s", template.Name, template.Spec.Channel, template.Generation,
 			version))

--- a/internal/maintenancewindows/maintenance_window.go
+++ b/internal/maintenancewindows/maintenance_window.go
@@ -73,14 +73,13 @@ func (MaintenanceWindow) IsRequired(moduleTemplate *v1beta2.ModuleTemplate, kyma
 	}
 
 	// module not installed yet => no need for maintenance window
-	moduleStatus := kyma.Status.GetModuleStatus(moduleTemplate.Spec.ModuleName)
+	moduleStatus := kyma.Status.GetModuleStatus(moduleTemplate.GetModuleName())
 	if moduleStatus == nil {
 		return false
 	}
 
 	// module already installed in this version => no need for maintenance window
-	installedVersion := moduleStatus.Version
-	return installedVersion != moduleTemplate.Spec.Version
+	return moduleStatus.Version != moduleTemplate.GetVersion()
 }
 
 // IsActive determines if a maintenance window is currently active.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds another set of helpers to the ModuleTemplate type for getting version and name
- Background: make it more robust when handling different gerneations of ModuleTempalte (old ones, new ones)
  - e.g., in the maintenance window logic

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.com/kyma-project/lifecycle-manager/issues/2101
