### PR TITLE
chore(KymaDeletion): Exists check on SKR access secret by label

### DIFF
--- a/internal/repository/secret/secret_repo.go
+++ b/internal/repository/secret/secret_repo.go
@@ -8,6 +8,7 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
@@ -34,8 +35,17 @@ func (r *Repository) Get(ctx context.Context, name string) (*apicorev1.Secret, e
 	return secret, nil
 }
 
-func (r *Repository) Exists(ctx context.Context, name string) (bool, error) {
-	_, err := r.Get(ctx, name)
+func (r *Repository) ExistsForKyma(ctx context.Context, kymaName string) (bool, error) {
+	secrets, err := r.List(ctx, k8slabels.SelectorFromSet(k8slabels.Set{shared.KymaName: kymaName}))
+	if err != nil {
+		return false, err
+	}
+
+	return len(secrets.Items) > 0, nil
+}
+
+func (r *Repository) Exists(ctx context.Context, secretName string) (bool, error) {
+	_, err := r.Get(ctx, secretName)
 
 	// not found error => (false, nil)
 	// other error => (true, err)

--- a/internal/repository/secret/secret_repo_exists_for_kyma_test.go
+++ b/internal/repository/secret/secret_repo_exists_for_kyma_test.go
@@ -1,0 +1,83 @@
+package secret_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apicorev1 "k8s.io/api/core/v1"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	secretrepo "github.com/kyma-project/lifecycle-manager/internal/repository/secret"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
+)
+
+func TestExistsForKyma_ClientCallSucceeds_ReturnsExists(t *testing.T) {
+	kymaName := random.Name()
+	repoNamespace := random.Name()
+	selector := k8slabels.SelectorFromSet(k8slabels.Set{shared.KymaName: kymaName})
+
+	clientStub := &listClientStub{
+		list: &apicorev1.SecretList{
+			Items: []apicorev1.Secret{
+				{
+					ObjectMeta: apimetav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+		},
+	}
+	secretRepository := secretrepo.NewRepository(clientStub, repoNamespace)
+
+	result, err := secretRepository.ExistsForKyma(t.Context(), kymaName)
+
+	require.NoError(t, err)
+	assert.True(t, result)
+	assert.True(t, clientStub.called)
+	assert.Equal(t, repoNamespace, clientStub.lastNamespace)
+	assert.Equal(t, selector, clientStub.lastSelector)
+}
+
+func TestExistsForKyma_ClientCallSucceeds_ReturnsNotExists(t *testing.T) {
+	kymaName := random.Name()
+	repoNamespace := random.Name()
+	selector := k8slabels.SelectorFromSet(k8slabels.Set{shared.KymaName: kymaName})
+
+	clientStub := &listClientStub{
+		list: &apicorev1.SecretList{
+			Items: []apicorev1.Secret{},
+		},
+	}
+	secretRepository := secretrepo.NewRepository(clientStub, repoNamespace)
+
+	result, err := secretRepository.ExistsForKyma(t.Context(), kymaName)
+
+	require.NoError(t, err)
+	assert.False(t, result)
+	assert.True(t, clientStub.called)
+	assert.Equal(t, repoNamespace, clientStub.lastNamespace)
+	assert.Equal(t, selector, clientStub.lastSelector)
+}
+
+func TestExistsForKyma_ClientReturnsAnError_ReturnsError(t *testing.T) {
+	kymaName := random.Name()
+	repoNamespace := random.Name()
+	selector := k8slabels.SelectorFromSet(k8slabels.Set{shared.KymaName: kymaName})
+
+	clientStub := &listClientStub{
+		err: assert.AnError,
+	}
+	secretRepository := secretrepo.NewRepository(clientStub, repoNamespace)
+
+	result, err := secretRepository.ExistsForKyma(t.Context(), kymaName)
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, result)
+	assert.True(t, clientStub.called)
+	assert.Equal(t, repoNamespace, clientStub.lastNamespace)
+	assert.Equal(t, selector, clientStub.lastSelector)
+}

--- a/internal/repository/secret/secret_repo_exists_test.go
+++ b/internal/repository/secret/secret_repo_exists_test.go
@@ -15,9 +15,6 @@ import (
 )
 
 func TestExists_ClientCallSucceeds_ReturnsExists(t *testing.T) {
-	kymaName := random.Name()
-	repoNamespace := random.Name()
-
 	clientStub := &getClientStub{
 		object: &apicorev1.Secret{
 			ObjectMeta: apimetav1.ObjectMeta{
@@ -26,34 +23,31 @@ func TestExists_ClientCallSucceeds_ReturnsExists(t *testing.T) {
 			},
 		},
 	}
-	secretRepository := secretrepo.NewRepository(clientStub, repoNamespace)
+	secretRepository := secretrepo.NewRepository(clientStub, namespace)
 
-	result, err := secretRepository.Exists(t.Context(), kymaName)
+	result, err := secretRepository.Exists(t.Context(), secretName)
 
 	require.NoError(t, err)
 	assert.True(t, result)
 	assert.True(t, clientStub.called)
 	assert.Equal(t,
-		client.ObjectKey{Name: kymaName, Namespace: repoNamespace},
+		client.ObjectKey{Name: secretName, Namespace: namespace},
 		clientStub.key)
 }
 
 func TestExists_ClientCallFailsWithNotFound_ReturnsNotExists(t *testing.T) {
-	kymaName := random.Name()
-	repoNamespace := random.Name()
-
 	clientStub := &getClientStub{
-		err: apierrors.NewNotFound(apicorev1.Resource("secrets"), kymaName),
+		err: apierrors.NewNotFound(apicorev1.Resource("secrets"), secretName),
 	}
-	secretRepository := secretrepo.NewRepository(clientStub, repoNamespace)
+	secretRepository := secretrepo.NewRepository(clientStub, namespace)
 
-	result, err := secretRepository.Exists(t.Context(), kymaName)
+	result, err := secretRepository.Exists(t.Context(), secretName)
 
 	require.NoError(t, err)
 	assert.False(t, result)
 	assert.True(t, clientStub.called)
 	assert.Equal(t,
-		client.ObjectKey{Name: kymaName, Namespace: repoNamespace},
+		client.ObjectKey{Name: secretName, Namespace: namespace},
 		clientStub.key)
 }
 

--- a/internal/repository/secret/secret_repo_test.go
+++ b/internal/repository/secret/secret_repo_test.go
@@ -54,6 +54,8 @@ func TestList_ClientCallSucceeds_ReturnsSecrets(t *testing.T) {
 type listClientStub struct {
 	client.Client
 
+	err error
+
 	called        bool
 	list          *apicorev1.SecretList
 	lastSelector  k8slabels.Selector
@@ -75,6 +77,10 @@ func (c *listClientStub) List(_ context.Context, obj client.ObjectList, opts ...
 			}
 		}
 	}
-	c.list.DeepCopyInto(obj.(*apicorev1.SecretList))
-	return nil
+
+	if c.list != nil {
+		c.list.DeepCopyInto(obj.(*apicorev1.SecretList))
+	}
+
+	return c.err
 }

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd.go
@@ -31,7 +31,7 @@ func (u *DeleteSkrCrd) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma) 
 		return false, nil
 	}
 
