### PR TITLE
Add check for label before creating a new comment

### DIFF
--- a/.github/workflows/check-manifests-changes.yml
+++ b/.github/workflows/check-manifests-changes.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           path: ./cache/pr/
           key: ${{ env.PR_CACHE_KEY }}
+
   create-main-manifests:
     runs-on: ubuntu-latest
     steps:
@@ -35,16 +36,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+
       - name: Create manifests on main branch
         run: |
           make dry-run-control-plane
           mkdir -p ./cache/main
           mv ./dry-run/manifests.yaml ./cache/main/manifests.yaml
+
       - name: Save main manifests in cache
         uses: actions/cache@v3
         with:
           path: ./cache/main/
           key: ${{ env.MAIN_CACHE_KEY }}
+
   diff-manifests:
     needs:
       - create-pr-manifests
@@ -56,11 +60,13 @@ jobs:
         with:
           path: ./cache/pr/
           key: ${{ env.PR_CACHE_KEY }}
+
       - name: Restore main manifests from cache
         uses: actions/cache@v3
         with:
           path: ./cache/main/
           key: ${{ env.MAIN_CACHE_KEY }}
+
       - name: Compare Manifests
         id: compare-manifests
         run: |
@@ -76,23 +82,39 @@ jobs:
             echo "manifests_diff_detected=false" >> $GITHUB_OUTPUT
           fi
           exit 0
-      - name: Add PR Comment if Manifest Differences Detected
-        if: steps.compare-manifests.outputs.manifests_diff_detected == 'true'
+
+      - name: Check if 'manifests-diff' Label Exists
+        id: check-manifests-label
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
+            const labelName = 'manifests-diff';
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: "❌ **Manifests created with 'make dry-run-control-plane' changed!** Please make sure to check if changes are needed in related repositories like management-plane-charts, runtime-watchter, etc.."
             });
-            github.rest.issues.addLabels({
+            return labels.some(label => label.name === labelName);
+          result-encoding: string
+
+      - name: Add PR Comment if Manifest Differences Detected
+        if: steps.compare-manifests.outputs.manifests_diff_detected == 'true' && steps.check-manifests-label.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "❌ **Manifests created with 'make dry-run-control-plane' changed!** Please check if changes are needed in related repositories like management-plane-charts, runtime-watchter, etc."
+            });
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               labels: ["manifests-diff"]
             });
+
       - name: Remove 'manifests-diff' Label if No Differences
         if: steps.compare-manifests.outputs.manifests_diff_detected == 'false'
         uses: actions/github-script@v7

--- a/.github/workflows/check-pipeline-changes.yml
+++ b/.github/workflows/check-pipeline-changes.yml
@@ -33,6 +33,7 @@ jobs:
               pathsToCheck.some(path => file.filename === path || file.filename.startsWith(path + '/'))
             );
             core.setOutput('pipelineFiles', pipelineFiles.map(file => file.filename).join(','));
+
       - name: Evaluate Pipeline Changes
         id: eval-changes
         run: |
@@ -45,23 +46,39 @@ jobs:
             echo "✅ No pipeline-related changes detected."
             echo "pipeline_changed=false" >> $GITHUB_OUTPUT
           fi
-      - name: Add PR Comment & Label if Pipeline Changes Detected
-        if: steps.eval-changes.outputs.pipeline_changed == 'true'
+
+      - name: Check if 'pipeline-changed' Label Exists
+        id: check-pipeline-label
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
+            const labelName = 'pipeline-changed';
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            return labels.some(label => label.name === labelName);
+          result-encoding: string
+
+      - name: Add PR Comment & Label if Pipeline Changes Detected
+        if: steps.eval-changes.outputs.pipeline_changed == 'true' && steps.check-pipeline-label.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               body: "⚠️ **Pipeline-related file changes detected!** Please review if related updates (e.g. manifest generation or workflow adjustments) are required."
             });
-            github.rest.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: context.payload.pull_request.number, 
               labels: ["pipeline-changed"]
             });
+
       - name: Remove 'pipeline-changed' Label if No Changes Detected
         if: steps.eval-changes.outputs.pipeline_changed == 'false'
         uses: actions/github-script@v7


### PR DESCRIPTION

**Description**
This PR is for purpose to reduce the comments on each update on the existing PR.

Changes proposed in this pull request:

- Add Check if 'manifests-diff' Label Exists step.
- Add Check if 'pipeline-changed' Label Exists
 - Verify labels conditions before posting a comment.

**Related issue(s)**
#2269 
