### PR TITLE
chore: Replace flaky `CheckPodLogs` with `DeploymentIsReady` for detect SKR watcher deployment

### DIFF
--- a/tests/e2e/skr_secret_rotation_test.go
+++ b/tests/e2e/skr_secret_rotation_test.go
@@ -3,9 +3,6 @@ package e2e_test
 import (
 	"os"
 	"os/exec"
-	"time"
-
-	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
@@ -70,11 +67,10 @@ var _ = Describe("SKR client cache get evicted due to connection error caused by
 				WithArguments(RemoteNamespace, []v1beta2.Module{}, skrClient, shared.StateReady).
 				Should(Succeed())
 			By("And the Runtime Watcher deployment on SKR is up and running", func() {
-				Eventually(CheckPodLogs).
+				Eventually(DeploymentIsReady).
 					WithContext(ctx).
-					WithArguments(RemoteNamespace, skrwebhookresources.SkrResourceName, "server",
-						"Starting server for validation endpoint", skrRESTConfig,
-						skrClient, &apimetav1.Time{Time: time.Now().Add(-5 * time.Minute)}).
+					WithArguments(skrClient, skrwebhookresources.SkrResourceName,
+						RemoteNamespace).
 					Should(Succeed())
 			})
 		})

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -66,11 +66,10 @@ func InitEmptyKymaBeforeAll(kyma *v1beta2.Kyma) {
 			WithArguments(RemoteNamespace, []v1beta2.Module{}, skrClient, shared.StateReady).
 			Should(Succeed())
 		By("And Runtime Watcher deployment is up and running in SKR", func() {
-			Eventually(CheckPodLogs).
+			Eventually(DeploymentIsReady).
 				WithContext(ctx).
-				WithArguments(RemoteNamespace, skrwebhookresources.SkrResourceName, "server",
-					"Starting server for validation endpoint", skrRESTConfig,
-					skrClient, &apimetav1.Time{Time: time.Now().Add(-5 * time.Minute)}).
+				WithArguments(skrClient, skrwebhookresources.SkrResourceName,
+					RemoteNamespace).
 				Should(Succeed())
 		})
 	})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The `CheckPodLogs` is not reliable. If the test runs for a longer time, the expected log message can't be fetched, changed to a more stable check to verify skr-webhook readiness by `DeploymentIsReady`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
