### PR TITLE
feat: Propagate Global Account and SubAccount Labels

### DIFF
--- a/api/shared/operator_labels.go
+++ b/api/shared/operator_labels.go
@@ -40,6 +40,7 @@ const (
 	BetaLabel              = OperatorGroup + Separator + "beta"
 
 	GlobalAccountIDLabel = KymaGroup + Separator + "global-account-id"
+	SubAccountIDLabel    = KymaGroup + Separator + "subaccount-id"
 	RegionLabel          = KymaGroup + Separator + "region"
 	PlatformRegionLabel  = KymaGroup + Separator + "platform-region"
 	PlanLabel            = KymaGroup + Separator + "broker-plan-name"

--- a/internal/remote/skr_context.go
+++ b/internal/remote/skr_context.go
@@ -234,12 +234,14 @@ func (s *SkrContext) getRemoteKyma(ctx context.Context) (*v1beta2.Kyma, error) {
 	return skrKyma, nil
 }
 
+// TODO: change here
 // syncWatcherLabelsAnnotations adds required labels and annotations to the skrKyma.
 // It returns true if any of the labels or annotations were changed.
 func syncWatcherLabelsAnnotations(kcpKyma, skrKyma *v1beta2.Kyma) bool {
 	labels, labelsChanged := collections.MergeMaps(skrKyma.Labels, map[string]string{
 		shared.WatchedByLabel: shared.WatchedByLabelValue,
 		shared.ManagedBy:      shared.ManagedByLabelValue,
+		"customLabel":         "customValue",
 	})
 	skrKyma.Labels = labels
 

--- a/internal/remote/skr_context.go
+++ b/internal/remote/skr_context.go
@@ -251,9 +251,6 @@ func syncBTPRelatedLabels(kcpKyma, skrKyma *v1beta2.Kyma) bool {
 		labelsMap[shared.SubAccountIDLabel] = subAccountIDLabelValue
 	}
 
-	labelsMap[shared.WatchedByLabel] = shared.WatchedByLabelValue
-	labelsMap[shared.ManagedBy] = shared.ManagedByLabelValue
-
 	labels, labelsChanged := collections.MergeMaps(skrKyma.Labels, labelsMap)
 
 	skrKyma.Labels = labels

--- a/internal/remote/skr_context.go
+++ b/internal/remote/skr_context.go
@@ -234,15 +234,25 @@ func (s *SkrContext) getRemoteKyma(ctx context.Context) (*v1beta2.Kyma, error) {
 	return skrKyma, nil
 }
 
-// TODO: change here
 // syncWatcherLabelsAnnotations adds required labels and annotations to the skrKyma.
 // It returns true if any of the labels or annotations were changed.
 func syncWatcherLabelsAnnotations(kcpKyma, skrKyma *v1beta2.Kyma) bool {
-	labels, labelsChanged := collections.MergeMaps(skrKyma.Labels, map[string]string{
-		shared.WatchedByLabel: shared.WatchedByLabelValue,
-		shared.ManagedBy:      shared.ManagedByLabelValue,
-		"customLabel":         "customValue",
-	})
+	labelsMap := map[string]string{}
+	globalAccountIDLabelValue, ok := kcpKyma.Labels[shared.GlobalAccountIDLabel]
+	if ok {
+		labelsMap[shared.GlobalAccountIDLabel] = globalAccountIDLabelValue
+	}
+
+	subAccountIDLabelValue, ok := kcpKyma.Labels[shared.SubAccountIDLabel]
+	if ok {
+		labelsMap[shared.SubAccountIDLabel] = subAccountIDLabelValue
+	}
+
+	labelsMap[shared.WatchedByLabel] = shared.WatchedByLabelValue
+	labelsMap[shared.ManagedBy] = shared.ManagedByLabelValue
+
+	labels, labelsChanged := collections.MergeMaps(skrKyma.Labels, labelsMap)
+
 	skrKyma.Labels = labels
 
 	annotations, annotationsChanged := collections.MergeMaps(skrKyma.Annotations, map[string]string{

--- a/internal/remote/skr_context_test.go
+++ b/internal/remote/skr_context_test.go
@@ -311,6 +311,7 @@ func Test_syncWatcherLabelsAnnotations_AddsAnnotations(t *testing.T) {
 	assertLabelsAndAnnotations(t, skrKyma)
 }
 
+// TODO: change here too
 func Test_syncWatcherLabelsAnnotations_ChangesAnnotations(t *testing.T) {
 	skrKyma := builder.NewKymaBuilder().
 		WithLabel(shared.WatchedByLabel, shared.WatchedByLabelValue).

--- a/internal/remote/skr_context_test.go
+++ b/internal/remote/skr_context_test.go
@@ -311,7 +311,6 @@ func Test_syncWatcherLabelsAnnotations_AddsAnnotations(t *testing.T) {
 	assertLabelsAndAnnotations(t, skrKyma)
 }
 
-// TODO: change here too
 func Test_syncWatcherLabelsAnnotations_ChangesAnnotations(t *testing.T) {
 	skrKyma := builder.NewKymaBuilder().
 		WithLabel(shared.WatchedByLabel, shared.WatchedByLabelValue).

--- a/maintenancewindows/resolver/resolver.go
+++ b/maintenancewindows/resolver/resolver.go
@@ -19,9 +19,10 @@ var (
 
 // Runtime is the data type which captures the needed runtime specific attributes to perform orchestrations on a given runtime.
 type Runtime struct {
-	InstanceID             string
-	RuntimeID              string
-	GlobalAccountID        string
+	InstanceID      string
+	RuntimeID       string
+	GlobalAccountID string
+	//TODO: wtf? SubAccountID is not used anywhere in the codebase
 	SubAccountID           string
 	ShootName              string
 	Plan                   string

--- a/maintenancewindows/resolver/resolver.go
+++ b/maintenancewindows/resolver/resolver.go
@@ -19,10 +19,9 @@ var (
 
 // Runtime is the data type which captures the needed runtime specific attributes to perform orchestrations on a given runtime.
 type Runtime struct {
-	InstanceID      string
-	RuntimeID       string
-	GlobalAccountID string
-	//TODO: wtf? SubAccountID is not used anywhere in the codebase
+	InstanceID             string
+	RuntimeID              string
+	GlobalAccountID        string
 	SubAccountID           string
 	ShootName              string
 	Plan                   string

--- a/tests/e2e/labelling_test.go
+++ b/tests/e2e/labelling_test.go
@@ -16,23 +16,27 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var managedSkrResources = map[types.NamespacedName]schema.GroupVersionKind{
-	{Name: "default", Namespace: RemoteNamespace}:         v1beta2.GroupVersion.WithKind("Kyma"),
-	{Name: "skr-webhook", Namespace: RemoteNamespace}:     apiappsv1.SchemeGroupVersion.WithKind("Deployment"),
-	{Name: "skr-webhook", Namespace: RemoteNamespace}:     admissionregistrationv1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration"),
-	{Name: "skr-webhook-tls", Namespace: RemoteNamespace}: apicorev1.SchemeGroupVersion.WithKind("Secret"),
-	{Name: "skr-webhook-sa", Namespace: RemoteNamespace}:  apicorev1.SchemeGroupVersion.WithKind("ServiceAccount"),
-	{Name: RemoteNamespace, Namespace: ""}:                apicorev1.SchemeGroupVersion.WithKind("Namespace"),
-}
+var (
+	managedSkrResources = map[types.NamespacedName]schema.GroupVersionKind{
+		{Name: "default", Namespace: RemoteNamespace}:         v1beta2.GroupVersion.WithKind("Kyma"),
+		{Name: "skr-webhook", Namespace: RemoteNamespace}:     apiappsv1.SchemeGroupVersion.WithKind("Deployment"),
+		{Name: "skr-webhook", Namespace: RemoteNamespace}:     admissionregistrationv1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration"),
+		{Name: "skr-webhook-tls", Namespace: RemoteNamespace}: apicorev1.SchemeGroupVersion.WithKind("Secret"),
+		{Name: "skr-webhook-sa", Namespace: RemoteNamespace}:  apicorev1.SchemeGroupVersion.WithKind("ServiceAccount"),
+		{Name: RemoteNamespace, Namespace: ""}:                apicorev1.SchemeGroupVersion.WithKind("Namespace"),
+	}
+	globalAccountIDLabelValue = "dummy-global-account"
+	subAccountIDLabelValue    = "dummy-sub-account"
+)
 
 var _ = Describe("Labelling SKR resources", Ordered, func() {
 	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	setBTPRelatedLabels(kyma)
 	InitEmptyKymaBeforeAll(kyma)
 	CleanupKymaAfterAll(kyma)
 
 	module := NewTemplateOperator(v1beta2.DefaultChannel)
 
-	// TODO: good location to change in E2E tests
 	Context("Given SKR Cluster", func() {
 		It("When SKR cluster is setup", func() {
 			By("Then SKR Kyma CR is labelled with watched-by label")
@@ -64,6 +68,26 @@ var _ = Describe("Labelling SKR resources", Ordered, func() {
 					"istio-injection": "enabled",
 					"namespaces.warden.kyma-project.io/validate": "enabled",
 				}).Should(Succeed())
+		})
+		It("Contains BTP related Labels", func() {
+			By("Global account label being propagated")
+			Eventually(HasExpectedLabel).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					types.NamespacedName{Name: "default", Namespace: RemoteNamespace},
+					v1beta2.GroupVersion.WithKind("Kyma"),
+					shared.GlobalAccountIDLabel, globalAccountIDLabelValue).
+				Should(Succeed())
+			By("Sub account label being propagated")
+			Eventually(HasExpectedLabel).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					types.NamespacedName{Name: "default", Namespace: RemoteNamespace},
+					v1beta2.GroupVersion.WithKind("Kyma"),
+					shared.SubAccountIDLabel, subAccountIDLabelValue).
+				Should(Succeed())
 		})
 
 		It("When Kyma Module is enabled in SKR Kyma CR", func() {
@@ -102,3 +126,8 @@ var _ = Describe("Labelling SKR resources", Ordered, func() {
 		})
 	})
 })
+
+func setBTPRelatedLabels(kyma *v1beta2.Kyma) {
+	kyma.Labels[shared.GlobalAccountIDLabel] = globalAccountIDLabelValue
+	kyma.Labels[shared.SubAccountIDLabel] = subAccountIDLabelValue
+}

--- a/tests/e2e/labelling_test.go
+++ b/tests/e2e/labelling_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Labelling SKR resources", Ordered, func() {
 
 	module := NewTemplateOperator(v1beta2.DefaultChannel)
 
+	// TODO: good location to change in E2E tests
 	Context("Given SKR Cluster", func() {
 		It("When SKR cluster is setup", func() {
 			By("Then SKR Kyma CR is labelled with watched-by label")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Propagate the label `kyma-project.io/global-account-id` from KCP to SKR
- Propagate the label `kyma-project.io/subaccount-id` from KCP to SKR

**Related issue(s)**
Resolves: #2235