### PR TITLE
fix: Manifest Change workflow is flakey

### DIFF
--- a/.github/workflows/check-manifests-changes.yml
+++ b/.github/workflows/check-manifests-changes.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
+        uses: ./lifecycle-manager/.github/actions/install-yq
+        with:
+          yq_version: 4.45.1
 
       - name: Checkout main branch
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor License Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The reason why the workflow does not work sometimes is still not clear, but it can be related to caching of manifest files between the jobs.
This caching is not strictly required here, as we can generate and compare files in a single job. The additional benefit is that the job becomes simpler.

Changes proposed in this pull request:

- Moved everything into a single job to avoid caching of files between subsequent jobs, to eliminate the scenario of cached files "leaking" between jobs in an uncontrolled way
- Using yq to sort the YAMLs before comparing them for more meaningful diffs
- Configuring specific yq version to be used

**Related issue(s)**
* #2427 
