### PR TITLE
refactor: Remove Execution Time From SSA Failed Error Logging

### DIFF
--- a/internal/manifest/skrresources/ssa.go
+++ b/internal/manifest/skrresources/ssa.go
@@ -85,7 +85,6 @@ func (c *ConcurrentDefaultSSA) Run(ctx context.Context, resources []*resource.In
 		errs = append(errs, ErrModuleResourcesSSAFailed)
 		return errors.Join(errs...)
 	}
-	logger.V(internal.DebugLogLevel).Info("ServerSideApply finished")
 	if err := c.collector.Emit(ctx); err != nil {
 		logger.V(internal.DebugLogLevel).Error(err, "error emitting data of unknown field managers")
 	}

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -78,7 +78,6 @@ func (r *Runner) ReconcileManifests(ctx context.Context, kyma *v1beta2.Kyma,
 		errs = append(errs, fmt.Errorf("%w for Kyma %s", ErrManifestSSAFailed, kyma.GetName()))
 		return errors.Join(errs...)
 	}
-	baseLogger.V(log.DebugLevel).Info("ServerSideApply finished")
 	return nil
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- in runner.go, refactor `ErrServerSideApplyFailed` to `ErrManifestSSAFailed`
  - when returning this error, execution time is not appended to string
- in sync.go, refactor `ErrServerSideApplyFailed` to `ErrModuleResourcesSSAFailed`
  - when returning this error, execution time is not appended to string

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #2843 