### PR TITLE
feat: Unexepected field managers reporting

### DIFF
--- a/internal/manifest/skrresources/collector.go
+++ b/internal/manifest/skrresources/collector.go
@@ -51,9 +51,9 @@ type LogCollectorEntry struct {
 	ManagedFields   []apimetav1.ManagedFieldsEntry `json:"managedFields"`
 }
 
-// Implements ManagedFieldsCollector interface, emits the collected data to the log stream.
+// Implements skrresources.ManagedFieldsCollector interface, emits the collected data to the log stream.
 // The collector is thread-safe.
-// The collector is frequency-limited to prevent emitting entries for the same objectKey multiple times in a short period.
+// The collector is frequency-limited to prevent emitting entries for the same objectKey multiple times in a short time.
 type LogCollector struct {
 	objectKey        string
 	frequencyLimiter *ttlcache.Cache[string, bool]
@@ -178,23 +178,13 @@ func getFrequencyLimiterTTL() int {
 }
 
 func newFrequencyLimiter() *ttlcache.Cache[string, bool] {
-	cache := ttlcache.New[string, bool](ttlcache.WithTTL[string, bool](time.Duration(getFrequencyLimiterTTL()) * time.Second))
+	cache := ttlcache.New(ttlcache.WithTTL[string, bool](time.Duration(getFrequencyLimiterTTL()) * time.Second))
 	go cache.Start()
 	return cache
 }
 
 func splitBySemicolons(value string) []string {
 	return strings.Split(value, ";")
-}
-
-// Implements ManagedFieldsCollector interface, does nothing.
-type nopCollector struct{}
-
-func (c nopCollector) Collect(ctx context.Context, obj client.Object) {
-}
-
-func (c nopCollector) Emit(ctx context.Context) error {
-	return nil
 }
 
 func getManagedFieldsAnalysisLabel() string {

--- a/internal/manifest/skrresources/collector.go
+++ b/internal/manifest/skrresources/collector.go
@@ -1,0 +1,185 @@
+package skrresources
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/internal"
+	"github.com/kyma-project/lifecycle-manager/internal/manifest/manifestclient"
+)
+
+const (
+	knownManagersDefault = string(manifestclient.DefaultFieldOwner) + ";" +
+		shared.OperatorName + ";" +
+		"k3s" // Applied in k3s environments.
+	knownManagersEnvVar = "KLM_EXPERIMENTAL_KNOWN_MANAGERS"
+	knownManagersRegexp = `^[a-zA-Z][a-zA-Z0-9.:_/-]{1,127}$`
+
+	frequencyCacheTTLDefault = 60 * 5 // 5 minutes
+	frequencyCacheTTLEnvVar  = "KLM_EXPERIMENTAL_FREQUENCY_CACHE_TTL"
+	frequencyCacheTTLRegexp  = `^[1-9][0-9]{1,3}$`
+
+	managedFieldsAnalysisLabelEnvVar = "KLM_EXPERIMENTAL_MANAGED_FIELDS_ANALYSIS_LABEL"
+)
+
+var (
+	allowedManagers = getAllowedManagers() //nolint:gochecknoglobals // list of managers is a global configuration
+	emitCache       = newEmitCache()       //nolint:gochecknoglobals // singleton cache is used to prevent emitting the same log multiple times in a short period
+)
+
+type LogCollectorEntry struct {
+	ObjectName      string                         `json:"objectName"`
+	ObjectNamespace string                         `json:"objectNamespace"`
+	ObjectGVK       string                         `json:"objectGvk"`
+	ManagedFields   []apimetav1.ManagedFieldsEntry `json:"managedFields"`
+}
+
+// Implements ManagedFieldsCollector interface, emits the colloected data to the log stream.
+type LogCollector struct {
+	key     string
+	owner   client.FieldOwner
+	entries []LogCollectorEntry
+}
+
+func NewLogCollector(key string, owner client.FieldOwner) *LogCollector {
+	return &LogCollector{
+		key:     key,
+		owner:   owner,
+		entries: []LogCollectorEntry{},
+	}
+}
+
+func (c *LogCollector) Collect(ctx context.Context, remoteObj client.Object) {
+	managedFields := remoteObj.GetManagedFields()
+	for _, mf := range managedFields {
+		if isUnknownManager(mf.Manager) {
+			newEntry := LogCollectorEntry{
+				ObjectName:      remoteObj.GetName(),
+				ObjectNamespace: remoteObj.GetNamespace(),
+				ObjectGVK:       remoteObj.GetObjectKind().GroupVersionKind().String(),
+				ManagedFields:   slices.Clone(remoteObj.GetManagedFields()),
+			}
+			c.entries = append(c.entries, newEntry)
+			return
+		}
+	}
+}
+
+func (c *LogCollector) Emit(ctx context.Context) error {
+	if len(c.entries) > 0 {
+		if emitCache.Has(c.key) {
+			logger := logf.FromContext(ctx, "owner", c.owner)
+			logger.V(internal.TraceLogLevel).Info("Unknown managers detection skipped (frequency)")
+			return nil
+		}
+		emitCache.Set(c.key, true, ttlcache.DefaultTTL)
+
+		jsonSer, err := json.MarshalIndent(c.entries, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to serialize managed field data: %w", err)
+		}
+		logData, err := compressAndBase64(jsonSer)
+		if err != nil {
+			return err
+		}
+
+		logger := logf.FromContext(ctx, "owner", c.owner)
+		logger.V(internal.TraceLogLevel).Info("Unknown managers detected", "base64gzip", logData)
+	}
+	return nil
+}
+
+// compressAndBase64 compresses the input byte slice using gzip and encodes it to base64 so that it can be logged as a string.
+func compressAndBase64(in []byte) (string, error) {
+	var buf bytes.Buffer
+	archive := gzip.NewWriter(&buf)
+
+	_, err := archive.Write(in)
+	if err != nil {
+		return "", fmt.Errorf("failed to write to gzip archive: %w", err)
+	}
+
+	if err := archive.Close(); err != nil {
+		return "", fmt.Errorf("failed to close gzip archive: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+func isUnknownManager(manager string) bool {
+	return !slices.Contains(allowedManagers, manager)
+}
+
+// allowedManagers returns either a list configured in the KLM_RECONCILECONFIG_KNOWN_MANAGERS environment variable or the default list.
+// The values must be separated by semicolons and are case-sensitive!
+func getAllowedManagers() []string {
+	configured := os.Getenv(knownManagersEnvVar)
+	if configured == "" {
+		return splitBySemicolons(knownManagersDefault)
+	} else {
+		rxp := regexp.MustCompile(knownManagersRegexp)
+		configuredValues := splitBySemicolons(configured)
+		res := []string{}
+		for _, name := range configuredValues {
+			if rxp.MatchString(name) {
+				res = append(res, name)
+			}
+		}
+		return res
+	}
+}
+
+func getCacheTTL() int {
+	var res int = frequencyCacheTTLDefault
+
+	if configured := os.Getenv(frequencyCacheTTLEnvVar); configured != "" {
+		rxp := regexp.MustCompile(frequencyCacheTTLRegexp)
+		if rxp.MatchString(configured) {
+			if parsed, err := strconv.Atoi(configured); err == nil {
+				res = parsed
+			}
+		}
+	}
+
+	return res
+}
+
+func newEmitCache() *ttlcache.Cache[string, bool] {
+	cache := ttlcache.New[string, bool](ttlcache.WithTTL[string, bool](time.Duration(getCacheTTL()) * time.Second))
+	go cache.Start()
+	return cache
+}
+
+func splitBySemicolons(value string) []string {
+	return strings.Split(value, ";")
+}
+
+// Implements ManagedFieldsCollector interface, does nothing.
+type nopCollector struct{}
+
+func (c nopCollector) Collect(ctx context.Context, obj client.Object) {
+}
+
+func (c nopCollector) Emit(ctx context.Context) error {
+	return nil
+}
+
+func getManagedFieldsAnalysisLabel() string {
+	return os.Getenv(managedFieldsAnalysisLabelEnvVar)
+}

--- a/internal/manifest/skrresources/collector_test.go
+++ b/internal/manifest/skrresources/collector_test.go
@@ -75,9 +75,9 @@ func TestGetCacheTTL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
-				t.Setenv(frequencyCacheTTLEnvVar, tt.envValue)
+				t.Setenv(frequencyLimiterTTLEnvVar, tt.envValue)
 			}
-			assert.Equal(t, tt.want, getCacheTTL())
+			assert.Equal(t, tt.want, getFrequencyLimiterTTL())
 		})
 	}
 }

