### PR TITLE
chore: Use Go 1.25.3

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/api
 
-go 1.25.1
+go 1.25.3
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager
 
-go 1.25.1
+go 1.25.3
 
 replace (
 	github.com/kyma-project/lifecycle-manager/api => ./api

--- a/maintenancewindows/go.mod
+++ b/maintenancewindows/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/maintenancewindows
 
-go 1.25.1
+go 1.25.3
 
 require github.com/stretchr/testify v1.11.1
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ certManager: "1.18.1"
 gardenerCertManager: "0.18.0"
 controllerTools: "0.18.0"
 docker: "27.5.1"
-go: "1.25.1"
+go: "1.25.3"
 golangciLint: "2.4.0"
 istio: "1.26.4" # https://github.com/kyma-project/lifecycle-manager/issues/2797
 k3d: "5.8.3"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Using Go 1.25.3 as 1.25.1 has a CVE
- builder in Dockerfile was already bumped to 1.25.3 earlier

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
