### PR TITLE
chore: Bump Golang to 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine@sha256:d9b2e14101f27ec8d09674cd01186798d227bb0daec90e032aeb1cd22ac0f029 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS builder
 
 WORKDIR /lifecycle-manager
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/api
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager
 
-go 1.25.5
+go 1.25.7
 
 replace (
 	//required as of OCM v0.34.3

--- a/maintenancewindows/go.mod
+++ b/maintenancewindows/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/maintenancewindows
 
-go 1.25.5
+go 1.25.7
 
 require github.com/stretchr/testify v1.11.1
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@ certManager: "1.19.3"
 gardenerCertManager: "0.18.0"
 controllerTools: "0.18.0"
 docker: "27.5.1"
-go: "1.25.5"
+go: "1.25.7"
 golangciLint: "2.4.0"
 istio: "1.26.4" # https://github.com/kyma-project/lifecycle-manager/issues/2797
 k3d: "5.8.3"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- needed to fix e2e tests which fail due to template-operator being bumped to 1.25.7 already

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
