### PR TITLE
fix: Support gzip compressed OCI artifacts application/x-tgz

### DIFF
--- a/internal/manifest/img/parse.go
+++ b/internal/manifest/img/parse.go
@@ -110,7 +110,7 @@ func getOCIRef(
 	accessSpec *localblob.AccessSpec,
 ) (*OCI, error) {
 	layerRef := OCI{}
-	if accessSpec.MediaType == mime.MIME_TAR {
+	if accessSpec.MediaType == mime.MIME_TAR || accessSpec.MediaType == mime.MIME_TGZ {
 		layerRef.Type = string(v1beta2.OciDirType)
 	} else {
 		layerRef.Type = string(v1beta2.OciRefType)

--- a/internal/manifest/img/parse_test.go
+++ b/internal/manifest/img/parse_test.go
@@ -36,6 +36,19 @@ func TestParse(t *testing.T) {
 				},
 			},
 		}, {
+			"should parse raw-manifest layer from mediaType: application/x-tgz",
+			"v1beta2_template_operator_tgz_format.yaml",
+			"1.0.0-tgz-format",
+			img.Layer{
+				LayerName: "raw-manifest",
+				LayerRepresentation: &img.OCI{
+					Repo: "europe-west3-docker.pkg.dev/sap-kyma-jellyfish-dev/template-operator/component-descriptors",
+					Name: testutils.DefaultFQDN,
+					Ref:  "sha256:d2cc278224a71384b04963a83e784da311a268a2b3fa8732bc31e70ca0c5bc52",
+					Type: "oci-dir",
+				},
+			},
+		}, {
 			"should parse raw-manifest layer from mediaType: application/octet-stream",
 			"v1beta2_template_operator_current_ocm.yaml",
 			"1.1.1-e2e-test",

--- a/tests/integration/moduletemplate/v1beta2_template_operator_tgz_format.yaml
+++ b/tests/integration/moduletemplate/v1beta2_template_operator_tgz_format.yaml
@@ -1,0 +1,82 @@
+apiVersion: operator.kyma-project.io/v1beta2
+kind: ModuleTemplate
+metadata:
+  name: template-operator-regular
+  namespace: kcp-system
+  annotations:
+    "operator.kyma-project.io/is-cluster-scoped": "false"
+    "operator.kyma-project.io/module-version": "1.0.0-tgz-format"
+spec:
+  channel: regular
+  mandatory: false
+  data:
+    apiVersion: operator.kyma-project.io/v1alpha1
+    kind: Sample
+    metadata:
+      name: sample-yaml
+    spec:
+      initKey: initValue
+      resourceFilePath: "./module-data/yaml"
+  descriptor:
+    component:
+      componentReferences: [ ]
+      creationTime: "2024-07-09T12:22:30Z"
+      name: kyma-project.io/module/template-operator
+      provider: kyma-project.io
+      repositoryContexts:
+        - baseUrl: europe-west3-docker.pkg.dev
+          componentNameMapping: urlPath
+          subPath: sap-kyma-jellyfish-dev/template-operator
+          type: OCIRegistry
+      resources:
+        - access:
+            imageReference: europe-docker.pkg.dev/kyma-project/prod/template-operator:1.0.0
+            type: ociArtifact
+          digest:
+            hashAlgorithm: SHA-256
+            normalisationAlgorithm: ociArtifactDigest/v1
+            value: 03a194e1dca2421755cec5ec1e946de744407e6e1ca3b671f715fee939e8d1fb
+          name: module-image
+          relation: external
+          type: ociArtifact
+          version: 1.0.0
+        - access:
+            localReference: sha256:d2cc278224a71384b04963a83e784da311a268a2b3fa8732bc31e70ca0c5bc52
+            mediaType: application/x-tgz
+            type: localBlob
+          digest:
+            hashAlgorithm: SHA-256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: d2cc278224a71384b04963a83e784da311a268a2b3fa8732bc31e70ca0c5bc52
+          name: raw-manifest
+          relation: local
+          type: directory
+          version: 1.0.0
+        - access:
+            localReference: sha256:9230471fa6a62ff7b1549e8d0e9ccb545896fabadf82d2ec4503fc798d2bcd8a
+            mediaType: application/x-tar
+            type: localBlob
+          digest:
+            hashAlgorithm: SHA-256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: 9230471fa6a62ff7b1549e8d0e9ccb545896fabadf82d2ec4503fc798d2bcd8a
+          name: default-cr
+          relation: local
+          type: directory
+          version: 1.0.0
+        - access:
+            localReference: sha256:b46281580f6377bf10672b5a8f156d183d47c0ec3bcda8b807bd8c5d520884bd
+            mediaType: application/octet-stream
+            type: localBlob
+          digest:
+            hashAlgorithm: SHA-256
+            normalisationAlgorithm: genericBlobDigest/v1
+            value: b46281580f6377bf10672b5a8f156d183d47c0ec3bcda8b807bd8c5d520884bd
+          name: associated-resources
+          relation: local
+          type: plainText
+          version: 1.0.0
+      sources: [ ]
+      version: 1.0.0-tgz-format
+    meta:
+      schemaVersion: v2


### PR DESCRIPTION
**Description**
This PR adds support for gzip-compressed OCI artifacts in lifecycle-manager, enabling compatibility with modulectl 2.x + OCM CLI workflow.


**Changes proposed in this pull request:**

- **pathextractor.go**: Added automatic gzip detection and decompression when reading tar files from disk.
- **parse.go** Extended mediaType recognition to support both `application/x-tar` and `application/x-tgz.

https://github.com/kyma-project/modulectl/blob/f92adedb9b1df138a5825a4ff5f4a933a2d94ec0/internal/common/types/component/constructor.go#L188

**Related issue(s)**
https://github.com/kyma-project/modulectl/issues/287