### PR TITLE
fix: GH Code Scan: Set release workflows jobs to least privilege permission

### DIFF
--- a/.github/workflows/create-release-api.yml
+++ b/.github/workflows/create-release-api.yml
@@ -6,10 +6,12 @@ on:
         description: "Semantic version to release (e.g. 1.2.3 or v1.2.3)"
         required: true
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   call-create-release:
+    permissions:
+      contents: write
     uses: ./.github/workflows/create-release-go-module.yml
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/create-release-go-module.yml
+++ b/.github/workflows/create-release-go-module.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   release-listener:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-maintenancewindows.yml
+++ b/.github/workflows/create-release-maintenancewindows.yml
@@ -6,10 +6,12 @@ on:
         description: "Semantic version to release (e.g. 1.2.3 or v1.2.3)"
         required: true
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   call-create-release:
+    permissions:
+      contents: write
     uses: ./.github/workflows/create-release-go-module.yml
     with:
       version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

See these Github Code Scanning results:
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/86
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/85
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/84
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/75
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/73
* https://github.com/kyma-project/lifecycle-manager/security/code-scanning/72

With this PR our interdependent release workflows are following security recommendation to start top-level permissions as restrictive as possible and set permissions to `write` only on job level.

* Related issue: #2645