--- a/internal/manifest/skrresources/collector_test.go
+++ b/internal/manifest/skrresources/collector_test.go
@@ -1,0 +1,83 @@
+package skrresources //nolint:testpackage // testing package internals
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAllowedManagers(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     []string
+	}{
+		{
+			name:     "default managers",
+			envValue: "",
+			want:     []string{"declarative.kyma-project.io/applier", "lifecycle-manager", "k3s"},
+		},
+		{
+			name:     "single manager in env",
+			envValue: "manager1",
+			want:     []string{"manager1"},
+		},
+		{
+			name:     "multiple managers in env",
+			envValue: "manager1;manager2;some-manager:3",
+			want:     []string{"manager1", "manager2", "some-manager:3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(knownManagersEnvVar, tt.envValue)
+			}
+			assert.Equal(t, tt.want, getAllowedManagers())
+		})
+	}
+}
+
+func TestGetCacheTTL(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     int
+	}{
+		{
+			name:     "default TTL",
+			envValue: "",
+			want:     300,
+		},
+		{
+			name:     "custom TTL",
+			envValue: "123",
+			want:     123,
+		},
+		{
+			name:     "invalid value is ignored, default TTL is returned",
+			envValue: "abc",
+			want:     300,
+		},
+		{
+			name:     "zero is invalid, default TTL is returned",
+			envValue: "0",
+			want:     300,
+		},
+		{
+			name:     "Negative value is ignored, default TTL is returned",
+			envValue: "-123",
+			want:     300,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(frequencyCacheTTLEnvVar, tt.envValue)
+			}
+			assert.Equal(t, tt.want, getCacheTTL())
+		})
+	}
+}

