### PR TITLE
chore: Write info log when switching server certificate

### DIFF
--- a/internal/gatewaysecret/cabundle/handler.go
+++ b/internal/gatewaysecret/cabundle/handler.go
@@ -8,12 +8,12 @@ import (
 
 	apicorev1 "k8s.io/api/core/v1"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/internal/gatewaysecret"
 	"github.com/kyma-project/lifecycle-manager/pkg/log"
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var ErrCACertificateNotReady = errors.New("watcher-serving ca certificate is not ready")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- it looks like there may be switching the server cert too early. Adding an Info log so we can see in CLS the exact times when the server cert was switched.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
