### PR TITLE
fix: Secret Repo Exists properly handles NotFound error

### DIFF
--- a/internal/repository/secret/secret_repo.go
+++ b/internal/repository/secret/secret_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kyma-project/lifecycle-manager/pkg/util"
 	apicorev1 "k8s.io/api/core/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,8 +34,12 @@ func (r *Repository) Get(ctx context.Context, name string) (*apicorev1.Secret, e
 }
 
 func (r *Repository) Exists(ctx context.Context, name string) (bool, error) {
-	secret, err := r.Get(ctx, name)
-	return secret != nil && secret.GetName() != "", err
+	_, err := r.Get(ctx, name)
+
+	// not found error => (false, nil)
+	// other error => (true, err)
+	// no error => (true, nil)
+	return !util.IsNotFound(err), client.IgnoreNotFound(err)
 }
 
 func (r *Repository) List(ctx context.Context, labelSelector k8slabels.Selector) (*apicorev1.SecretList, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- the handling of the return value in the exists check was faulty. Actually, the client returns a NotFound error when the object is gone. Updating the repo to handling it correctly.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