--- a/internal/manifest/skrresources/manifestcollector.go
+++ b/internal/manifest/skrresources/manifestcollector.go
@@ -43,7 +43,7 @@ func (c *ManifestLogCollector) Emit(ctx context.Context) error {
 	return nil
 }
 
-// isCollectionEnabled checks if managed fields detection is enabled for the given manifest.
+// isManifestCollectionEnabled checks if managed fields detection is enabled for the given manifest.
 // The detection is disabled by default, but can be enabled by setting a specific label on the manifest CR.
 func isManifestCollectionEnabled(obj *v1beta2.Manifest) bool {
 	if obj == nil {

--- a/internal/manifest/skrresources/manifestcollector.go
+++ b/internal/manifest/skrresources/manifestcollector.go
@@ -1,0 +1,54 @@
+package skrresources
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/internal/manifest/manifestclient"
+)
+
+// ManifestLogCollector is a collector for remote Manifest objects. It delegates the calls to the embedded generic collector if collection is enabled for the given Manifest.
+type ManifestLogCollector struct {
+	collector *LogCollector
+	enabled   bool
+}
+
+func NewManifestLogCollector(manifest *v1beta2.Manifest, owner client.FieldOwner) *ManifestLogCollector {
+	return &ManifestLogCollector{
+		collector: NewLogCollector(string(manifest.GetUID()), manifestclient.DefaultFieldOwner),
+		enabled:   isManifestCollectionEnabled(manifest),
+	}
+}
+
+// Implements the skrresources.ManagedFieldsCollector interface.
+func (c *ManifestLogCollector) Collect(ctx context.Context, obj client.Object) {
+	if c.enabled {
+		c.collector.Collect(ctx, obj)
+	}
+}
+
+// Implements the skrresources.ManagedFieldsCollector interface.
+func (c *ManifestLogCollector) Emit(ctx context.Context) error {
+	if c.enabled {
+		return c.collector.Emit(ctx)
+	}
+	return nil
+}
+
+// isCollectionEnabled checks if managed fields detection is enabled for the given manifest.
+// The detection is enabled by default, but can be controlled by setting a specific label on the manifest CR.
+func isManifestCollectionEnabled(obj *v1beta2.Manifest) bool {
+	if obj == nil {
+		return false
+	}
+
+	detectionLabelName := getManagedFieldsAnalysisLabel()
+	if detectionLabelName == "" {
+		return true
+	}
+
+	_, found := obj.GetLabels()[detectionLabelName]
+	return found
+}

--- a/internal/manifest/skrresources/manifestcollector.go
+++ b/internal/manifest/skrresources/manifestcollector.go
@@ -16,9 +16,15 @@ type ManifestLogCollector struct {
 }
 
 func NewManifestLogCollector(manifest *v1beta2.Manifest, owner client.FieldOwner) *ManifestLogCollector {
+	key := ""
+	enabled := false
+	if manifest != nil {
+		key = string(manifest.GetUID())
+		enabled = isManifestCollectionEnabled(manifest)
+	}
 	return &ManifestLogCollector{
-		collector: NewLogCollector(string(manifest.GetUID()), manifestclient.DefaultFieldOwner),
-		enabled:   isManifestCollectionEnabled(manifest),
+		collector: NewLogCollector(key, manifestclient.DefaultFieldOwner),
+		enabled:   enabled,
 	}
 }
 

--- a/internal/manifest/skrresources/manifestcollector.go
+++ b/internal/manifest/skrresources/manifestcollector.go
@@ -44,17 +44,18 @@ func (c *ManifestLogCollector) Emit(ctx context.Context) error {
 }
 
 // isCollectionEnabled checks if managed fields detection is enabled for the given manifest.
-// The detection is enabled by default, but can be controlled by setting a specific label on the manifest CR.
+// The detection is disabled by default, but can be enabled by setting a specific label on the manifest CR.
 func isManifestCollectionEnabled(obj *v1beta2.Manifest) bool {
 	if obj == nil {
 		return false
 	}
 
-	detectionLabelName := getManagedFieldsAnalysisLabel()
-	if detectionLabelName == "" {
-		return true
+	configuredLabelName := getManagedFieldsAnalysisLabel()
+
+	if configuredLabelName == "" {
+		return false
 	}
 
-	_, found := obj.GetLabels()[detectionLabelName]
+	_, found := obj.GetLabels()[configuredLabelName]
 	return found
 }

--- a/internal/manifest/skrresources/ssa.go
+++ b/internal/manifest/skrresources/ssa.go
@@ -26,19 +26,38 @@ type SSA interface {
 	Run(ctx context.Context, resourceInfo []*resource.Info) error
 }
 
+type ManagedFieldsCollector interface {
+	// Collect collects managed fields data from the single object
+	Collect(ctx context.Context, obj client.Object)
+	// Emit emits collected data to some backing store
+	Emit(ctx context.Context) error
+}
+
 type ConcurrentDefaultSSA struct {
 	clnt      client.Client
 	owner     client.FieldOwner
 	versioner machineryruntime.GroupVersioner
 	converter machineryruntime.ObjectConvertor
+	collector ManagedFieldsCollector
 }
 
-func ConcurrentSSA(clnt client.Client, owner client.FieldOwner) *ConcurrentDefaultSSA {
+func ConcurrentSSA(clnt client.Client, owner client.FieldOwner, managedFieldsCollector ManagedFieldsCollector) *ConcurrentDefaultSSA {
 	return &ConcurrentDefaultSSA{
-		clnt: clnt, owner: owner,
+		clnt:      clnt,
+		owner:     owner,
 		versioner: schema.GroupVersions(clnt.Scheme().PrioritizedVersionsAllGroups()),
 		converter: clnt.Scheme(),
+		collector: managedFieldsCollector,
 	}
+}
+
+//nolint:ireturn // interface return is required here
+func (c *ConcurrentDefaultSSA) managedFieldsCollector() ManagedFieldsCollector {
+	if c.collector != nil {
+		return c.collector
+	}
+
+	return nopCollector{}
 }
 
 func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.Info) error {
@@ -70,6 +89,9 @@ func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.In
 		return errors.Join(errs...)
 	}
 	logger.V(internal.DebugLogLevel).Info("ServerSideApply finished", "time", ssaFinish)
+	if err := c.managedFieldsCollector().Emit(ctx); err != nil {
+		logger.V(internal.DebugLogLevel).Error(err, "error emitting data of unknown field managers")
+	}
 	return nil
 }
 
@@ -123,6 +145,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 		)
 	}
 
