### PR TITLE
fix: E2E Test for Legacy Istio Gateway Secret Rotation

### DIFF
--- a/.github/actions/deploy-lifecycle-manager-e2e/action.yml
+++ b/.github/actions/deploy-lifecycle-manager-e2e/action.yml
@@ -56,18 +56,7 @@ runs:
       shell: bash
       run: |
         pushd ${E2E_KUSTOMIZE_DIR}
-        if [[ -n "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
-        echo \
-        "- op: add
-          path: /spec/template/spec/containers/0/args/-
-          value: --self-signed-cert-duration=${E2E_GARDENER_CERT_MANAGER_CERTIFICATE_DURATION}
-        - op: add
-          path: /spec/template/spec/containers/0/args/-
-          value: --self-signed-cert-renew-before=${E2E_GARDENER_CERT_MANAGER_RENEWAL_WINDOW}
-        - op: add
-          path: /spec/template/spec/containers/0/args/-
-          value: --self-signed-cert-renew-buffer=1m" >> self-signed-cert.yaml
-        else
+        if [[ -z "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
         echo \
         "- op: add
           path: /spec/template/spec/containers/0/args/-
@@ -130,14 +119,7 @@ runs:
       shell: bash
       run: |
         pushd ${E2E_KUSTOMIZE_DIR}
-        if [[ -n "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
-        echo \
-        "- op: replace
-          path: /spec/duration
-          value: ${E2E_GARDENER_CERT_MANAGER_CERTIFICATE_DURATION}">> certificate_renewal.yaml
-        cat certificate_renewal.yaml
-        kustomize edit add patch --path certificate_renewal.yaml --kind Certificate --group cert.gardener.cloud --version v1alpha1 --name watcher-serving
-        else
+        if [[ -z "${E2E_USE_GARDENER_CERT_MANAGER}" ]]; then
         echo \
         "- op: replace
           path: /spec/renewBefore
@@ -150,7 +132,8 @@ runs:
         fi
         popd
     - name: Use legacy istio gateway secret rotation strategy
-      if: ${{matrix.e2e-test == 'legacy-istio-gateway-secret-rotation'}}
+      if: ${{matrix.e2e-test == 'legacy-istio-gateway-secret-rotation' ||
+        matrix.e2e-test == 'legacy-istio-gateway-secret-rotation-gcm'}}
       working-directory: lifecycle-manager
       shell: bash
       run: |
@@ -158,7 +141,10 @@ runs:
         echo \
         "- op: add
           path: /spec/template/spec/containers/0/args/-
-          value: --legacy-strategy-for-istio-gateway-secret=true" >> legacy-secret-rotation.yaml
+          value: --legacy-strategy-for-istio-gateway-secret=true
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --istio-gateway-secret-requeue-success-interval=5s" >> legacy-secret-rotation.yaml
         cat legacy-secret-rotation.yaml
         kustomize edit add patch --path legacy-secret-rotation.yaml --kind Deployment
         popd

--- a/.github/workflows/test-e2e-with-gcm.yml
+++ b/.github/workflows/test-e2e-with-gcm.yml
@@ -42,8 +42,7 @@ jobs:
       matrix:
         e2e-test:
           - watcher-enqueue
-          #- legacy-istio-gateway-secret-rotation
-          #- self-signed-certificate-rotation
+          - legacy-istio-gateway-secret-rotation-gcm
           - modulereleasemeta-watch-trigger
 
     runs-on: ubuntu-latest
@@ -75,10 +74,6 @@ jobs:
           echo "E2E_USE_GARDENER_CERT_MANAGER=1" >> $GITHUB_ENV
           echo "E2E_GARDENER_CERT_MANAGER_CERTIFICATE_DURATION=1441h" >> $GITHUB_ENV
           echo "E2E_GARDENER_CERT_MANAGER_RENEWAL_WINDOW=720h1m" >> $GITHUB_ENV
-#          if [[ "${{ matrix.e2e-test }}" == "legacy-istio-gateway-secret-rotation" || "${{ matrix.e2e-test }}" == "self-signed-certificate-rotation" ]]; then
-#            # renewing every minute, since certificate duration is 1441h
-#            echo "E2E_GARDENER_CERT_MANAGER_RENEWAL_WINDOW=1440h59m" >> $GITHUB_ENV
-#          fi
       - name: Setup test clusters
         uses: ./lifecycle-manager/.github/actions/setup-test-clusters-gcm
         with:

--- a/api/shared/istio.go
+++ b/api/shared/istio.go
@@ -1,6 +1,7 @@
 package shared
 
 const (
+	CACertificateName        = "klm-watcher-serving"
 	IstioNamespace           = "istio-system"
 	GatewaySecretName        = "klm-istio-gateway" //nolint:gosec // It is just a name
 	LastModifiedAtAnnotation = "lastModifiedAt"

--- a/config/watcher_local_test_gcm/kustomization.yaml
+++ b/config/watcher_local_test_gcm/kustomization.yaml
@@ -88,6 +88,12 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --self-signed-cert-duration=1441h
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --legacy-strategy-for-istio-gateway-secret=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --istio-gateway-secret-requeue-success-interval=5s
   - target:
       kind: ConfigMap
       name: dashboard-(overview|status|watcher|mandatory-modules)

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -139,6 +139,9 @@ module-install-by-version:
 legacy-istio-gateway-secret-rotation:
 	go test -timeout 20m -ginkgo.v -ginkgo.focus "Legacy Istio Gateway Secret Rotation"
 
+legacy-istio-gateway-secret-rotation-gcm:
+	go test -timeout 20m -ginkgo.v -ginkgo.focus "Legacy Istio Gateway Secret Rotation With GCM"
+
 self-signed-certificate-rotation:
 	go test -timeout 20m -ginkgo.v -ginkgo.focus "Self Signed Certificate Rotation"
 

--- a/tests/e2e/commontestutils/watcher.go
+++ b/tests/e2e/commontestutils/watcher.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	gcertv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	apicorev1 "k8s.io/api/core/v1"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -153,4 +154,21 @@ func GetLastModifiedTimeFromAnnotation(secret *apicorev1.Secret) (time.Time, err
 		}
 	}
 	return time.Time{}, errors.New("getting lastModifiedAt time failed")
+}
+
+func RotateCAManuallyWithGCM(ctx context.Context, kcpClient client.Client) error {
+	caCert := &gcertv1alpha1.Certificate{}
+	if err := kcpClient.Get(ctx, types.NamespacedName{
+		Name:      shared.CACertificateName,
+		Namespace: shared.IstioNamespace,
+	}, caCert); err != nil {
+		return fmt.Errorf("failed to get CA certificate %w", err)
+	}
+	caCert.Spec.EnsureRenewedAfter = nil
+	renew := true
+	caCert.Spec.Renew = &renew
+	if err := kcpClient.Update(ctx, caCert); err != nil {
+		return fmt.Errorf("failed to update CA certificate %w", err)
+	}
+	return nil
 }

--- a/tests/e2e/legacy_istio_gateway_secret_rotation_gcm_test.go
+++ b/tests/e2e/legacy_istio_gateway_secret_rotation_gcm_test.go
@@ -1,0 +1,60 @@
+package e2e_test
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
+	. "github.com/kyma-project/lifecycle-manager/tests/e2e/commontestutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Legacy Istio Gateway Secret Rotation With GCM", Ordered, func() {
+	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	InitEmptyKymaBeforeAll(kyma)
+	CleanupKymaAfterAll(kyma)
+
+	Context("Given KCP Cluster, rotated CA certificate, and Istio Gateway Secret", func() {
+		It("Then Istio Gateway Secret is a copy of CA Certificate", func() {
+			namespacedRootCASecretName := types.NamespacedName{
+				Name:      "klm-watcher",
+				Namespace: IstioNamespace,
+			}
+
+			By("When CA Certificate is rotated")
+			Expect(RotateCAManuallyWithGCM(ctx, kcpClient)).
+				To(Succeed())
+
+			By("Then Istio Gateway Secret is synced to Root CA Secret")
+			Eventually(IstioGatewaySecretIsSyncedToRootCA, 4*time.Minute).
+				WithContext(ctx).
+				WithArguments(namespacedRootCASecretName, kcpClient).
+				Should(Succeed())
+
+			By("And LastModifiedAt timestamp is valid")
+			gwSecret, err := GetGatewaySecret(ctx, kcpClient)
+			Expect(err).NotTo(HaveOccurred())
+			lastModifiedAtTime, err := GetLastModifiedTimeFromAnnotation(gwSecret)
+			Expect(err).To(Succeed())
+
+			By("When CA Certificate is rotated again")
+			Expect(RotateCAManuallyWithGCM(ctx, kcpClient)).
+				To(Succeed())
+
+			By("Then LastModifiedAt timestamp is updated")
+			Eventually(GatewaySecretCreationTimeIsUpdated, 4*time.Minute).
+				WithContext(ctx).
+				WithArguments(lastModifiedAtTime, kcpClient).
+				Should(Succeed())
+
+			By("And new Istio Gateway Secret is also a copy of CA Certificate")
+			Eventually(IstioGatewaySecretIsSyncedToRootCA, 4*time.Minute).
+				WithContext(ctx).
+				WithArguments(namespacedRootCASecretName, kcpClient).
+				Should(Succeed())
+		})
+	})
+})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	gcertv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,6 +90,7 @@ var _ = BeforeSuite(func() {
 	Expect(api.AddToScheme(k8sclientscheme.Scheme)).NotTo(HaveOccurred())
 	Expect(apiextensionsv1.AddToScheme(k8sclientscheme.Scheme)).NotTo(HaveOccurred())
 	Expect(certmanagerv1.AddToScheme(k8sclientscheme.Scheme)).NotTo(HaveOccurred())
+	Expect(gcertv1alpha1.AddToScheme(k8sclientscheme.Scheme)).NotTo(HaveOccurred())
 	SetDefaultEventuallyPollingInterval(interval)
 	SetDefaultEventuallyTimeout(EventuallyTimeout)
 	SetDefaultConsistentlyDuration(ConsistentDuration)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Introduce modified E2E test `legacy-istio-gateway-secret-rotation-gcm`
- Test util to rotate CA certificate in GCM manually

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #2436 