### PR TITLE
fix: Populate Manifest operator.kyma-project.io/channel label for non-mandatory modules

### DIFF
--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -45,7 +45,11 @@ func (m *Module) ApplyDefaultMetaToManifest(kyma *v1beta2.Kyma) {
 		lbls[shared.ControllerName] = m.TemplateInfo.GetLabels()[shared.ControllerName]
 	}
 	lbls[shared.ModuleName] = m.ModuleName
-	lbls[shared.ChannelLabel] = m.TemplateInfo.Spec.Channel
+
+	if !m.TemplateInfo.IsMandatory() {
+		lbls[shared.ChannelLabel] = m.TemplateInfo.DesiredChannel
+	}
+
 	lbls[shared.ManagedBy] = shared.OperatorName
 	if m.TemplateInfo.Spec.Mandatory {
 		lbls[shared.IsMandatoryModule] = shared.EnableLabelValue

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -74,7 +74,6 @@ func TestApplyDefaultMetaToManifest_WhenCalledWithNonMandatoryModule_ChannelLabe
 
 	resultLabels := module.Manifest.GetLabels()
 	assert.Equal(t, "regular", resultLabels["operator.kyma-project.io/channel"])
-
 }
 
 func TestApplyDefaultMetaToManifest_WhenCalled_SetsManagedByLabel(t *testing.T) {

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -54,15 +54,27 @@ func TestApplyDefaultMetaToManifest_WhenCalledWithControllerName_SetsControllerN
 	assert.Equal(t, "some-controller", resultLabels["operator.kyma-project.io/controller-name"])
 }
 
-func TestApplyDefaultMetaToManifest_WhenCalledWithChannel_SetsChannelLabel(t *testing.T) {
+func TestApplyDefaultMetaToManifest_WhenCalledWithMandatoryModule_NoChannelLabelIsSet(t *testing.T) {
 	module := createModule()
-	module.TemplateInfo.Spec.Channel = "some-channel"
+	module.TemplateInfo.Spec.Mandatory = true
 	kyma := &v1beta2.Kyma{}
 
 	module.ApplyDefaultMetaToManifest(kyma)
 
 	resultLabels := module.Manifest.GetLabels()
-	assert.Equal(t, "some-channel", resultLabels["operator.kyma-project.io/channel"])
+	assert.NotContains(t, resultLabels, "operator.kyma-project.io/channel")
+}
+
+func TestApplyDefaultMetaToManifest_WhenCalledWithNonMandatoryModule_ChannelLabelIsSet(t *testing.T) {
+	module := createModule()
+	module.TemplateInfo.DesiredChannel = "regular"
+	kyma := &v1beta2.Kyma{}
+
+	module.ApplyDefaultMetaToManifest(kyma)
+
+	resultLabels := module.Manifest.GetLabels()
+	assert.Equal(t, "regular", resultLabels["operator.kyma-project.io/channel"])
+
 }
 
 func TestApplyDefaultMetaToManifest_WhenCalled_SetsManagedByLabel(t *testing.T) {

--- a/pkg/testutils/manifest.go
+++ b/pkg/testutils/manifest.go
@@ -177,7 +177,8 @@ func MandatoryManifestExistsWithLabelAndAnnotation(ctx context.Context, clnt cli
 }
 
 func ManifestContainExpectedLabel(ctx context.Context, clnt client.Client,
-	kymaName, kymaNamespace, moduleName, labelKey, labelValue string) error {
+	kymaName, kymaNamespace, moduleName, labelKey, labelValue string,
+) error {
 	manifest, err := GetManifest(ctx, clnt, kymaName, kymaNamespace, moduleName)
 	if err != nil {
 		return err

--- a/pkg/testutils/manifest.go
+++ b/pkg/testutils/manifest.go
@@ -184,6 +184,7 @@ func ManifestContainExpectedLabel(ctx context.Context, clnt client.Client,
 		return err
 	}
 
+	fmt.Println("Manifest labels:", manifest.Labels)
 	if manifest.Labels == nil {
 		return ErrManifestNotContainLabelKey
 	}

--- a/tests/e2e/mandatory_module_test.go
+++ b/tests/e2e/mandatory_module_test.go
@@ -61,6 +61,14 @@ var _ = Describe("Mandatory Module Installation and Deletion", Ordered, func() {
 					WithArguments(kcpClient, "template-operator", "1.1.0-smoke-test").
 					Should(Succeed())
 			})
+
+			By("And the mandatory module manifest does not contain the operator.kyma-project.io/channel label")
+			Eventually(ManifestContainExpectedLabel).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "template-operator",
+					"operator.kyma-project.io/channel", "").
+				Should(Equal(ErrManifestNotContainLabelKey))
+
 		})
 
 		It("When the mandatory Manifest is labelled to skip reconciliation", func() {

--- a/tests/e2e/mandatory_module_test.go
+++ b/tests/e2e/mandatory_module_test.go
@@ -63,10 +63,9 @@ var _ = Describe("Mandatory Module Installation and Deletion", Ordered, func() {
 			})
 
 			By("And the mandatory module manifest does not contain the operator.kyma-project.io/channel label")
-			Eventually(ManifestContainExpectedLabel).
+			Eventually(MandatoryModuleManifestContainsExpectedLabel).
 				WithContext(ctx).
-				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "template-operator",
-					"operator.kyma-project.io/channel", "").
+				WithArguments(kcpClient, "template-operator", "operator.kyma-project.io/channel", "").
 				Should(Equal(ErrManifestNotContainLabelKey))
 		})
 

--- a/tests/e2e/mandatory_module_test.go
+++ b/tests/e2e/mandatory_module_test.go
@@ -68,7 +68,6 @@ var _ = Describe("Mandatory Module Installation and Deletion", Ordered, func() {
 				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "template-operator",
 					"operator.kyma-project.io/channel", "").
 				Should(Equal(ErrManifestNotContainLabelKey))
-
 		})
 
 		It("When the mandatory Manifest is labelled to skip reconciliation", func() {

--- a/tests/e2e/manifest_reconciliation_test.go
+++ b/tests/e2e/manifest_reconciliation_test.go
@@ -42,6 +42,13 @@ var _ = Describe("Manifest Skip Reconciliation Label", Ordered, func() {
 				WithContext(ctx).
 				WithArguments(kyma.GetName(), kyma.GetNamespace(), kcpClient, shared.StateReady).
 				Should(Succeed())
+
+			By("And the Manifest contains the operator.kyma-project.io/channel label set to regular")
+			Eventually(ManifestContainExpectedLabel).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name,
+					"operator.kyma-project.io/channel", "regular").
+				Should(Succeed())
 		})
 
 		It("When the Manifest is labelled to skip reconciliation", func() {

--- a/tests/e2e/manifest_reconciliation_test.go
+++ b/tests/e2e/manifest_reconciliation_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Manifest Skip Reconciliation Label", Ordered, func() {
 				Should(Succeed())
 
 			By("And the Manifest contains the operator.kyma-project.io/channel label set to regular")
-			Eventually(ManifestContainExpectedLabel).
+			Eventually(ManifestContainsExpectedLabel).
 				WithContext(ctx).
 				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), module.Name,
 					"operator.kyma-project.io/channel", "regular").


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Populate Manifest operator.kyma-project.io/channel label for non-mandatory modules
- Adjust unit and E2E tests

**Related issue(s)**
Resolves #2556 
