### PR TITLE
chore: Drop KLM 1.14.0 from sec scanning

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -9,7 +9,6 @@ checkmarx-one:
     - "tests/**"
 bdba:
   - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.15.0
-  - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:1.14.0
   - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:latest
 mend:
   language: golang-mod


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- stop scanning v1.14.0 once 1.15.0 arrives on PROD

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
