### PR TITLE
Implement network policies for the skr-webhook

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,7 +31,7 @@ linters-settings:
       - name: line-length-limit
         severity: warning
         disabled: true
-        arguments: [ 120 ]
+        arguments: [120]
   funlen:
     lines: 80
   cyclop:
@@ -40,11 +40,11 @@ linters-settings:
     min-complexity: 6
   gci:
     sections:
-      - standard                                             # Standard packages.
-      - default                                              # Imports that could not be matched to another section type.
-      - prefix(github.com/kyma-project/lifecycle-manager)    # Imports with the specified prefix.
-      - blank                                                # Blank imports.
-      - dot                                                  # Dot imports.
+      - standard # Standard packages.
+      - default # Imports that could not be matched to another section type.
+      - prefix(github.com/kyma-project/lifecycle-manager) # Imports with the specified prefix.
+      - blank # Blank imports.
+      - dot # Dot imports.
     custom-order: true
     skip-generated: true
   nolintlint:
@@ -141,6 +141,8 @@ linters-settings:
         alias: gatewaysecrethandler
       - pkg: github.com/kyma-project/lifecycle-manager/pkg/module/common
         alias: modulecommon
+      - pkg: k8s.io/api/networking/v1
+        alias: apinetworkv1
   ireturn:
     allow:
       - anon
@@ -204,9 +206,9 @@ issues:
         - wrapcheck # Errors do not need to be wrapped in integration test utils
         - err113 # Dynamic error creation in integration test utils is ok
     - path: tests/e2e/
-      linters: [ gci ] # Disable gci due to the test utilities dot import.
+      linters: [gci] # Disable gci due to the test utilities dot import.
     - path: tests/integration/
-      linters: [ gci ] # Disable gci due to the test utilities dot import.
+      linters: [gci] # Disable gci due to the test utilities dot import.
     - linters:
         - importas
       text: has alias "" which is not part of config # Ignore false positives that emerged due to https://github.com/julz/importas/issues/15.

--- a/internal/setup/watcher.go
+++ b/internal/setup/watcher.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"net"
 	"os"
 	"strings"
 
