### PR TITLE
chore: Bump modulectl to v2.5.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -11,7 +11,7 @@ k8s: "1.32.2" # kubernetes version used in e2e tests
 envtest_k8s: "1.32.0" # kubernetes version used in integration tests
 kubectl: "1.31.3"
 kustomize: "5.4.3"
-modulectl: "2.5.0"
+modulectl: "2.5.1"
 ocm-cli: "0.32.0"
 template-operator: "1.0.4"
 yq: "4.45.1"


### PR DESCRIPTION

**Description**
Bump modulectl to 2.5.1 to use the latest stable release.

**Changes proposed in this pull request:**

- `versions.yaml` file 's updated.


**Related issue(s)**
https://github.com/kyma-project/modulectl/issues/367