### PR TITLE
chore: Bump watcher reference to latest release

### DIFF
--- a/.run/Launch KLM locally.run.xml
+++ b/.run/Launch KLM locally.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Launch KLM locally" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="lifecycle-manager" />
     <working_directory value="$PROJECT_DIR$" />
-    <parameters value="--in-kcp-mode --enable-kcp-watcher --skr-watcher-image-tag=1.1.13" />
+    <parameters value="--in-kcp-mode --enable-kcp-watcher --skr-watcher-image-tag=1.1.14" />
     <envs>
       <env name="KUBECONFIG" value="$USER_HOME$/.k3d/kcp-local.yaml" />
     </envs>

--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -18,7 +18,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=1.1.13
+        value: --skr-watcher-image-tag=1.1.14
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump the reference to used default watcher image to 1.1.14
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
