### PR TITLE
docs: Replace a relative link in ModuleTemplate CR documentation

### DIFF
--- a/docs/contributor/resources/03-moduletemplate.md
+++ b/docs/contributor/resources/03-moduletemplate.md
@@ -151,7 +151,7 @@ In this scenario, the `Ready` state will only be reached if both `module.state.f
 
 The core of any ModuleTemplate CR, the descriptor can be one of the schemas mentioned in the latest version of the [OCM Model Specification](https://github.com/open-component-model/ocm-spec/blob/7bfbc171e814e73d6e95cfa07cc85813f89a1d44/doc/01-model/01-model.md#components-and-component-versions). While it is a `runtime.RawExtension` in the Go types, it will be resolved via ValidatingWebhook into an internal descriptor with the help of the official [OCM library](https://github.com/open-component-model/ocm).
 
-For more information on how to create ModuleTemplates with component descriptors using modulectl and OCM CLI, see [Creating ModuleTemplates](../14-creating-moduletemplate.md).
+For more information on how to create ModuleTemplates with component descriptors using modulectl and OCM CLI, see [Creating ModuleTemplates](https://github.com/kyma-project/lifecycle-manager/blob/main/docs/contributor/14-creating-moduletemplate.md).
 
 ### **.spec.mandatory**
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Replaced a relative link in ModuleTemplate CR documentation. The Creating ModuleTemplate with modulectl and OCM CLI document as not part of the NS2. Using a releative path when inking to it from the ModuleManifest CR documentation makes the link broken in Help Portal.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
