### PR TITLE
chore: Use dummy placeholder for skr-wbhook/resources image

### DIFF
--- a/skr-webhook/resources.yaml
+++ b/skr-webhook/resources.yaml
@@ -73,7 +73,7 @@ spec:
               value: "v2"
             - name: KCP_ADDR
               value: "kcp-base-url-invalid"
-          image: "europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:latest" # this image will be dynamically replaced by flags
+          image: "<please/replace:me>" # this image will be dynamically replaced by flags
           imagePullPolicy: Always
           volumeMounts:
             - name: ssl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- the image defined there is never actually used and always overwritten by a flag on KLM
- to make this more prominent, using a dummy value

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- resolves https://github.com/kyma-project/lifecycle-manager/issues/1951