### PR TITLE
chore: Drop temp.ca.crt from gateway secret creation

### DIFF
--- a/internal/gatewaysecret/cabundle/handler.go
+++ b/internal/gatewaysecret/cabundle/handler.go
@@ -103,7 +103,6 @@ func (h *Handler) createGatewaySecretFromRootSecret(ctx context.Context,
 	newSecret.Data[apicorev1.TLSPrivateKeyKey] = rootSecret.Data[apicorev1.TLSPrivateKeyKey]
 	newSecret.Data[gatewaysecret.CACrt] = rootSecret.Data[gatewaysecret.CACrt]
 
-	newSecret.Data[caBundleTempCertKey] = rootSecret.Data[gatewaysecret.CACrt]
 	setLastModifiedToNow(newSecret)
 
 	return h.client.CreateGatewaySecret(ctx, newSecret)

--- a/internal/gatewaysecret/cabundle/handler_test.go
+++ b/internal/gatewaysecret/cabundle/handler_test.go
@@ -132,7 +132,6 @@ func TestManageGatewaySecret_WhenGetGatewaySecretReturnsNotFoundError_CreatesGat
 				//nolint:revive // false positive
 				string(secret.Data[apicorev1.TLSPrivateKeyKey]) == string(rootSecret.Data[apicorev1.TLSPrivateKeyKey]) &&
 				string(secret.Data["ca.crt"]) == string(rootSecret.Data["ca.crt"]) &&
-				string(secret.Data["temp.ca.crt"]) == string(rootSecret.Data["ca.crt"]) &&
 				secret.Annotations[shared.LastModifiedAtAnnotation] != ""
 		}))
 }
@@ -204,7 +203,6 @@ func TestManageGatewaySecret_BundlesAndDropsCerts(t *testing.T) {
 			apicorev1.TLSCertKey:       certificates.Cert1,
 			apicorev1.TLSPrivateKeyKey: []byte("value2"),
 			"ca.crt":                   append(certificates.Cert1, certificates.CertExpired...),
-			"temp.ca.crt":              []byte("value3"),
 		},
 	}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
@@ -245,7 +243,6 @@ func TestManageGatewaySecret_WhenUpdateSecretFails_ReturnsError(t *testing.T) {
 			apicorev1.TLSCertKey:       certificates.Cert1,
 			apicorev1.TLSPrivateKeyKey: []byte("value2"),
 			"ca.crt":                   certificates.Cert1,
-			"temp.ca.crt":              []byte("value3"),
 		},
 	}, nil)
 	expectedError := errors.New("some-error")
@@ -283,7 +280,6 @@ func TestManageGatewaySecret_WhenRequiresCertSwitching_SwitchesTLSCertAndKeyWith
 			apicorev1.TLSCertKey:       certificates.Cert1,
 			apicorev1.TLSPrivateKeyKey: []byte("value2"),
 			"ca.crt":                   certificates.Cert2,
-			"temp.ca.crt":              []byte("new-value3"),
 		},
 	}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
@@ -325,7 +321,6 @@ func TestManageGatewaySecret_WhenBundlingFails_ReturnsError(t *testing.T) {
 			apicorev1.TLSCertKey:       certificates.Cert1,
 			apicorev1.TLSPrivateKeyKey: []byte("value2"),
 			"ca.crt":                   []byte("invalid bundle"),
-			"temp.ca.crt":              []byte("value3"),
 		},
 	}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(assert.AnError)
@@ -359,7 +354,6 @@ func TestManageGatewaySecret_WhenDroppingExpiredCertsFails_ReturnsError(t *testi
 			apicorev1.TLSCertKey:       certificates.Cert1,
 			apicorev1.TLSPrivateKeyKey: []byte("value2"),
 			"ca.crt":                   certificates.Cert1,
-			"temp.ca.crt":              []byte("value3"),
 		},
 	}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(assert.AnError)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- the `temp.ca.crt` was written for legacy reasons. This is a first step towards cleaning this up. Note that it is still set as part of `bootstrapLegacyGatewaySecret(gwSecret, rootSecret)`, but we already kick it out from the functionality that will stay. For removing the entire legacy part, there is a separate ticket.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.com/kyma-project/lifecycle-manager/issues/2983