### PR TITLE
chore: Bump RT watcher to 2.0.3; KLM in sec-scanners to 1.7.0

### DIFF
--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=2.0.2
+        value: --skr-watcher-image-tag=2.0.3
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -8,7 +8,7 @@ checkmarx-one:
     - "**/testutils/**"
     - "tests/**"
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.6.0
+  - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.7.0
   - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:latest
 mend:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump RT watcher to 2.0.3
- Bump KLM in sec-scanners to 1.7.0

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
