### PR TITLE
chore: Make WatcherCR `spec.labelsToWatch` optional

### DIFF
--- a/api/v1beta2/watcher_types.go
+++ b/api/v1beta2/watcher_types.go
@@ -29,7 +29,8 @@ type WatcherSpec struct {
 	ServiceInfo Service `json:"serviceInfo"`
 
 	// LabelsToWatch describes the labels that should be watched
-	LabelsToWatch map[string]string `json:"labelsToWatch"`
+	// +optional
+	LabelsToWatch map[string]string `json:"labelsToWatch,omitempty"`
 
 	// ResourceToWatch is the GroupVersionResource of the resource that should be watched.
 	ResourceToWatch WatchableGVR `json:"resourceToWatch"`

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -452,13 +452,13 @@ func (in *ModuleStatus) DeepCopyInto(out *ModuleStatus) {
 		*out = new(TrackingObject)
 		**out = **in
 	}
-	if in.Template != nil {
-		in, out := &in.Template, &out.Template
+	if in.Resource != nil {
+		in, out := &in.Resource, &out.Resource
 		*out = new(TrackingObject)
 		**out = **in
 	}
-	if in.Resource != nil {
-		in, out := &in.Resource, &out.Resource
+	if in.Template != nil {
+		in, out := &in.Template, &out.Template
 		*out = new(TrackingObject)
 		**out = **in
 	}

--- a/config/crd/bases/operator.kyma-project.io_watchers.yaml
+++ b/config/crd/bases/operator.kyma-project.io_watchers.yaml
@@ -151,7 +151,6 @@ spec:
             required:
             - field
             - gateway
-            - labelsToWatch
             - resourceToWatch
             - serviceInfo
             type: object
@@ -391,7 +390,6 @@ spec:
             required:
             - field
             - gateway
-            - labelsToWatch
             - resourceToWatch
             - serviceInfo
             type: object


### PR DESCRIPTION
**Description**
- Makes watcherCR `spec.labelsToWatch` optional

**Related issue(s)**
Resolves #2341