### PR TITLE
chore: Bump sec-scanner-cfg release ver and RW ref

### DIFF
--- a/.run/Launch KLM locally.run.xml
+++ b/.run/Launch KLM locally.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Launch KLM locally" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="lifecycle-manager" />
     <working_directory value="$PROJECT_DIR$" />
-    <parameters value="--enable-kcp-watcher --skr-watcher-image-tag=1.2.0"/>
+    <parameters value="--enable-kcp-watcher --skr-watcher-image-tag=1.2.2"/>
     <envs>
       <env name="KUBECONFIG" value="$USER_HOME$/.k3d/kcp-local.yaml" />
     </envs>

--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=1.2.0
+        value: --skr-watcher-image-tag=1.2.2
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -8,7 +8,7 @@ checkmarx-one:
     - "**/testutils/**"
     - "tests/**"
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.3.12
+  - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.5.0
   - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:latest
 mend:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Latest release is [1.5.0](https://github.com/kyma-project/lifecycle-manager/releases/tag/1.5.0), it needs to be scanned
- Update reference to latest runtime-watcher release 1.2.2 for test-suites and local run cfgs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
