### PR TITLE
chore: Make some flag by default enabled

### DIFF
--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -118,7 +118,7 @@ func DefineFlagVar() *FlagVar {
 		"max-concurrent-mandatory-modules-deletion-reconciles",
 		DefaultMaxConcurrentMandatoryModuleDeletionReconciles,
 		"Maximum number of concurrent Mandatory Modules deletion reconciles which can be run.")
-	flag.BoolVar(&flagVar.EnableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&flagVar.EnableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&flagVar.LeaderElectionLeaseDuration, "leader-election-lease-duration",
@@ -183,7 +183,7 @@ func DefineFlagVar() *FlagVar {
 			" limit when there are sudden spikes in request volume.")
 	flag.BoolVar(&flagVar.EnableWebhooks, "enable-webhooks", false,
 		"Enable Validation/Conversion Webhooks.")
-	flag.BoolVar(&flagVar.EnableKcpWatcher, "enable-kcp-watcher", false,
+	flag.BoolVar(&flagVar.EnableKcpWatcher, "enable-kcp-watcher", true,
 		"Enable KCP Watcher controller to reconcile Watcher CRs.")
 	flag.StringVar(&flagVar.AdditionalDNSNames, "additional-dns-names", "",
 		"Additional DNS Names which are added to SKR certificates as SANs. Input should be given as "+
@@ -218,7 +218,7 @@ func DefineFlagVar() *FlagVar {
 		&flagVar.LogLevel, "log-level", DefaultLogLevel,
 		"Log level. Enter negative or positive values to increase verbosity. 0 has the lowest verbosity.",
 	)
-	flag.BoolVar(&flagVar.EnablePurgeFinalizer, "enable-purge-finalizer", false,
+	flag.BoolVar(&flagVar.EnablePurgeFinalizer, "enable-purge-finalizer", true,
 		"Enable Purge controller.")
 	flag.DurationVar(&flagVar.PurgeFinalizerTimeout, "purge-finalizer-timeout", DefaultPurgeFinalizerTimeout,
 		"Duration after a Kyma's deletion timestamp when the remaining resources should be purged in the SKR.")
@@ -253,7 +253,7 @@ func DefineFlagVar() *FlagVar {
 		"Duration after which the Istio Gateway Secret is enqueued after unsuccessful reconciliation.")
 	flag.BoolVar(&flagVar.UseLegacyStrategyForIstioGatewaySecret, "legacy-strategy-for-istio-gateway-secret",
 		false, "Use the legacy strategy (with downtime) for the Istio Gateway Secret.")
-	flag.BoolVar(&flagVar.IsKymaManaged, "is-kyma-managed", false, "Use managed Kyma mode.")
+	flag.BoolVar(&flagVar.IsKymaManaged, "is-kyma-managed", true, "Use managed Kyma mode.")
 	flag.StringVar(&flagVar.DropCrdStoredVersionMap, "drop-crd-stored-version-map", DefaultDropCrdStoredVersionMap,
 		"API versions to be dropped from the storage version. The input format should be a "+
 			"comma-separated list of API versions, where each API version is in the format 'kind:version'.")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Some of these flags don’t need to be configured directly. In this PR, the goal is to adjust their default values so they don’t have to be explicitly exposed for different landscape profiles. Ultimately, these flags should be removed altogether, which will be addressed in a follow-up [issue](https://github.com/kyma-project/lifecycle-manager/issues/2673).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