-	if exists, err := u.skrAccessSecretRepo.Exists(ctx, kcpKyma.GetName()); !exists || err != nil {
+	if exists, err := u.skrAccessSecretRepo.ExistsForKyma(ctx, kcpKyma.GetName()); !exists || err != nil {
 		return false, err
 	}
 

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
@@ -62,6 +62,29 @@ func TestDeleteSkrCrd_IsApplicable_False_SecretDoesNotExist(t *testing.T) {
 	assert.Equal(t, kcpKyma.GetName(), skrAccessSecretRepo.kymaName)
 }
 
+func TestDeleteSkrCrd_IsApplicable_False_SecretRepoReturnsError(t *testing.T) {
+	kcpKyma := &v1beta2.Kyma{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:              random.Name(),
+			Namespace:         random.Name(),
+			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
+		},
+	}
+
+	skrAccessSecretRepo := &skrAccessSecretRepoStub{
+		err: assert.AnError,
+	}
+
+	uc := usecases.NewDeleteSkrCrd(nil, skrAccessSecretRepo, result.UseCase(random.Name()))
+
+	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, applicable)
+	assert.True(t, skrAccessSecretRepo.called)
+	assert.Equal(t, kcpKyma.GetName(), skrAccessSecretRepo.kymaName)
+}
+
 func TestDeleteSkrCrd_IsApplicable_True_CrdExists(t *testing.T) {
 	kcpKyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
@@ -29,7 +29,7 @@ func (u *DeleteSkrKyma) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma)
 		return false, nil
 	}
 
