### PR TITLE
fix: Removes deletion timestamp check from error handling

### DIFF
--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -550,7 +550,7 @@ func (r *Reconciler) finishReconcile(ctx context.Context, manifest *v1beta2.Mani
 		return ctrl.Result{}, err
 	}
 	switch {
-	case util.IsConnectionRelatedError(originalErr) && !manifest.GetDeletionTimestamp().IsZero():
+	case util.IsConnectionRelatedError(originalErr):
 		r.evictSKRClientCache(ctx, manifest)
 		r.ManifestMetrics.RecordRequeueReason(metrics.ManifestUnauthorized, queue.UnexpectedRequeue)
 		return ctrl.Result{}, originalErr


### PR DESCRIPTION
Evicts client cache and records requeue reason for all
connection-related errors, regardless of deletion timestamp.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Evict cache should not limited to deleted Manifest, because skr secret also rotated, so the normal manifest connection error should trigger cache evicting as well 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
