### PR TITLE
chore: Bump controller-runtime to 0.22.2

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.34.1
-	sigs.k8s.io/controller-runtime v0.21.0
+	sigs.k8s.io/controller-runtime v0.22.2
 )
 
 require github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -41,7 +41,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.34.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/client-go v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,7 @@
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -62,6 +64,14 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
+github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
+github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
+github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
+github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
+github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
+github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
@@ -148,8 +158,8 @@ k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOP
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
-sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
+sigs.k8s.io/controller-runtime v0.22.2 h1:cK2l8BGWsSWkXz09tcS4rJh95iOLney5eawcK5A33r4=
+sigs.k8s.io/controller-runtime v0.22.2/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	golang.org/x/time v0.13.0
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	ocm.software/ocm v0.29.1
-	sigs.k8s.io/controller-runtime v0.21.0
+	sigs.k8s.io/controller-runtime v0.22.2
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2670,8 +2670,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
-sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
+sigs.k8s.io/controller-runtime v0.22.2 h1:cK2l8BGWsSWkXz09tcS4rJh95iOLney5eawcK5A33r4=
+sigs.k8s.io/controller-runtime v0.22.2/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=
 sigs.k8s.io/gateway-api v1.3.0/go.mod h1:d8NV8nJbaRbEKem+5IuxkL8gJGOZ+FJ+NvOIltV8gDk=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/internal/remote/modulereleasemeta_syncer_test.go
