### PR TITLE
junk: Expect missing client certificate on renewal

### DIFF
--- a/internal/service/watcher/certificate/certificate_service.go
+++ b/internal/service/watcher/certificate/certificate_service.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	ErrDomainAnnotationEmpty   = errors.New("domain annotation is empty")
-	ErrDomainAnnotationMissing = errors.New("domain annotation is missing")
+	ErrDomainAnnotationEmpty                = errors.New("domain annotation is empty")
+	ErrDomainAnnotationMissing              = errors.New("domain annotation is missing")
+	ErrWaitingForSkrCertificateToBeReIssued = errors.New("waiting for SKR certificate to be issued")
 )
 
 type RenewalService interface {
@@ -108,7 +109,7 @@ func (c *Service) RenewSkrCertificate(ctx context.Context, kymaName string) erro
 
 	skrCertificateSecret, err := c.secretRepo.Get(ctx, name.SkrCertificate(kymaName))
 	if err != nil {
-		return fmt.Errorf("failed to get SKR certificate secret: %w", err)
+		return errors.Join(ErrWaitingForSkrCertificateToBeReIssued, err)
 	}
 
 	if !c.renewalService.SkrSecretNeedsRenewal(gatewaySecret, skrCertificateSecret) {

--- a/pkg/watcher/skr_webhook_manifest_manager.go
+++ b/pkg/watcher/skr_webhook_manifest_manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
 	"github.com/kyma-project/lifecycle-manager/internal/remote"
+	"github.com/kyma-project/lifecycle-manager/internal/service/watcher/certificate"
 	"github.com/kyma-project/lifecycle-manager/internal/service/watcher/certificate/secret/data"
 	"github.com/kyma-project/lifecycle-manager/internal/service/watcher/chartreader"
 	skrwebhookresources "github.com/kyma-project/lifecycle-manager/internal/service/watcher/resources"
@@ -104,6 +105,9 @@ func (m *SkrWebhookManifestManager) Reconcile(ctx context.Context, kyma *v1beta2
 	m.writeCertificateRenewalMetrics(ctx, kyma.Name, logger)
 
 	if err = m.skrCertificateService.RenewSkrCertificate(ctx, kyma.Name); err != nil {
+		if errors.Is(err, certificate.ErrWaitingForSkrCertificateToBeReIssued) {
+			return err
+		}
 		return fmt.Errorf("failed to renew SKR certificate: %w", err)
 	}
 

--- a/scripts/tests/delete_certs.sh
+++ b/scripts/tests/delete_certs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Exporting the path to the kubeconfig file
+export KUBECONFIG=$HOME/.k3d/kcp-local.yaml
+
+for i in {1..100}; do
+  cat <<EOF | kubectl delete -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert-$i
+  namespace: istio-system
+spec:
+  commonName: test-cert-$i
+  subject:
+    organizationalUnits:
+      - "BTP Kyma Runtime"
+    organizations:
+      - "SAP SE"
+    localities:
+      - "Walldorf"
+    provinces:
+      - "Baden-Württemberg"
+    countries:
+      - "DE"
+  secretName: test-cert-$i
+  privateKey:
+    rotationPolicy: Always
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: klm-watcher-root
+    kind: Issuer
+    group: cert-manager.io
+  duration: 2160h # 90d
+  renewBefore: 1464h # 61d
+EOF
+
+  if [ $? -ne 0 ]; then
+    echo "[$(basename "$0")] Cert deployment failed for test-cert-$i"
+    exit 1
+  fi
+
+done
+
+echo "[$(basename "$0")] All certs deployed successfully"

--- a/scripts/tests/delete_secrets.sh
+++ b/scripts/tests/delete_secrets.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Exporting the path to the kubeconfig file
+export KUBECONFIG=$HOME/.k3d/kcp-local.yaml
+
+for i in {1..100}; do
+  cat <<EOF | kubectl delete -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cert-$i
+  namespace: istio-system
+EOF
+
+  if [ $? -ne 0 ]; then
+    echo "[$(basename "$0")] Cert deployment failed for test-cert-$i"
+    exit 1
+  fi
+
+done
+
+echo "[$(basename "$0")] All certs deployed successfully"

--- a/scripts/tests/deploy_certs.sh
+++ b/scripts/tests/deploy_certs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Exporting the path to the kubeconfig file
+export KUBECONFIG=$HOME/.k3d/kcp-local.yaml
+
+for i in {1..100}; do
+  cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert-$i
+  namespace: istio-system
+spec:
+  commonName: test-cert-$i
+  subject:
+    organizationalUnits:
+      - "BTP Kyma Runtime"
+    organizations:
+      - "SAP SE"
+    localities:
+      - "Walldorf"
+    provinces:
+      - "Baden-Württemberg"
+    countries:
+      - "DE"
+  secretName: test-cert-$i
+  privateKey:
+    rotationPolicy: Always
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: klm-watcher-root
+    kind: Issuer
+    group: cert-manager.io
+  duration: 2160h # 90d
+  renewBefore: 1464h # 61d
+EOF
+
+  if [ $? -ne 0 ]; then
+    echo "[$(basename "$0")] Cert deployment failed for test-cert-$i"
+    exit 1
+  fi
+
+done
+
+echo "[$(basename "$0")] All certs deployed successfully"


### PR DESCRIPTION
only for demo purposes

With this, the Kyma doesn't transition to Error state. Rather, we see the following:
<img width="1137" height="469" alt="Image" src="https://github.com/user-attachments/assets/88faae05-1ce8-48ac-a71c-dcaca57e59f3" />

Still not super nice as we see "not all modules are in error state"