### PR TITLE
fix: Ensure non-empty k8s event.Action attribute

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -25,6 +25,8 @@ func NewRecorderWrapper(recorder events.EventRecorder) *RecorderWrapper {
 	return &RecorderWrapper{recorder}
 }
 
+// Normal records a normal event for the given object with the specified reason and message.
+// The provided obj must not be nil and the reason must not be empty.
 func (e *RecorderWrapper) Normal(obj machineryruntime.Object, reason Reason, msg string) {
 	if obj == nil {
 		return
@@ -34,12 +36,14 @@ func (e *RecorderWrapper) Normal(obj machineryruntime.Object, reason Reason, msg
 	e.recorder.Eventf(obj, related, apicorev1.EventTypeNormal, string(reason), action, msg)
 }
 
+// Warning records a warning event for the given object with the specified reason and error message.
+// The provided obj must not be nil and the err must not be nil. The reason must not be empty.
 func (e *RecorderWrapper) Warning(obj machineryruntime.Object, reason Reason, err error) {
 	if obj == nil || err == nil {
 		return
 	}
 	var related machineryruntime.Object = nil // related object is optional. We may consider using it in the future.
-	action := string(reason) 
+	action := string(reason)
 	e.recorder.Eventf(obj, related, apicorev1.EventTypeWarning, string(reason), action, truncatedErrMsg(err))
 }
 


### PR DESCRIPTION
**Description**

Fix for #3142.
_Note: This is a quick fix, because currently we don't emit any events at all, so the goal is to restore the working state._


Before upgrade to Events `v1` API we provided just the `reason` attribute during Event creation.
Now also `action` is required.
The problem is that currently we don't know what to provide for `action` and our internal functions are not prepared (refactored) to take the `action` as an argument.
So, for now, as a "quick fix" to make things work, let's just assign `reason` to `action`, making the two values identical.
Not perfect, but once we'll expose `action` as a proper argument to the `Normal()` and `Warning()` methods, we'll be able to improve on that.

Corner case: What happens if someone provides an empty `reason`? The action will also be empty then? And we have a bug?
Not quite. OK, both values will be empty, but the reason must be **not empty** - otherwise the API server will reject such event anyway.
It means that if the `reason` is empty, the value of `action` doesn't matter (may be empty or not) - such event is considered invalid anyway by the API Server.
The empty `reason` is just an invalid argument to the `Normal()` and `Warning()` methods, which I documented accordingly.
And if a user (another part of KLM) uses such invalid argument (an empty string), an error should be emitted into the log stream - which is exactly what happens.
Because of the above it seems to be safe to just assign `action` the same value as `reason`.

Changes proposed in this pull request:

- Ensure that the `action` attribute is assigned the same value as `reason`
- Document that `reason` must not be an empty string

**Related issue(s)**
Fixes: #3142 