### PR TITLE
fix: Read GCM SKR Secret timestamp from requestedAt annotation

### DIFF
--- a/api/shared/istio.go
+++ b/api/shared/istio.go
@@ -5,4 +5,5 @@ const (
 	IstioNamespace           = "istio-system"
 	GatewaySecretName        = "klm-istio-gateway" //nolint:gosec // It is just a name
 	LastModifiedAtAnnotation = "lastModifiedAt"
+	GCMSecretAnnotation      = "cert.gardener.cloud/requestedAt"
 )

--- a/internal/service/watcher/certificate/renewal/certmanager/renewal_service.go
+++ b/internal/service/watcher/certificate/renewal/certmanager/renewal_service.go
@@ -3,6 +3,11 @@ package certmanager
 import (
 	"context"
 	"fmt"
+	"time"
+
+	apicorev1 "k8s.io/api/core/v1"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 )
 
 type SecretRepository interface {
@@ -25,4 +30,22 @@ func (s *Service) Renew(ctx context.Context, name string) error {
 	}
 
 	return nil
+}
+
+// SkrSecretNeedsRenewal check if the SKR Secret needs to be renewed.
+// Renewal is required if the gateway certificate secret is newer than the SKR certificate secret.
+func (_ *Service) SkrSecretNeedsRenewal(gatewaySecret, skrSecret *apicorev1.Secret) bool {
+	gwSecretLastModifiedAtValue, ok := gatewaySecret.Annotations[shared.LastModifiedAtAnnotation]
+	// always renew if the annotation is not set
+	if !ok {
+		return true
+	}
+
+	gwSecretLastModifiedAt, err := time.Parse(time.RFC3339, gwSecretLastModifiedAtValue)
+	// always renew if unable to parse
+	if err != nil {
+		return true
+	}
+
+	return skrSecret.CreationTimestamp.Time.Before(gwSecretLastModifiedAt)
 }

--- a/internal/service/watcher/certificate/renewal/certmanager/renewal_service_test.go
+++ b/internal/service/watcher/certificate/renewal/certmanager/renewal_service_test.go
@@ -3,10 +3,14 @@ package certmanager_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apicorev1 "k8s.io/api/core/v1"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	certmanagerrenewal "github.com/kyma-project/lifecycle-manager/internal/service/watcher/certificate/renewal/certmanager"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
@@ -28,6 +32,96 @@ func TestRenew_WhenRepositoryDeleteReturnsAnError_ReturnsError(t *testing.T) {
 
 	require.ErrorIs(t, err, assert.AnError)
 	require.ErrorContains(t, err, "failed to renew SKR certificate secret. Deletion failed")
+}
+
+func TestSkrSecretNeedsRenewal_WhenSkrCreationOlderThanGatewayLastModified_ReturnsTrue(t *testing.T) {
+	renewalService := certmanagerrenewal.NewService(&secretRepoStub{})
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, modified now
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: time.Now().Format(time.RFC3339),
+			},
+		},
+	}
+	skrSecret := &apicorev1.Secret{ // skr secret, created a minute ago
+		ObjectMeta: apimetav1.ObjectMeta{
+			CreationTimestamp: apimetav1.Time{
+				Time: time.Now().Add(-time.Minute),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestSkrSecretNeedsRenewal_WhenSkrCreationNewerThanGatewayLastModified_ReturnsFalse(t *testing.T) {
+	renewalService := certmanagerrenewal.NewService(&secretRepoStub{})
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, modified a minute ago
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	skrSecret := &apicorev1.Secret{ // skr secret, created now
+		ObjectMeta: apimetav1.ObjectMeta{
+			CreationTimestamp: apimetav1.Time{
+				Time: time.Now(),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.False(t, result)
+}
+
+func TestSkrSecretNeedsRenewal_GatewaySecretHasNoLastModified_ReturnsTrue(t *testing.T) {
+	renewalService := certmanagerrenewal.NewService(&secretRepoStub{})
+	// gateway secret, no last modified
+	gatewaySecret := &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+	// skr secret, created a minute ago
+	skrSecret := &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			CreationTimestamp: apimetav1.Time{
+				Time: time.Now().Add(-time.Minute),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestRenewSkrCertificate_WhenGatewaySecretHasInvalidLastModified_ReturnsTrue(t *testing.T) {
+	renewalService := certmanagerrenewal.NewService(&secretRepoStub{})
+	// gateway secret, no last modified
+	gatewaySecret := &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: "not a time",
+			},
+		},
+	}
+	// skr secret, created a minute ago
+	skrSecret := &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			CreationTimestamp: apimetav1.Time{
+				Time: time.Now().Add(-time.Minute),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
 }
 
 type secretRepoStub struct {

--- a/internal/service/watcher/certificate/renewal/gcm/renewal_service_test.go
+++ b/internal/service/watcher/certificate/renewal/gcm/renewal_service_test.go
@@ -3,12 +3,15 @@ package gcm_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	gcertv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apicorev1 "k8s.io/api/core/v1"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/internal/service/watcher/certificate/renewal/gcm"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
@@ -101,6 +104,108 @@ func TestRenew_WhenRepoUpdateReturnsError_ReturnsError(t *testing.T) {
 
 	require.ErrorIs(t, err, assert.AnError)
 	require.ErrorContains(t, err, "failed to update certificate for renewal")
+}
+
+func TestSkrSecretNeedsRenewal_WhenSkrRequestedAtOlderThanGatewayLastModified_ReturnsTrue(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, modified now
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: time.Now().Format(time.RFC3339),
+			},
+		},
+	}
+	skrSecret := &apicorev1.Secret{ // skr secret, created a minute ago
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.GCMSecretAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestSkrSecretNeedsRenewal_WhenSkrCreationNewerThanGatewayLastModified_ReturnsFalse(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, modified a minute ago
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+	}
+	skrSecret := &apicorev1.Secret{ // skr secret, created now
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.GCMSecretAnnotation: time.Now().Format(time.RFC3339),
+			},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.False(t, result)
+}
+
+func TestSkrSecretNeedsRenewal_GatewaySecretHasNoLastModified_ReturnsTrue(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, no lastModifiedAt
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+	skrSecret := &apicorev1.Secret{}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestRenewSkrCertificate_WhenGatewaySecretHasInvalidLastModified_CallsRenewalServiceRenew(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{ // gateway secret, invalid lastModifiedAt
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: "not a time",
+			},
+		},
+	}
+	skrSecret := &apicorev1.Secret{}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestSkrSecretNeedsRenewal_WhenSkrSecretHasNoRequestedAt_ReturnsTrue(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{}
+	skrSecret := &apicorev1.Secret{ // skr secret, no requestedAt
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
+}
+
+func TestRenewSkrCertificate_WhenSkrSecretHasInvalidRequestedAt_ReturnsTrue(t *testing.T) {
+	renewalService := gcm.NewService(nil)
+	gatewaySecret := &apicorev1.Secret{}
+	skrSecret := &apicorev1.Secret{ // skr secret, invalid requestedAt
+		ObjectMeta: apimetav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	result := renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrSecret)
+
+	assert.True(t, result)
 }
 
 type certRepoStub struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Since the CreationTimestamp will always be older, because the Secret is not deleted as renewal mechanism in comparison to the CNCF cert-manager related implementation, the requires renewal check needs to compare from requestedAt annotation from gardener

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