-	if exists, err := u.skrAccessSecretRepo.Exists(ctx, kcpKyma.GetName()); !exists || err != nil {
+	if exists, err := u.skrAccessSecretRepo.ExistsForKyma(ctx, kcpKyma.GetName()); !exists || err != nil {
 		return false, err
 	}
 

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
@@ -36,7 +36,7 @@ func (u *SetSkrKymaStateDeleting) IsApplicable(ctx context.Context, kcpKyma *v1b
 		return false, nil
 	}
 
-	if exists, err := u.skrAccessSecretRepo.Exists(ctx, kcpKyma.GetName()); !exists || err != nil {
+	if exists, err := u.skrAccessSecretRepo.ExistsForKyma(ctx, kcpKyma.GetName()); !exists || err != nil {
 		return false, err
 	}
 

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
@@ -81,7 +81,7 @@ func TestIsApplicable_False_DeletionTimestampNotSet(t *testing.T) {
 }
 
 func TestIsApplicable_False_SecretDoesNotExist(t *testing.T) {
-	kyma := &v1beta2.Kyma{
+	kcpKyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:              random.Name(),
 			Namespace:         random.Name(),
@@ -95,16 +95,16 @@ func TestIsApplicable_False_SecretDoesNotExist(t *testing.T) {
 
 	uc := usecases.NewSetSkrKymaStateDeleting(nil, skrAccessSecretRepo)
 
-	applicable, err := uc.IsApplicable(t.Context(), kyma)
+	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
 
 	require.NoError(t, err)
 	assert.False(t, applicable)
 	assert.True(t, skrAccessSecretRepo.called)
-	assert.Equal(t, kyma.GetName(), skrAccessSecretRepo.kymaName)
+	assert.Equal(t, kcpKyma.GetName(), skrAccessSecretRepo.kymaName)
 }
 
 func TestIsApplicable_False_SecretRepoReturnsError(t *testing.T) {
-	kyma := &v1beta2.Kyma{
+	kcpKyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:              random.Name(),
 			Namespace:         random.Name(),
@@ -118,12 +118,12 @@ func TestIsApplicable_False_SecretRepoReturnsError(t *testing.T) {
 
 	uc := usecases.NewSetSkrKymaStateDeleting(nil, skrAccessSecretRepo)
 
-	applicable, err := uc.IsApplicable(t.Context(), kyma)
+	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
 
 	require.ErrorIs(t, err, assert.AnError)
 	assert.False(t, applicable)
 	assert.True(t, skrAccessSecretRepo.called)
-	assert.Equal(t, kyma.GetName(), skrAccessSecretRepo.kymaName)
+	assert.Equal(t, kcpKyma.GetName(), skrAccessSecretRepo.kymaName)
 }
 
 func TestIsApplicable_False_KymaAlreadyInDeletingState(t *testing.T) {

--- a/internal/service/kyma/deletion/usecases/types.go
+++ b/internal/service/kyma/deletion/usecases/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SkrAccessSecretRepo interface {
-	Exists(ctx context.Context, name string) (bool, error)
+	ExistsForKyma(ctx context.Context, kymaName string) (bool, error)
 }
 
 type ExistsDeleteRepo interface {

--- a/internal/service/kyma/deletion/usecases/types_test.go
+++ b/internal/service/kyma/deletion/usecases/types_test.go
@@ -15,7 +15,7 @@ type skrAccessSecretRepoStub struct {
 	err      error
 }
 
-func (r *skrAccessSecretRepoStub) Exists(_ context.Context, kymaName string) (bool, error) {
+func (r *skrAccessSecretRepoStub) ExistsForKyma(_ context.Context, kymaName string) (bool, error) {
 	r.called = true
 	r.kymaName = kymaName
 	return r.exists, r.err


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- the Exists check of the SKR kubeconfig access secret was done by name where it was assumed that secretName == kymaName == runtimeId
- this was true for our test environments, but not the live landscapes where secretName is `kubeconfig-<runtimeId>`
- fixes this by adding a dedicated func `ExistsForKyma` that is looking up the secret based on a kyma-name label selector
- the original Exists check is still there because we need it for other checks

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