+++ b/internal/remote/modulereleasemeta_syncer_test.go
@@ -35,6 +35,7 @@ func TestModuleReleaseMetaSyncer_SyncToSKR_happypath(t *testing.T) { //nolint:du
 	skrClient := fake.NewClientBuilder().
 		WithObjects(&mrmSKR2, &mrmSKR3, &mrmSKR4).
 		WithScheme(scheme).
+		WithReturnManagedFields().
 		Build()
 
 	onSyncConcurrentlyFn := func(_ context.Context, kcpModules []v1beta2.ModuleReleaseMeta) {
@@ -95,6 +96,7 @@ func TestModuleReleaseMetaSyncer_SyncToSKR_nilList(t *testing.T) {
 	skrClient := fake.NewClientBuilder().
 		WithObjects(&mtSKR2, &mtSKR3, &mtSKR4).
 		WithScheme(scheme).
+		WithReturnManagedFields().
 		Build()
 
 	// onSyncConcurrentlyFn "pretends" to be the moduleReleaseMetaConcurrentWorker.SyncConcurrently
@@ -149,7 +151,10 @@ func moduleReleaseMeta(name, namespace string) v1beta2.ModuleReleaseMeta {
 			Namespace: namespace,
 			ManagedFields: []apimetav1.ManagedFieldsEntry{
 				{
-					Manager: moduleCatalogSyncFieldManager,
+					Manager:    moduleCatalogSyncFieldManager,
+					Operation:  apimetav1.ManagedFieldsOperationApply,
+					APIVersion: v1beta2.GroupVersion.String(),
+					FieldsType: "FieldsV1",
 				},
 			},
 		},

--- a/internal/remote/moduletemplate_syncer_test.go
+++ b/internal/remote/moduletemplate_syncer_test.go
@@ -32,6 +32,7 @@ func TestSyncer_SyncToSKR_happypath(t *testing.T) { //nolint:dupl,revive // dupl
 	skrClient := fake.NewClientBuilder().
 		WithObjects(&mtSKR2, &mtSKR3, &mtSKR4).
 		WithScheme(scheme).
+		WithReturnManagedFields().
 		Build()
 
 	onSyncConcurrentlyFn := func(_ context.Context, kcpModules []v1beta2.ModuleTemplate) {
@@ -92,6 +93,7 @@ func TestSyncer_SyncToSKR_nilList(t *testing.T) {
 	skrClient := fake.NewClientBuilder().
 		WithObjects(&mtSKR2, &mtSKR3, &mtSKR4).
 		WithScheme(scheme).
+		WithReturnManagedFields().
 		Build()
 
 	// onSyncConcurrentlyFn "pretends" to be the moduleTemplateConcurrentWorker.SyncConcurrently
@@ -146,7 +148,10 @@ func moduleTemplate(name, namespace string) v1beta2.ModuleTemplate {
 			Namespace: namespace,
 			ManagedFields: []apimetav1.ManagedFieldsEntry{
 				{
-					Manager: moduleCatalogSyncFieldManager,
+					Manager:    moduleCatalogSyncFieldManager,
+					Operation:  apimetav1.ManagedFieldsOperationApply,
+					APIVersion: v1beta2.GroupVersion.String(),
+					FieldsType: "FieldsV1",
 				},
 			},
 		},

--- a/internal/service/skrclient/client_proxy.go
+++ b/internal/service/skrclient/client_proxy.go
@@ -159,9 +159,9 @@ func (p *ProxyClient) List(ctx context.Context, obj client.ObjectList, opts ...c
 	return nil
 }
 
-// Apply implements client.Apply
-// Will be implemented in https://github.com/kyma-project/lifecycle-manager/issues/2707
-func (p *ProxyClient) Apply(ctx context.Context, applyConfig machineryruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
+// NOT IMPLEMENTED YET.
+// Returns error implemented in https://github.com/kyma-project/lifecycle-manager/issues/2707.
+func (_ *ProxyClient) Apply(_ context.Context, _ machineryruntime.ApplyConfiguration, _ ...client.ApplyOption) error {
 	return ErrNotImplemented
 }
 

--- a/internal/service/skrclient/client_proxy.go
+++ b/internal/service/skrclient/client_proxy.go
@@ -161,7 +161,7 @@ func (p *ProxyClient) List(ctx context.Context, obj client.ObjectList, opts ...c
 
 // NOT IMPLEMENTED YET.
 // Returns error implemented in https://github.com/kyma-project/lifecycle-manager/issues/2707.
-func (_ *ProxyClient) Apply(_ context.Context, _ machineryruntime.ApplyConfiguration, _ ...client.ApplyOption) error {
+func (p *ProxyClient) Apply(_ context.Context, _ machineryruntime.ApplyConfiguration, _ ...client.ApplyOption) error {
 	return ErrNotImplemented
 }
 

--- a/internal/service/skrclient/client_proxy.go
+++ b/internal/service/skrclient/client_proxy.go
@@ -14,6 +14,8 @@ import (
 // Checking compliance with the interface methods implemented below.
 var _ client.Client = &SKRClient{}
 
+var NotImplementedError = fmt.Errorf("not implemented")
+
 // ProxyClient holds information required to proxy Client requests to verify RESTMapper integrity.
 // During the proxy, the underlying mapper verifies mapping for the calling resource.
 // If not available and NoMatchesKind error occurs, the mappings are reset (if type meta.ResettableRESTMapper).
@@ -154,6 +156,12 @@ func (p *ProxyClient) List(ctx context.Context, obj client.ObjectList, opts ...c
 		return fmt.Errorf("failed to fetch object for [%v]: %w", obj, err)
 	}
 	return nil
+}
+
+// Apply implements client.Apply
+// Will be implemented in https://github.com/kyma-project/lifecycle-manager/issues/2707
+func (p *ProxyClient) Apply(ctx context.Context, applyConfig machineryruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	return NotImplementedError
 }
 
 // Status implements client.StatusClient.

--- a/internal/service/skrclient/client_proxy.go
+++ b/internal/service/skrclient/client_proxy.go
@@ -2,6 +2,7 @@ package skrclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -14,7 +15,7 @@ import (
 // Checking compliance with the interface methods implemented below.
 var _ client.Client = &SKRClient{}
 
-var ErrNotImplemented = fmt.Errorf("not implemented")
+var ErrNotImplemented = errors.New("not implemented")
 
 // ProxyClient holds information required to proxy Client requests to verify RESTMapper integrity.
 // During the proxy, the underlying mapper verifies mapping for the calling resource.

--- a/internal/service/skrclient/client_proxy.go
+++ b/internal/service/skrclient/client_proxy.go
@@ -14,7 +14,7 @@ import (
 // Checking compliance with the interface methods implemented below.
 var _ client.Client = &SKRClient{}
 
-var NotImplementedError = fmt.Errorf("not implemented")
+var ErrNotImplemented = fmt.Errorf("not implemented")
 
 // ProxyClient holds information required to proxy Client requests to verify RESTMapper integrity.
 // During the proxy, the underlying mapper verifies mapping for the calling resource.
@@ -161,7 +161,7 @@ func (p *ProxyClient) List(ctx context.Context, obj client.ObjectList, opts ...c
 // Apply implements client.Apply
 // Will be implemented in https://github.com/kyma-project/lifecycle-manager/issues/2707
 func (p *ProxyClient) Apply(ctx context.Context, applyConfig machineryruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
-	return NotImplementedError
+	return ErrNotImplemented
 }
 
 // Status implements client.StatusClient.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bumps controller-runtime to `0.22.2`
  - I made a mistake and earlier ignored the whole `0.22` minor https://github.com/kyma-project/lifecycle-manager/pull/2705#issuecomment-3247951247
- with `0.22.0` the new `client.Client.Apply` was introduced and `client.Apply` was deprecated. The deprecation of `client.Apply` was reverted in `0.22.1` as the support for `client.Client.Apply` was incomplete (missing sub-resource writer). Once the full support for `client.Client.Apply` is there and the actual deprecation of `client.Apply` happens, we must make code changes as described in this ticket https://github.com/kyma-project/lifecycle-manager/issues/2707
- we still have the problem with our `ClientProxy`
  - as of now, we expect it to implement the new `Apply` method. However, the signature does not include a `client.Object` which we need to call the `getResourceMapping`. I don't have a good understanding of `getResourceMapping` but my understanding is that we call this to ensure that we can call the object's API which may require a refresh (reset), e.g., when a new CRD has been introduced. I don't know yet how we can solve this and we should investigate that more thoroughly as part of the ticket linked above. To make the code compile, I created a dummy implementation returning a NotImplementedError.



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
