### PR TITLE
feat: Add `runtime-id` as skr cert common name

### DIFF
--- a/api/shared/operator_labels.go
+++ b/api/shared/operator_labels.go
@@ -44,6 +44,7 @@ const (
 	RegionLabel          = KymaGroup + Separator + "region"
 	PlatformRegionLabel  = KymaGroup + Separator + "platform-region"
 	PlanLabel            = KymaGroup + Separator + "broker-plan-name"
+	RuntimeIDLabel       = KymaGroup + Separator + "runtime-id"
 
 	EnableLabelValue  = "true"
 	DisableLabelValue = "false"

--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -447,3 +447,7 @@ func (kyma *Kyma) GetPlatformRegion() string {
 func (kyma *Kyma) GetPlan() string {
 	return kyma.Labels[shared.PlanLabel]
 }
+
+func (kyma *Kyma) GetRuntimeID() string {
+	return kyma.Labels[shared.RuntimeIDLabel]
+}

--- a/pkg/watcher/certificate_manager.go
+++ b/pkg/watcher/certificate_manager.go
@@ -96,7 +96,8 @@ func (c *CertificateManager) CreateSelfSignedCert(ctx context.Context, kyma *v1b
 	if err != nil {
 		return nil, fmt.Errorf("error get Subject Alternative Name from KymaCR: %w", err)
 	}
-	return c.patchCertificate(ctx, subjectAltNames)
+	runtimeID := kyma.GetRuntimeID()
+	return c.patchCertificate(ctx, subjectAltNames, runtimeID)
 }
 
 // Remove removes the certificate including its certificate secret.
@@ -148,7 +149,7 @@ func (c *CertificateManager) removeSecret(ctx context.Context) error {
 }
 
 func (c *CertificateManager) patchCertificate(ctx context.Context,
-	subjectAltName *SubjectAltName,
+	subjectAltName *SubjectAltName, commonName string,
 ) (*certmanagerv1.Certificate, error) {
 	issuer, err := c.getIssuer(ctx)
 	if err != nil {
@@ -165,6 +166,7 @@ func (c *CertificateManager) patchCertificate(ctx context.Context,
 			Namespace: c.config.IstioNamespace,
 		},
 		Spec: certmanagerv1.CertificateSpec{
+			CommonName:     commonName,
 			Duration:       &apimetav1.Duration{Duration: c.config.Duration},
 			RenewBefore:    &apimetav1.Duration{Duration: c.config.RenewBefore},
 			DNSNames:       subjectAltName.DNSNames,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds `runtime-id` of the SKR to its watcher certificate

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
