### PR TITLE
chore: Make klm-watcher istio gateway accept TLS 1.3 only

### DIFF
--- a/config/watcher/gateway.yaml
+++ b/config/watcher/gateway.yaml
@@ -22,3 +22,5 @@ spec:
       tls:
         credentialName: klm-istio-gateway
         mode: MUTUAL
+        minProtocolVersion: TLSV1_3
+        maxProtocolVersion: TLSV1_3


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-  Make klm-watcher istio gateway accept TLS 1.3 only


**Related issue(s)**
Resolves #2575