@@ -61,7 +62,7 @@ func SetupSkrWebhookManager(mgr ctrl.Manager,
 func getResolvedKcpAddress(mgr ctrl.Manager,
 	flagVar *flags.FlagVar,
 	setupLog logr.Logger,
-) string {
+) net.TCPAddr {
 	gatewayConfig := watcher.GatewayConfig{
 		IstioGatewayName:          flagVar.IstioGatewayName,
 		IstioGatewayNamespace:     flagVar.IstioGatewayNamespace,
@@ -69,12 +70,12 @@ func getResolvedKcpAddress(mgr ctrl.Manager,
 	}
 
 	resolvedKcpAddr, err := gatewayConfig.ResolveKcpAddr(mgr)
-	if err != nil {
+	if err != nil || resolvedKcpAddr == nil {
 		setupLog.Error(err, "failed to resolve KCP address")
 		os.Exit(bootstrapFailedExitCode)
 	}
 
-	return resolvedKcpAddr
+	return *resolvedKcpAddr
 }
 
 func setupCertManager(kcpClient client.Client,

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -42,7 +43,7 @@ type SkrWebhookManifestManager struct {
 	kcpClient          client.Client
 	skrContextFactory  remote.SkrContextProvider
 	config             SkrWebhookManagerConfig
-	kcpAddr            string
+	kcpAddr            net.TCPAddr
 	baseResources      []*unstructured.Unstructured
 	watcherMetrics     WatcherMetrics
 	certificateManager CertificateManager
@@ -64,7 +65,7 @@ func NewSKRWebhookManifestManager(
 	kcpClient client.Client,
 	skrContextFactory remote.SkrContextProvider,
 	managerConfig SkrWebhookManagerConfig,
-	resolvedKcpAddr string,
+	resolvedKcpAddr net.TCPAddr,
 	certificateManager CertificateManager,
 	watcherMetrics *metrics.WatcherMetrics,
 ) (*SkrWebhookManifestManager, error) {

--- a/skr-webhook/resources.yaml
+++ b/skr-webhook/resources.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,61 +8,66 @@ kind: ClusterRole
 metadata:
   name: kyma-reader
 rules:
-  - apiGroups: [ "operator.kyma-project.io" ]
-    resources: [ "kymas" ]
-    verbs: [ "get", "watch", "list" ]
+  - apiGroups:
+      - operator.kyma-project.io
+    resources:
+      - kymas
+    verbs:
+      - get
+      - watch
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: read-kymas
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kyma-reader
 subjects:
   - kind: ServiceAccount
     name: skr-webhook-sa
-roleRef:
-  kind: ClusterRole
-  name: kyma-reader
-  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: skr-webhook
 spec:
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: watcher-port
   selector:
     app: skr-webhook
-  ports:
-    - port: 443
-      targetPort: watcher-port
-      name: webhook
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: skr-webhook-metrics
 spec:
+  ports:
+    - name: http-metrics
+      port: 2112
+      targetPort: metrics-port
   selector:
     app: skr-webhook
-  ports:
-    - port: 2112
-      targetPort: metrics-port
-      name: http-metrics
 ---
 apiVersion: scheduling.k8s.io/v1
+description: This priority class is used for skr-webhook to ensure reconciliation, even with high workload.
+globalDefault: false
 kind: PriorityClass
 metadata:
   name: skr-webhook-priority
 value: 1000000000
-globalDefault: false
-description: "This priority class is used for skr-webhook to ensure reconciliation, even with high workload."
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: skr-webhook
-  namespace: default
   labels:
     app: skr-webhook
+  name: skr-webhook
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -76,10 +80,8 @@ spec:
         operator.kyma-project.io/pod-restart-trigger: ""
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: skr-webhook-sa
       containers:
-        - name: server
-          env:
+        - env:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -89,38 +91,40 @@ spec:
             - name: METRICS_PORT
               value: "2112"
             - name: TLS_KEY
-              value: "/app/etc/ssl/tls.key"
+              value: /app/etc/ssl/tls.key
             - name: TLS_CERT
-              value: "/app/etc/ssl/tls.crt"
+              value: /app/etc/ssl/tls.crt
             - name: CA_CERT
-              value: "/app/etc/ssl/ca.crt"
+              value: /app/etc/ssl/ca.crt
             - name: TLS_CALLBACK
               value: "true"
             - name: KCP_CONTRACT
-              value: "v1"
+              value: v1
             - name: KCP_ADDR
-              value: "kcp-base-url-invalid"
-          image: "europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:latest" # this image will be dynamically replaced by flags
+              value: kcp-base-url-invalid
+          image: europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:latest
           imagePullPolicy: Always
-          volumeMounts:
-            - name: ssl
-              mountPath: /app/etc/ssl
-          resources:
-            requests:
-              memory: 20Mi
-              cpu: "0.01"
-            limits:
-              memory: 200Mi
-              cpu: "0.1"
+          name: server
           ports:
             - containerPort: 8443
               name: watcher-port
             - containerPort: 2112
               name: metrics-port
+          resources:
+            limits:
+              cpu: "0.1"
+              memory: 200Mi
+            requests:
+              cpu: "0.01"
+              memory: 20Mi
+          volumeMounts:
+            - mountPath: /app/etc/ssl
+              name: ssl
+      priorityClassName: skr-webhook-priority
+      serviceAccountName: skr-webhook-sa
       volumes:
         - name: ssl
           secret:
-            secretName: skr-webhook-tls
             items:
               - key: tls.key
                 path: tls.key
@@ -128,4 +132,91 @@ spec:
                 path: tls.crt
               - key: ca.crt
                 path: ca.crt
-      priorityClassName: skr-webhook-priority
+            secretName: skr-webhook-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: skr-webhook
+  name: kyma-project.io--seed-to-watcher
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              gardener.cloud/purpose: kube-system
+          podSelector:
+            matchLabels:
+              app: vpn-shoot
+  podSelector:
+    matchLabels:
+      app: skr-webhook
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: skr-webhook
+  name: kyma-project.io--watcher-to-apiserver
+  namespace: default
+spec:
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: skr-webhook
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: skr-webhook
+  name: kyma-project.io--watcher-to-dns
+  namespace: default
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+        - port: 8053
+          protocol: UDP
+        - port: 8053
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+  podSelector:
+    matchLabels:
+      app: skr-webhook
+  policyTypes:
+    - Egress

--- a/tests/integration/controller/withwatcher/suite_test.go
+++ b/tests/integration/controller/withwatcher/suite_test.go
@@ -228,7 +228,7 @@ var _ = BeforeSuite(func() {
 		kcpClient,
 		testSkrContextFactory,
 		skrChartCfg,
-		resolvedKcpAddr,
+		*resolvedKcpAddr,
 		certificateManager,
 		metrics.NewWatcherMetrics(),
 	)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use net.TCPAddr to process the KCP IP Address instead of a string
- Added network policies for the SKR webhook to be deployed on the SKR clusters
- Added a function to modify the network policies to have the right port of the lifecycle-manager

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
