### PR TITLE
fix: Ensure proper annotation migration

### DIFF
--- a/internal/controller/istiogatewaysecret/setup.go
+++ b/internal/controller/istiogatewaysecret/setup.go
@@ -42,17 +42,7 @@ func SetupReconciler(mgr ctrl.Manager,
 
 	var handler gatewaysecret.Handler
 	if flagVar.UseLegacyStrategyForIstioGatewaySecret {
-		var parseLastModifiedFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-			annotation string,
-		) (time.Time, error) {
-			if strValue, ok := secret.Annotations[annotation]; ok {
-				if time, err := time.Parse(time.RFC3339, strValue); err == nil {
-					return time, nil
-				}
-			}
-			return time.Time{}, fmt.Errorf("%w: %s", errCouldNotGetTimeFromAnnotation, annotation)
-		}
-		handler = legacy.NewGatewaySecretHandler(clnt, parseLastModifiedFunc)
+		handler = legacy.NewGatewaySecretHandler(clnt, legacyHandlerParseAnnotationTime)
 	} else {
 		handler = cabundle.NewGatewaySecretHandler(clnt,
 			flagVar.IstioGatewayServerCertSwitchGracePeriod,
@@ -102,4 +92,25 @@ func (r *Reconciler) setupWithManager(mgr ctrl.Manager, opts ctrlruntime.Options
 
 func isRootSecret(object client.Object) bool {
 	return object.GetNamespace() == shared.IstioNamespace && object.GetName() == kcpRootSecretName
+}
+
+func legacyHandlerParseAnnotationTime(secret *apicorev1.Secret,
+	annotation, fallbackAnnotation string,
+) (time.Time, error) {
+	if strValue, ok := secret.Annotations[annotation]; ok {
+		if time, err := time.Parse(time.RFC3339, strValue); err == nil {
+			return time, nil
+		}
+
+		return time.Time{}, fmt.Errorf("%w: %s", errCouldNotGetTimeFromAnnotation, annotation)
+	}
+	if strValue, ok := secret.Annotations[fallbackAnnotation]; ok {
+		if time, err := time.Parse(time.RFC3339, strValue); err == nil {
+			return time, nil
+		}
+
+		return time.Time{}, fmt.Errorf("%w: %s", errCouldNotGetTimeFromAnnotation, fallbackAnnotation)
+	}
+
+	return time.Time{}, fmt.Errorf("%w: %s or %s", errCouldNotGetTimeFromAnnotation, annotation, fallbackAnnotation)
 }

--- a/internal/gatewaysecret/cabundle/handler.go
+++ b/internal/gatewaysecret/cabundle/handler.go
@@ -132,7 +132,7 @@ func setCaBundleTimeAnnotationToNow(secret *apicorev1.Secret) {
 	}
 	secret.Annotations[shared.CaAddedToBundleAtAnnotation] = apimetav1.Now().Format(time.RFC3339)
 	//nolint:godox // valid TODO
-	//TODO: drop in the second release after 1.14.0
+	//TODO: drop in the second release after 1.14.0, issue: 3105.
 	delete(secret.Annotations, shared.LastModifiedAtAnnotation)
 }
 

--- a/internal/gatewaysecret/handler.go
+++ b/internal/gatewaysecret/handler.go
@@ -19,7 +19,7 @@ type Client interface {
 	UpdateGatewaySecret(ctx context.Context, secret *apicorev1.Secret) error
 }
 
-type TimeParserFunc func(secret *apicorev1.Secret, annotation string) (time.Time, error)
+type TimeParserFunc func(secret *apicorev1.Secret, annotation, fallbackAnnotation string) (time.Time, error)
 
 type Handler interface {
 	ManageGatewaySecret(ctx context.Context, rootSecret *apicorev1.Secret) error

--- a/internal/gatewaysecret/legacy/handler.go
+++ b/internal/gatewaysecret/legacy/handler.go
@@ -68,7 +68,8 @@ func (h *Handler) createGatewaySecretFromRootSecret(ctx context.Context, rootSec
 func (h *Handler) requiresUpdate(gwSecret *apicorev1.Secret, notBefore time.Time) bool {
 	// If the last modified time of the gateway secret is after the notBefore time of the CA certificate,
 	// then we don't need to update the gateway secret
-	if caBundleExtendedAt, err := h.parseLastModifiedTime(gwSecret, shared.CaAddedToBundleAtAnnotation); err == nil {
+	if caBundleExtendedAt, err := h.parseLastModifiedTime(gwSecret,
+		shared.CaAddedToBundleAtAnnotation, shared.LastModifiedAtAnnotation); err == nil {
 		if !notBefore.IsZero() && caBundleExtendedAt.After(notBefore) {
 			return false
 		}

--- a/internal/gatewaysecret/legacy/handler_test.go
+++ b/internal/gatewaysecret/legacy/handler_test.go
@@ -139,7 +139,7 @@ func TestManageGatewaySecret_WhenRequiresUpdate_UpdatesGatewaySecretWithRootSecr
 	mockClient.On("GetWatcherServingCertValidity", mock.Anything).Return(notBefore, time.Time{}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
 	var mockFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-		annotation string,
+		annotation, fallbackAnnotation string,
 	) (time.Time, error) {
 		return time.Now(), nil
 	}
@@ -182,7 +182,7 @@ func TestManageGatewaySecret_WhenRequiresUpdate_UpdatesGatewaySecretWithUpdatedM
 	mockClient.On("GetWatcherServingCertValidity", mock.Anything).Return(notBefore, time.Time{}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
 	var mockFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-		annotation string,
+		annotation, fallbackAnnotation string,
 	) (time.Time, error) {
 		return time.Now(), nil
 	}
@@ -214,7 +214,7 @@ func TestManageGatewaySecret_WhenRequiresUpdateAndUpdateFails_ReturnsError(t *te
 	expectedError := errors.New("some-error")
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(expectedError)
 	var mockFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-		annotation string,
+		annotation, fallbackAnnotation string,
 	) (time.Time, error) {
 		return time.Now(), nil
 	}
@@ -237,7 +237,7 @@ func TestManageGatewaySecret_WhenRequiresUpdateIsFalse_DoesNotUpdateGatewaySecre
 	mockClient.On("GetWatcherServingCertValidity", mock.Anything).Return(time.Now().Add(-1*time.Hour), time.Time{}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
 	var mockFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-		annotation string,
+		annotation, fallbackAnnotation string,
 	) (time.Time, error) {
 		return time.Now(), nil
 	}
@@ -258,7 +258,7 @@ func TestManageGatewaySecret_WhenTimeParserFuncReturnsError_UpdatesGatewaySecret
 	mockClient.On("GetWatcherServingCertValidity", mock.Anything).Return(notBefore, time.Time{}, nil)
 	mockClient.On("UpdateGatewaySecret", mock.Anything, mock.Anything).Return(nil)
 	var mockFunc gatewaysecret.TimeParserFunc = func(secret *apicorev1.Secret,
-		annotation string,
+		annotation, fallbackAnnotation string,
 	) (time.Time, error) {
 		return time.Time{}, errors.New("some-error")
 	}

--- a/internal/service/watcher/certificate/certificate_service.go
+++ b/internal/service/watcher/certificate/certificate_service.go
@@ -219,7 +219,7 @@ func (s *Service) getGatewaySecretCaBundleExtendedAtTime(ctx context.Context) (t
 		return time.Time{}, fmt.Errorf("failed to get gateway secret: %w", err)
 	}
 
-	caBundleExtendedAtValue, ok := gatewaySecret.Annotations[shared.CaAddedToBundleAtAnnotation]
+	caBundleExtendedAtValue, ok := getCaAddedToBundleAtAnnotation(gatewaySecret)
 	if !ok {
 		return time.Time{}, ErrGatewaySecretMissingBundlingTimeAnnotation
 	}
@@ -230,4 +230,20 @@ func (s *Service) getGatewaySecretCaBundleExtendedAtTime(ctx context.Context) (t
 	}
 
 	return caBundleExtendedAt, nil
+}
+
+func getCaAddedToBundleAtAnnotation(secret *apicorev1.Secret) (string, bool) {
+	if secret.Annotations == nil {
+		return "", false
+	}
+
+	if value, ok := secret.Annotations[shared.CaAddedToBundleAtAnnotation]; ok {
+		return value, true
+	}
+
+	// To be removed along with fallback logic, issue: #3105.
+	// Fallback to lastModifiedAt for the transition phase until next bundling occurs,
+	// when the "lastModifiedAt" will be replaced by "caAddedToBundleAt".
+	value, ok := secret.Annotations[shared.LastModifiedAtAnnotation]
+	return value, ok
 }

--- a/internal/service/watcher/certificate/certificate_service.go
+++ b/internal/service/watcher/certificate/certificate_service.go
@@ -233,10 +233,6 @@ func (s *Service) getGatewaySecretCaBundleExtendedAtTime(ctx context.Context) (t
 }
 
 func getCaAddedToBundleAtAnnotation(secret *apicorev1.Secret) (string, bool) {
-	if secret.Annotations == nil {
-		return "", false
-	}
-
 	if value, ok := secret.Annotations[shared.CaAddedToBundleAtAnnotation]; ok {
 		return value, true
 	}

--- a/internal/service/watcher/certificate/certificate_service_test.go
+++ b/internal/service/watcher/certificate/certificate_service_test.go
@@ -182,7 +182,7 @@ func TestIsSkrCertificateRenewalOverdue_WhenRenewalOverdue_ReturnsTrue(t *testin
 	caRotationTime := time.Now().Add(-30 * time.Minute)
 	clientCertRotationTime := time.Now().Add(-time.Hour)
 
-	gatewaySecret := getGatewaySecretWithLastModifiedAnnotation(caRotationTime.Format(time.RFC3339))
+	gatewaySecret := getGatewaySecretWithCaAddedToBundleAtAnnotation(caRotationTime.Format(time.RFC3339))
 	secretRepo := &secretRepoStub{
 		getSecrets: []*apicorev1.Secret{gatewaySecret, gatewaySecret},
 	}
@@ -202,7 +202,7 @@ func TestIsSkrCertificateRenewalOverdue_WhenRenewalOverdue_ReturnsTrue(t *testin
 	require.True(t, secretRepo.getCalled)
 }
 
-func getGatewaySecretWithLastModifiedAnnotation(rfc3339Value string) *apicorev1.Secret {
+func getGatewaySecretWithCaAddedToBundleAtAnnotation(rfc3339Value string) *apicorev1.Secret {
 	return &apicorev1.Secret{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:      gatewaySecretName,
@@ -214,11 +214,49 @@ func getGatewaySecretWithLastModifiedAnnotation(rfc3339Value string) *apicorev1.
 	}
 }
 
+// To be removed along with fallback logic, issue: #3105.
+func getGatewaySecretWithOldAnnotation(rfc3339Value string) *apicorev1.Secret {
+	return &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:      gatewaySecretName,
+			Namespace: testutils.IstioNamespace,
+			Annotations: map[string]string{
+				shared.LastModifiedAtAnnotation: rfc3339Value,
+			},
+		},
+	}
+}
+
 func TestIsSkrCertificateRenewalOverdue_WhenClientCertificateMoreRecentThanCA_ReturnsFalse(t *testing.T) {
 	caRotationTime := time.Now().Add(-time.Second)
 	clientCertRotationTime := time.Now()
 
-	gatewaySecret := getGatewaySecretWithLastModifiedAnnotation(caRotationTime.Format(time.RFC3339))
+	gatewaySecret := getGatewaySecretWithCaAddedToBundleAtAnnotation(caRotationTime.Format(time.RFC3339))
+	secretRepo := &secretRepoStub{
+		getSecrets: []*apicorev1.Secret{gatewaySecret, gatewaySecret},
+	}
+	certRepo := &certRepoStub{
+		getValidityStart: clientCertRotationTime,
+		getValidityEnd:   clientCertRotationTime.Add(time.Hour),
+	}
+	certService := certificate.NewService(certRepo, secretRepo, certificate.Config{
+		RenewBuffer: renewBuffer,
+	})
+
+	overdue, err := certService.IsSkrCertificateRenewalOverdue(t.Context(), kymaName)
+
+	require.NoError(t, err)
+	require.False(t, overdue)
+	require.True(t, certRepo.getValidityCalled)
+	require.True(t, secretRepo.getCalled)
+}
+
+// To be removed along with fallback logic, issue: #3105.
+func TestIsSkrCertificateRenewalOverdue_WhenCertHasOldAnnotation_ReturnsFalse(t *testing.T) {
+	caRotationTime := time.Now().Add(-time.Second)
+	clientCertRotationTime := time.Now()
+
+	gatewaySecret := getGatewaySecretWithOldAnnotation(caRotationTime.Format(time.RFC3339))
 	secretRepo := &secretRepoStub{
 		getSecrets: []*apicorev1.Secret{gatewaySecret, gatewaySecret},
 	}
@@ -242,7 +280,7 @@ func TestIsSkrCertificateRenewalOverdue_WhenClientCertificateOlderThanCA_ButWith
 	caRotationTime := time.Now().Add(-5 * time.Minute)
 	clientCertRotationTime := time.Now().Add(-30 * time.Minute)
 
-	gatewaySecret := getGatewaySecretWithLastModifiedAnnotation(caRotationTime.Format(time.RFC3339))
+	gatewaySecret := getGatewaySecretWithCaAddedToBundleAtAnnotation(caRotationTime.Format(time.RFC3339))
 	secretRepo := &secretRepoStub{
 		getSecrets: []*apicorev1.Secret{gatewaySecret, gatewaySecret},
 	}
@@ -303,8 +341,8 @@ func TestIsSkrCertificateRenewalOverdue_SecretRepositoryReturnsError2_ReturnsErr
 	caRotationTime := time.Now().Add(-30 * time.Minute)
 	clientCertRotationTime := time.Now().Add(-time.Hour)
 
-	gatewaySecret := getGatewaySecretWithLastModifiedAnnotation(caRotationTime.Format(time.RFC3339))
-	invalidGatewaySecret := getGatewaySecretWithLastModifiedAnnotation("")
+	gatewaySecret := getGatewaySecretWithCaAddedToBundleAtAnnotation(caRotationTime.Format(time.RFC3339))
+	invalidGatewaySecret := getGatewaySecretWithCaAddedToBundleAtAnnotation("")
 	secretRepo := &secretRepoStub{
 		getSecrets: []*apicorev1.Secret{gatewaySecret, invalidGatewaySecret},
 	}

--- a/unit-test-coverage-lifecycle-manager.yaml
+++ b/unit-test-coverage-lifecycle-manager.yaml
@@ -1,6 +1,6 @@
 packages:
   internal/controller: 100
-  internal/controller/istiogatewaysecret: 28
+  internal/controller/istiogatewaysecret: 26
   internal/crd: 92
   internal/descriptor/cache: 90
   internal/descriptor/provider: 100


### PR DESCRIPTION
**Description**

A bug has been revealed in GW Secret annotation handling: We blindly changed the annotation name from `lastModifiedAt` to `caAddedToBundleAt`. New code wasn't looking at all at  `lastModifiedAt` annotation anymore.

The problem:
If we deploy the new version to a system where existing GW Secret only has the "old"  `lastModifiedAt` annotation (as is the case), the new code cannot find the value it requires to properly execute the cert-related logic.
The  `lastModifiedAt` will be eventually replaced by `caAddedToBundleAt` annotation - this logic exists in code - but this only happens at "bundling time", i.e: after the root certificate is rotated, which happens once every week or once every month.

The fix: Introduce fallback to "old"  `lastModifiedAt` annotation value if the `caAddedToBundleAt` annotation does not exist.

Changes proposed in this pull request:

- ensure we read the value of `lastModifiedAt` annotation if `caAddedToBundleAt` does not exist - as a fallback

**Related issue(s)**
#3002 