+	c.managedFieldsCollector().Collect(ctx, obj)
 	return nil
 }
 

--- a/internal/manifest/skrresources/ssa.go
+++ b/internal/manifest/skrresources/ssa.go
@@ -51,15 +51,6 @@ func ConcurrentSSA(clnt client.Client, owner client.FieldOwner, managedFieldsCol
 	}
 }
 
-//nolint:ireturn // interface return is required here
-func (c *ConcurrentDefaultSSA) managedFieldsCollector() ManagedFieldsCollector {
-	if c.collector != nil {
-		return c.collector
-	}
-
-	return nopCollector{}
-}
-
 func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.Info) error {
 	ssaStart := time.Now()
 	logger := logf.FromContext(ctx, "owner", c.owner)
@@ -89,7 +80,7 @@ func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.In
 		return errors.Join(errs...)
 	}
 	logger.V(internal.DebugLogLevel).Info("ServerSideApply finished", "time", ssaFinish)
-	if err := c.managedFieldsCollector().Emit(ctx); err != nil {
+	if err := c.collector.Emit(ctx); err != nil {
 		logger.V(internal.DebugLogLevel).Error(err, "error emitting data of unknown field managers")
 	}
 	return nil
@@ -145,7 +136,7 @@ func (c *ConcurrentDefaultSSA) serverSideApplyResourceInfo(
 		)
 	}
 
