### PR TITLE
chore: Migrate ADR from wiki - 006 CRD Upgrade strategy

### DIFF
--- a/docs/contributor/adr/006-crd-upgrade-strategy
+++ b/docs/contributor/adr/006-crd-upgrade-strategy
@@ -1,0 +1,31 @@
+# ADR 006 - Upgrade Strategy for Custom Resource Definition (CRD) Version in Managed Mode
+
+## Status
+
+Accepted
+
+## Context
+
+We currently have several issues that require introducing new spec fields to existing v1beta1 CRDs in our system. Typically, if these spec fields do not introduce breaking changes, such as being optional fields, we can add them using the same CRD version. 
+
+However, in managed mode, we need to sync Kyma to remote, and the remote CRD does not get updated if they are in the same version, which means that remote Kyma instances will not contain changes introduced by new spec fields if we are not updating the CRD version in KCP.
+
+This has raised a concern about whether we should keep the current logic of requiring a version upgrade for any change, or introduce a process to detect differences even if CRDs are in the same version, to avoid unnecessary version upgrades.
+
+Options for non-breaking changes:
+- Keep current logic, when new change comes, create new version, set storage: true, served: false, which means content will be saved as new version, but the resources will be presented still using old version. When all changes are implemented, change served:true for new version.
+- Introduce a process to detect differences between KCP and SKR even if CRDs are in the same version, and update SKR CRD if necessary. 
+
+## Decision
+
+The decision is to implement option 2, which is to introduce a process to detect differences between KCP and SKR even if CRDs are in the same version, and update SKR CRDs if necessary.
+
+1. Doing time windowed research, find an efficient and robust mechanism to directly compare the remote SKR CRDs spec to KCR CRDs spec, 
+  a. run a performance test to approve it's not being bottlenecked.
+2. More preferred way: record existing CRDs generation numbers, both SKR and KCR CRDs, check for differences in CRD generation numbers, and if there are any, apply CRD updates to SKR.
+  a. use kyma CR annotation to save CRD generation numbers
+
+
+## Consequences
+
+The implementation of the process to detect differences in CRDs and update SKR CRDs will ensure that changes introduced in KCP CRDs are properly reflected in remote SKR instances, even if the CRDs are in the same version. This will prevent unnecessary version upgrades and ensure consistency between KCP and SKR CRDs. However, it may introduce additional overhead in terms of performance due to the comparison and update process, which will need to be carefully evaluated during performance testing.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- According to https://github.com/kyma-project/lifecycle-manager/issues/2405 we want to migrate ADRs from our Wiki to the repo
- This is adding the accepted ADR about Upgrade Strategy for Custom Resource Definition (CRD) Version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
