### PR TITLE
chore: Bump runtime-watcher version

### DIFF
--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value: --skr-watcher-path=/skr-webhook
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=2.0.9
+        value: --skr-watcher-image-tag=2.1.0
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the `runtime-watcher` image version to `2.1.0`

**Related issue(s)**

https://github.com/kyma-project/runtime-watcher/issues/549