### PR TITLE
fix: GH Code Scan: Reference actions by SHA

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,7 +25,7 @@ jobs:
       tags: ${{ steps.get_custom_tags.outputs.tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Get tags
         id: get_custom_tags
         run: |

--- a/.github/workflows/check-api-compatibility.yml
+++ b/.github/workflows/check-api-compatibility.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install Dependencies
         run: |
           sudo snap install dyff

--- a/.github/workflows/check-test-changes.yml
+++ b/.github/workflows/check-test-changes.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Get list of changed files
         id: changed-files

--- a/.github/workflows/create-release-go-module.yml
+++ b/.github/workflows/create-release-go-module.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           path: lifecycle-manager

--- a/.github/workflows/create-release-klm.yml
+++ b/.github/workflows/create-release-klm.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Validate the release tag
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Create changelog
@@ -72,14 +72,14 @@ jobs:
       id-token: write
   publish_release:
     name: Publish release
-    needs: [validate-release, draft-release, builds]
+    needs: [ validate-release, draft-release, builds ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Wait for the Docker image

--- a/.github/workflows/lint-golangci.yml
+++ b/.github/workflows/lint-golangci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: lifecycle-manager
       - uses: actions/setup-go@v5

--- a/.github/workflows/lint-markdown-links.yml
+++ b/.github/workflows/lint-markdown-links.yml
@@ -13,7 +13,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       # Relates to version 1.0.15. Sha is used as this is this is the allow-listed value
       - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec
         with:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: lifecycle-manager
       - name: yaml-lint

--- a/.github/workflows/report-acceptance-criteria.yml
+++ b/.github/workflows/report-acceptance-criteria.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out LM source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Check out report highlighter
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/qa-toolkit
           path: scripts

--- a/.github/workflows/report-package-metrics.yml
+++ b/.github/workflows/report-package-metrics.yml
@@ -19,18 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: target
       - name: Check out the base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.base_ref }}
           path: base
       - name: Check out report scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/qa-toolkit
           path: scripts

--- a/.github/workflows/report-sprint-commits.yml
+++ b/.github/workflows/report-sprint-commits.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out report scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/qa-toolkit
           path: scripts

--- a/.github/workflows/test-e2e-with-gcm.yml
+++ b/.github/workflows/test-e2e-with-gcm.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Set Image
@@ -49,11 +49,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: lifecycle-manager
       - name: Checkout template-operator
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/template-operator
           path: template-operator

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
       - name: Set Image
@@ -88,11 +88,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: lifecycle-manager
       - name: Checkout template-operator
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/template-operator
           path: template-operator

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -14,7 +14,7 @@ jobs:
       GOSUMDB: sum.golang.org
     steps:
       - name: Checkout lifecycle-manager
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/verify-unit-test-coverage.yml
+++ b/.github/workflows/verify-unit-test-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out reporting tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: kyma-project/qa-toolkit
           path: scripts
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r $pip_requirements
       - name: Check out the sourcecode
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: codebase
       - name: Set up Go


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
According to the [GitHub Actions Security reference](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions), and when using third-party actions, it is recommended to pin the actions by full-length commit SHA. Also if the creator is trusted, it is still recommended.
This updates all references to the `actions/checkout`  to the latest release, but referenced by SHA.
Related code scanning alerts example: https://github.com/kyma-project/lifecycle-manager/security/code-scanning/92

**Related issue(s)**
* https://github.com/kyma-project/lifecycle-manager/issues/2645