### PR TITLE
fix: Nil pointer when unmanaging module with `Ignore` CustomResourcePolicy

### DIFF
--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,14 +51,15 @@ func NewFromManager(mgr manager.Manager, requeueIntervals queue.RequeueIntervals
 	reconciler.RequeueIntervals = requeueIntervals
 	reconciler.specResolver = specResolver
 	reconciler.manifestClient = manifestAPIClient
-	reconciler.managedLabelRemovalService = labelsremoval.NewManagedLabelRemovalService(manifestAPIClient)
+	reconciler.managedLabelRemovalService = labelsremoval.NewManagedByLabelRemovalService(manifestAPIClient)
 	reconciler.Options = DefaultOptions().Apply(WithManager(mgr)).Apply(options...)
 	return reconciler
 }
 
-type ManagedLabelRemoval interface {
-	RemoveManagedLabel(ctx context.Context,
-		manifest *v1beta2.Manifest, skrClient client.Client, defaultCR *unstructured.Unstructured,
+type ManagedByLabelRemoval interface {
+	RemoveManagedByLabel(ctx context.Context,
+		manifest *v1beta2.Manifest,
+		skrClient client.Client,
 	) error
 }
 
@@ -77,7 +77,7 @@ type Reconciler struct {
 	MandatoryModuleMetrics     *metrics.MandatoryModulesMetrics
 	specResolver               SpecResolver
 	manifestClient             ManifestAPIClient
-	managedLabelRemovalService ManagedLabelRemoval
+	managedLabelRemovalService ManagedByLabelRemoval
 }
 
 //nolint:funlen,cyclop,gocognit // Declarative pkg will be removed soon
@@ -123,7 +123,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return r.cleanupManifest(ctx, manifest, manifestStatus, metrics.ManifestUnmanagedUpdate, nil)
 		}
 
-		if controllerutil.ContainsFinalizer(manifest, labelsremoval.LabelRemovalFinalizer) {
+		if controllerutil.ContainsFinalizer(manifest, finalizer.LabelRemovalFinalizer) {
 			return r.handleLabelsRemovalFinalizer(ctx, skrClient, manifest)
 		}
 
@@ -222,13 +222,9 @@ func recordMandatoryModuleState(manifest *v1beta2.Manifest, r *Reconciler) {
 func (r *Reconciler) handleLabelsRemovalFinalizer(ctx context.Context, skrClient client.Client,
 	manifest *v1beta2.Manifest,
 ) (ctrl.Result, error) {
-	defaultCR, err := modulecr.NewClient(skrClient).GetCR(ctx, manifest)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	err := r.managedLabelRemovalService.RemoveManagedByLabel(ctx, manifest, skrClient)
 
-	if err := r.managedLabelRemovalService.RemoveManagedLabel(ctx, manifest, skrClient,
-		defaultCR); err != nil {
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -223,7 +223,6 @@ func (r *Reconciler) handleLabelsRemovalFinalizer(ctx context.Context, skrClient
 	manifest *v1beta2.Manifest,
 ) (ctrl.Result, error) {
 	err := r.managedLabelRemovalService.RemoveManagedByLabel(ctx, manifest, skrClient)
-
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/manifest/finalizer/handler.go
+++ b/internal/manifest/finalizer/handler.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/kyma-project/lifecycle-manager/internal/manifest/labelsremoval"
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
@@ -19,11 +18,12 @@ var ErrRequeueRequired = errors.New("requeue required")
 const (
 	DefaultFinalizer               = "declarative.kyma-project.io/finalizer"
 	CustomResourceManagerFinalizer = "resource.kyma-project.io/finalizer"
+	LabelRemovalFinalizer          = "label-removal-finalizer"
 )
 
 // RemoveRequiredFinalizers removes preconfigured finalizers, but not include CustomResourceManagerFinalizer.
 func RemoveRequiredFinalizers(manifest *v1beta2.Manifest) bool {
-	finalizersToRemove := []string{DefaultFinalizer, labelsremoval.LabelRemovalFinalizer}
+	finalizersToRemove := []string{DefaultFinalizer, LabelRemovalFinalizer}
 
 	finalizerRemoved := false
 	for _, f := range finalizersToRemove {
@@ -46,7 +46,7 @@ func RemoveAllFinalizers(manifest *v1beta2.Manifest) bool {
 
 func FinalizersUpdateRequired(manifest *v1beta2.Manifest) bool {
 	defaultFinalizerAdded := controllerutil.AddFinalizer(manifest, DefaultFinalizer)
-	labelRemovalFinalizerAdded := controllerutil.AddFinalizer(manifest, labelsremoval.LabelRemovalFinalizer)
+	labelRemovalFinalizerAdded := controllerutil.AddFinalizer(manifest, LabelRemovalFinalizer)
 	return defaultFinalizerAdded || labelRemovalFinalizerAdded
 }
 

--- a/internal/manifest/labelsremoval/labels_removal_test.go
+++ b/internal/manifest/labelsremoval/labels_removal_test.go
@@ -1,4 +1,4 @@
-package labelsremoval
+package labelsremoval_test
 
 import (
 	"context"
@@ -16,31 +16,9 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/internal/manifest/labelsremoval"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 )
-
-func Test_needsUpdateAfterLabelRemoval_WhenLabelsAreEmpty(t *testing.T) {
-	emptyLabels := map[string]string{}
-	res := &unstructured.Unstructured{}
-	res.SetLabels(emptyLabels)
-	actual := removeManagedLabel(res)
-
-	require.False(t, actual)
-	require.Equal(t, emptyLabels, res.GetLabels())
-}
-
-func Test_needsUpdateAfterLabelRemoval_WhenManagedByLabel(t *testing.T) {
-	labels := map[string]string{
-		shared.ManagedBy: shared.ManagedByLabelValue,
-	}
-	expectedLabels := map[string]string{}
-	res := &unstructured.Unstructured{}
-	res.SetLabels(labels)
-	actual := removeManagedLabel(res)
-
-	require.True(t, actual)
-	require.Equal(t, expectedLabels, res.GetLabels())
-}
 
 func Test_RemoveManagedByLabel_WhenManifestResourcesHaveLabels(t *testing.T) {
 	gvk := schema.GroupVersionKind{
@@ -107,7 +85,7 @@ func Test_RemoveManagedByLabel_WhenManifestResourcesHaveLabels(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	manifestClient := manifestClientStub{}
 
-	service := NewManagedByLabelRemovalService(&manifestClient)
+	service := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 	require.NoError(t, err)
@@ -156,7 +134,7 @@ func Test_RemoveManagedByLabel_WhenManifestResourceCannotBeFetched(t *testing.T)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	manifestClient := manifestClientStub{}
 
-	svc := NewManagedByLabelRemovalService(&manifestClient)
+	svc := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = svc.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 	require.ErrorContains(t, err, "failed to get resource")
@@ -187,7 +165,7 @@ func Test_RemoveManagedByLabel_WhenDefaultCRHasLabels(t *testing.T) {
 	manifest := builder.NewManifestBuilder().WithResource(defaultCR).Build()
 	manifestClient := manifestClientStub{}
 
-	service := NewManagedByLabelRemovalService(&manifestClient)
+	service := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 
@@ -223,7 +201,7 @@ func Test_RemoveManagedByLabel_WhenDefaultCRCannotBeFetched(t *testing.T) {
 	manifest := builder.NewManifestBuilder().WithResource(defaultCR).Build()
 	manifestClient := manifestClientStub{}
 
-	service := NewManagedByLabelRemovalService(&manifestClient)
+	service := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 
@@ -274,7 +252,7 @@ func Test_RemoveManagedByLabel_WhenObjCannotBeUpdated(t *testing.T) {
 	manifest := builder.NewManifestBuilder().WithStatus(status).Build()
 	manifestClient := manifestClientStub{}
 
-	service := NewManagedByLabelRemovalService(&manifestClient)
+	service := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = service.RemoveManagedByLabel(context.TODO(), manifest, errorClientStub{fakeClient: fakeClient})
 
@@ -292,7 +270,7 @@ func Test_RemoveManagedByLabel_WhenManifestResourcesAreNilAndNoDefaultCR(t *test
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	manifestClient := manifestClientStub{}
 
-	service := NewManagedByLabelRemovalService(&manifestClient)
+	service := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 
@@ -343,7 +321,7 @@ func Test_RemoveManagedByLabel_WhenFinalizerIsRemoved(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(manifest).WithObjects(objs...).Build()
 	manifestClient := manifestClientStub{}
-	svc := NewManagedByLabelRemovalService(&manifestClient)
+	svc := labelsremoval.NewManagedByLabelRemovalService(&manifestClient)
 
 	err = svc.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 

--- a/internal/manifest/labelsremoval/labels_removal_test.go
+++ b/internal/manifest/labelsremoval/labels_removal_test.go
@@ -1,9 +1,11 @@
-package labelsremoval_test
+package labelsremoval
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,8 +16,6 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/kyma-project/lifecycle-manager/internal/manifest/labelsremoval"
-	"github.com/kyma-project/lifecycle-manager/internal/manifest/manifestclient"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 )
 
@@ -23,7 +23,7 @@ func Test_needsUpdateAfterLabelRemoval_WhenLabelsAreEmpty(t *testing.T) {
 	emptyLabels := map[string]string{}
 	res := &unstructured.Unstructured{}
 	res.SetLabels(emptyLabels)
-	actual := labelsremoval.IsManagedLabelRemoved(res)
+	actual := removeManagedLabel(res)
 
 	require.False(t, actual)
 	require.Equal(t, emptyLabels, res.GetLabels())
@@ -36,13 +36,13 @@ func Test_needsUpdateAfterLabelRemoval_WhenManagedByLabel(t *testing.T) {
 	expectedLabels := map[string]string{}
 	res := &unstructured.Unstructured{}
 	res.SetLabels(labels)
-	actual := labelsremoval.IsManagedLabelRemoved(res)
+	actual := removeManagedLabel(res)
 
 	require.True(t, actual)
 	require.Equal(t, expectedLabels, res.GetLabels())
 }
 
-func Test_handleLabelsRemovalFromResources_WhenManifestResourcesHaveLabels(t *testing.T) {
+func Test_RemoveManagedByLabel_WhenManifestResourcesHaveLabels(t *testing.T) {
 	gvk := schema.GroupVersionKind{
 		Group:   "test-group",
 		Version: "v1",
@@ -105,8 +105,11 @@ func Test_handleLabelsRemovalFromResources_WhenManifestResourcesHaveLabels(t *te
 	err := v1beta2.AddToScheme(scheme)
 	require.NoError(t, err)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	manifestClient := manifestClientStub{}
 
-	err = labelsremoval.HandleLabelsRemovalFromResources(context.TODO(), manifest, fakeClient, nil)
+	service := NewManagedByLabelRemovalService(&manifestClient)
+
+	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 	require.NoError(t, err)
 
 	firstObj, secondObj := &unstructured.Unstructured{}, &unstructured.Unstructured{}
@@ -121,29 +124,20 @@ func Test_handleLabelsRemovalFromResources_WhenManifestResourcesHaveLabels(t *te
 		secondObj)
 	require.NoError(t, err)
 	require.Empty(t, secondObj.GetLabels())
+
+	assert.True(t, manifestClient.called)
 }
 
-func Test_handleLabelsRemovalFromResources_WhenManifestResourcesAreNilAndNoDefaultCR(t *testing.T) {
-	manifest := builder.NewManifestBuilder().Build()
-
+func Test_RemoveManagedByLabel_WhenManifestResourceCannotBeFetched(t *testing.T) {
 	scheme := machineryruntime.NewScheme()
 	err := v1beta2.AddToScheme(scheme)
 	require.NoError(t, err)
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	err = labelsremoval.HandleLabelsRemovalFromResources(context.TODO(), manifest, fakeClient, nil)
-
-	require.NoError(t, err)
-}
-
-func Test_handleLabelsRemovalFromResources_WhenManifestResourcesAndDefaultCRHaveLabels(t *testing.T) {
 	gvk := schema.GroupVersionKind{
 		Group:   "test-group",
 		Version: "v1",
 		Kind:    "TestKind",
 	}
-
 	status := shared.Status{
 		Synced: []shared.Resource{
 			{
@@ -158,6 +152,104 @@ func Test_handleLabelsRemovalFromResources_WhenManifestResourcesAndDefaultCRHave
 		},
 	}
 	manifest := builder.NewManifestBuilder().WithStatus(status).Build()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	manifestClient := manifestClientStub{}
+
+	svc := NewManagedByLabelRemovalService(&manifestClient)
+
+	err = svc.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
+	require.ErrorContains(t, err, "failed to get resource")
+	assert.False(t, manifestClient.called)
+}
+
+func Test_RemoveManagedByLabel_WhenDefaultCRHasLabels(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "test-group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}
+
+	defaultCR := &unstructured.Unstructured{}
+	defaultCR.SetName("default-cr")
+	defaultCR.SetNamespace("default-ns")
+	defaultCR.SetGroupVersionKind(gvk)
+	defaultCR.SetLabels(map[string]string{
+		"operator.kyma-project.io/managed-by": "kyma",
+	})
+	objs := []client.Object{defaultCR}
+
+	scheme := machineryruntime.NewScheme()
+	err := v1beta2.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	manifest := builder.NewManifestBuilder().WithResource(defaultCR).Build()
+	manifestClient := manifestClientStub{}
+
+	service := NewManagedByLabelRemovalService(&manifestClient)
+
+	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
+
+	require.NoError(t, err)
+
+	err = fakeClient.Get(context.TODO(),
+		client.ObjectKey{Name: "default-cr", Namespace: "default-ns"},
+		defaultCR)
+	require.NoError(t, err)
+	assert.Empty(t, defaultCR.GetLabels())
+}
+
+func Test_RemoveManagedByLabel_WhenDefaultCRCannotBeFetched(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "test-group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}
+
+	defaultCR := &unstructured.Unstructured{}
+	defaultCR.SetName("default-cr")
+	defaultCR.SetNamespace("default-ns")
+	defaultCR.SetGroupVersionKind(gvk)
+	defaultCR.SetLabels(map[string]string{
+		"operator.kyma-project.io/managed-by": "kyma",
+	})
+
+	scheme := machineryruntime.NewScheme()
+	err := v1beta2.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	manifest := builder.NewManifestBuilder().WithResource(defaultCR).Build()
+	manifestClient := manifestClientStub{}
+
+	service := NewManagedByLabelRemovalService(&manifestClient)
+
+	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
+
+	require.ErrorContains(t, err, "failed to get default CR")
+	assert.False(t, manifestClient.called)
+}
+
+func Test_RemoveManagedByLabel_WhenObjCannotBeUpdated(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "test-group",
+		Version: "v1",
+		Kind:    "TestKind",
+	}
+	status := shared.Status{
+		Synced: []shared.Resource{
+			{
+				Name:      "test-resource-1",
+				Namespace: "test-1",
+				GroupVersionKind: apimetav1.GroupVersionKind{
+					Group:   gvk.Group,
+					Version: gvk.Version,
+					Kind:    gvk.Kind,
+				},
+			},
+		},
+	}
 
 	objs := []client.Object{
 		&unstructured.Unstructured{
@@ -174,73 +266,41 @@ func Test_handleLabelsRemovalFromResources_WhenManifestResourcesAndDefaultCRHave
 		"operator.kyma-project.io/managed-by": "kyma",
 	})
 
-	defaultCR := &unstructured.Unstructured{}
-	defaultCR.SetName("default-cr")
-	defaultCR.SetNamespace("default-ns")
-	defaultCR.SetGroupVersionKind(gvk)
-	defaultCR.SetLabels(map[string]string{
-		"operator.kyma-project.io/managed-by": "kyma",
-	})
-
-	objs = append(objs, defaultCR)
-
 	scheme := machineryruntime.NewScheme()
 	err := v1beta2.AddToScheme(scheme)
 	require.NoError(t, err)
-
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
-	err = labelsremoval.HandleLabelsRemovalFromResources(context.TODO(), manifest, fakeClient,
-		defaultCR)
+	manifest := builder.NewManifestBuilder().WithStatus(status).Build()
+	manifestClient := manifestClientStub{}
 
-	require.NoError(t, err)
+	service := NewManagedByLabelRemovalService(&manifestClient)
 
-	firstObj := &unstructured.Unstructured{}
-	firstObj.SetGroupVersionKind(gvk)
-	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: "test-resource-1", Namespace: "test-1"},
-		firstObj)
-	require.NoError(t, err)
-	require.Empty(t, firstObj.GetLabels())
+	err = service.RemoveManagedByLabel(context.TODO(), manifest, errorClientStub{fakeClient: fakeClient})
 
-	require.NoError(t, err)
-	require.Empty(t, defaultCR.GetLabels())
+	require.ErrorContains(t, err, "failed to update object")
+	require.ErrorContains(t, err, "test error")
 }
 
-func Test_RemoveManagedLabel_WhenErrorIsReturned(t *testing.T) {
+func Test_RemoveManagedByLabel_WhenManifestResourcesAreNilAndNoDefaultCR(t *testing.T) {
+	manifest := builder.NewManifestBuilder().Build()
+
 	scheme := machineryruntime.NewScheme()
 	err := v1beta2.AddToScheme(scheme)
 	require.NoError(t, err)
 
-	gvk := schema.GroupVersionKind{
-		Group:   "test-group",
-		Version: "v1",
-		Kind:    "TestKind",
-	}
-	status := shared.Status{
-		Synced: []shared.Resource{
-			{
-				Name:      "test-resource-1",
-				Namespace: "test-1",
-				GroupVersionKind: apimetav1.GroupVersionKind{
-					Group:   gvk.Group,
-					Version: gvk.Version,
-					Kind:    gvk.Kind,
-				},
-			},
-		},
-	}
-	manifest := builder.NewManifestBuilder().WithStatus(status).Build()
-
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	manifestClient := manifestClientStub{}
 
-	manifestClnt := manifestclient.NewManifestClient(nil, fakeClient)
-	svc := labelsremoval.NewManagedLabelRemovalService(manifestClnt)
+	service := NewManagedByLabelRemovalService(&manifestClient)
 
-	err = svc.RemoveManagedLabel(context.TODO(), manifest, fakeClient, nil)
-	require.ErrorContains(t, err, "failed to get resource")
+	err = service.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
+
+	require.NoError(t, err)
+	assert.True(t, manifestClient.called)
 }
 
-func Test_RemoveManagedLabel_WhenFinalizerIsRemoved(t *testing.T) {
+func Test_RemoveManagedByLabel_WhenFinalizerIsRemoved(t *testing.T) {
 	scheme := machineryruntime.NewScheme()
 	err := v1beta2.AddToScheme(scheme)
 	require.NoError(t, err)
@@ -282,15 +342,37 @@ func Test_RemoveManagedLabel_WhenFinalizerIsRemoved(t *testing.T) {
 	})
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(manifest).WithObjects(objs...).Build()
+	manifestClient := manifestClientStub{}
+	svc := NewManagedByLabelRemovalService(&manifestClient)
 
-	manifestClnt := manifestclient.NewManifestClient(nil, fakeClient)
-	svc := labelsremoval.NewManagedLabelRemovalService(manifestClnt)
+	err = svc.RemoveManagedByLabel(context.TODO(), manifest, fakeClient)
 
-	err = svc.RemoveManagedLabel(context.TODO(), manifest, fakeClient, nil)
 	require.NoError(t, err)
+	assert.Empty(t, manifest.GetFinalizers())
+	assert.True(t, manifestClient.called)
+}
 
-	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: manifest.GetName(), Namespace: manifest.GetNamespace()},
-		manifest)
-	require.NoError(t, err)
-	require.Empty(t, manifest.GetFinalizers())
+// stubs
+
+type manifestClientStub struct {
+	called bool
+	err    error
+}
+
+func (m *manifestClientStub) UpdateManifest(ctx context.Context, manifest *v1beta2.Manifest) error {
+	m.called = true
+	return m.err
+}
+
+type errorClientStub struct {
+	client.Client
+	fakeClient client.Client
+}
+
+func (e errorClientStub) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return errors.New("test error")
+}
+
+func (e errorClientStub) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return e.fakeClient.Get(ctx, key, obj, opts...)
 }

--- a/internal/manifest/modulecr/client.go
+++ b/internal/manifest/modulecr/client.go
@@ -2,6 +2,7 @@ package modulecr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +18,8 @@ import (
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
+var ErrNoResourceDefined = errors.New("no resource defined in the manifest")
+
 type Client struct {
 	client.Client
 }
@@ -31,7 +34,7 @@ func (c *Client) GetCR(ctx context.Context, manifest *v1beta2.Manifest) (*unstru
 	error,
 ) {
 	if manifest.Spec.Resource == nil {
-		return nil, nil
+		return nil, ErrNoResourceDefined
 	}
 
 	resourceCR := &unstructured.Unstructured{}

--- a/internal/manifest/modulecr/client.go
+++ b/internal/manifest/modulecr/client.go
@@ -30,6 +30,10 @@ func NewClient(client client.Client) *Client {
 func (c *Client) GetCR(ctx context.Context, manifest *v1beta2.Manifest) (*unstructured.Unstructured,
 	error,
 ) {
+	if manifest.Spec.Resource == nil {
+		return nil, nil
+	}
+
 	resourceCR := &unstructured.Unstructured{}
 	name := manifest.Spec.Resource.GetName()
 	namespace := manifest.Spec.Resource.GetNamespace()

--- a/pkg/testutils/builder/manifest.go
+++ b/pkg/testutils/builder/manifest.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
@@ -88,6 +89,11 @@ func (mb ManifestBuilder) WithStatus(status shared.Status) ManifestBuilder {
 // WithFinalizers sets v1beta2.Manifest.Finalizers.
 func (mb ManifestBuilder) WithFinalizers(finalizers []string) ManifestBuilder {
 	mb.manifest.Finalizers = finalizers
+	return mb
+}
+
+func (mb ManifestBuilder) WithResource(resource *unstructured.Unstructured) ManifestBuilder {
+	mb.manifest.Spec.Resource = resource
 	return mb
 }
 

--- a/unit-test-coverage.yaml
+++ b/unit-test-coverage.yaml
@@ -10,7 +10,7 @@ packages:
   internal/manifest/filemutex: 100
   internal/manifest/finalizer: 17.5
   internal/manifest/skrresources: 20.2
-  internal/manifest/labelsremoval: 93
+  internal/manifest/labelsremoval: 100
   internal/manifest/img: 65.5
   internal/manifest/manifestclient: 5.0
   internal/manifest/modulecr: 50.0

--- a/unit-test-coverage.yaml
+++ b/unit-test-coverage.yaml
@@ -13,7 +13,7 @@ packages:
   internal/manifest/labelsremoval: 100
   internal/manifest/img: 65.5
   internal/manifest/manifestclient: 5.0
-  internal/manifest/modulecr: 50.0
+  internal/manifest/modulecr: 47.0
   internal/maintenancewindows: 87.5
   internal/istio: 63.3
   internal/pkg/resources: 91.7


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fixes the nil pointer exception
- refactors the label removal service
  - it should be e2e responsible for label removal from all objects
  - therefore, the check if needed for defaultCR and respective lookup moved from reconciler into the service
  - this way the removal can now be completely unit tested
- extends the unmanaging e2e test to include the case wehere CustomResourcePolicy is Ignore

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- closes #2225 