-	c.managedFieldsCollector().Collect(ctx, obj)
+	c.collector.Collect(ctx, obj)
 	return nil
 }
 

--- a/internal/manifest/skrresources/ssa_test.go
+++ b/internal/manifest/skrresources/ssa_test.go
@@ -54,7 +54,7 @@ func TestConcurrentSSA(t *testing.T) {
 		t.Run(
 			testCase.name, func(t *testing.T) {
 				t.Parallel()
-				ssa := skrresources.ConcurrentSSA(testCase.ssa.clnt, testCase.ssa.owner)
+				ssa := skrresources.ConcurrentSSA(testCase.ssa.clnt, testCase.ssa.owner, nil)
 				if err := ssa.Run(context.Background(), testCase.apply); err != nil {
 					require.ErrorIs(t, err, testCase.err)
 				}

--- a/internal/manifest/skrresources/ssa_test.go
+++ b/internal/manifest/skrresources/ssa_test.go
@@ -29,6 +29,8 @@ func TestConcurrentSSA(t *testing.T) {
 	fakeClientBuilder := fake.NewClientBuilder().WithRuntimeObjects(pod).Build()
 	_ = fakeClientBuilder.Create(context.Background(), pod)
 
+	inactiveCollector := skrresources.NewManifestLogCollector(nil, client.FieldOwner("test"))
+
 	type args struct {
 		clnt  client.Client
 		owner client.FieldOwner
@@ -54,7 +56,7 @@ func TestConcurrentSSA(t *testing.T) {
 		t.Run(
 			testCase.name, func(t *testing.T) {
 				t.Parallel()
-				ssa := skrresources.ConcurrentSSA(testCase.ssa.clnt, testCase.ssa.owner, nil)
+				ssa := skrresources.ConcurrentSSA(testCase.ssa.clnt, testCase.ssa.owner, inactiveCollector)
 				if err := ssa.Run(context.Background(), testCase.apply); err != nil {
 					require.ErrorIs(t, err, testCase.err)
 				}

--- a/internal/manifest/skrresources/sync.go
+++ b/internal/manifest/skrresources/sync.go
@@ -19,10 +19,7 @@ func SyncResources(ctx context.Context, skrClient client.Client, manifest *v1bet
 ) error {
 	manifestStatus := manifest.GetStatus()
 
-	var managedFieldsCollector ManagedFieldsCollector
-	if managedFieldsAnalysisEnabledFor(manifest) {
-		managedFieldsCollector = NewLogCollector(string(manifest.GetUID()), manifestclient.DefaultFieldOwner)
-	}
+	managedFieldsCollector := NewManifestLogCollector(manifest, manifestclient.DefaultFieldOwner)
 
 	if err := ConcurrentSSA(skrClient, manifestclient.DefaultFieldOwner, managedFieldsCollector).Run(ctx, target); err != nil {
 		manifest.SetStatus(manifestStatus.WithState(shared.StateError).WithErr(err))
@@ -63,16 +60,4 @@ func HasDiff(oldResources []shared.Resource, newResources []shared.Resource) boo
 		}
 	}
 	return false
-}
-
-// managedFieldsAnalysisEnabledFor checks if managed fields detection is enabled for the given manifest.
-// The detection is enabled by default, but can be controlled by setting a specific label on the manifest CR.
-func managedFieldsAnalysisEnabledFor(obj *v1beta2.Manifest) bool {
-	detectionLabelName := getManagedFieldsAnalysisLabel()
-	if detectionLabelName == "" {
-		return true
-	}
-
-	_, found := obj.GetLabels()[detectionLabelName]
-	return found
 }


### PR DESCRIPTION
**Description**

The idea behind this PR is as follows:
In order to create a robust "unknown managers cleanup" process, we first must collect the data.
This PR allows to collect this data in the logging stream for easy analysis.
Once it starts working, we'll be able to see what kind of "unknown managers" are there in the environments. Then we can add logic to fix these "unknown" managers. During that process, the amount of logs for "unknown managers" should decrease.
After a few iterations we should achieve the state where (almost) no logs for "unknown" managers are produced.
At that time we should make the code introduced here more "production-ready", for example, replace env vars with proper flags etc.
For now it's a bit ad-hoc because it's not clear yet which parts of it will remain in the final solution.
It is also not clear if we want to use the same mechanism for other reconciliation processes. If that is the case, then the entire thing should be extracted to a dedicated package.


**Changes proposed in this pull request**
Added detection for "unknown" managers for the Manifest-related resources (resources defined by a Kyma module):

- There is a default list of names of "known" managers. It can be reconfigured via env var. All other names are considered "unknown"
- If an "unknown" manager is detected on some managed object, the entire list of `ManagedFieldsEntry` is collected for that object. The advantage of this is that all available data is collected for the purpose of analysis.
- All the collected data is logged at the end of Manifest Synchronization process. It may contain data for more than one resource in the SKR.
- To avoid overloading of the Cloud Logging, the collected data is compressed and then base64-encoded. It can be easily decoded using standard CLI tools (gzip + base64)
- To prevent overloading Cloud Logging, the logging frequency can be configured. By default, a log entry for any given Manifest is created only every 5 minutes, starting from the previous collection event. Any data collected within this interval is discarded. The 'frequency' value can be adjusted using the environment variable.
- By default, all Manifests are subject to the detection/collection process. If necessary, a label name can be configured using env var. If it's configured, only the Manifests that have the label configured are processed.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #2175 
