### PR TITLE
feat: Use `ocmComponentName` instead of `fqdn`

### DIFF
--- a/api/shared/operator_annotations.go
+++ b/api/shared/operator_annotations.go
@@ -1,7 +1,8 @@
 package shared
 
 const (
-	FQDN = OperatorGroup + Separator + "fqdn"
+	FQDN             = OperatorGroup + Separator + "fqdn" // Deprecated: use OCMComponentName instead.
+	OCMComponentName = OperatorGroup + Separator + "ocm-component-name"
 
 	// OwnedByAnnotation defines the resource managing the resource. Differing from ManagedBy
 	// in that it does not reference controllers. Used by the runtime-watcher to determine the

--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -168,10 +168,12 @@ type ModuleStatus struct {
 	// It can be any kind of Reference format supported by Module.Name.
 	Name string `json:"name"`
 
-	// FQDN is the fully qualified domain name of the module.
-	// In the ModuleTemplate it is located in .spec.descriptor.component.name of the ModuleTemplate
-	// FQDN is used to calculate Namespace and Name of the Manifest for tracking.
+	// Deprecated: This field is deprecated and will be removed in the upcoming API version.
+	// Use the `ComponentName` field instead to track the OCM component name of the module.
 	FQDN string `json:"fqdn,omitempty"`
+
+	// ComponentName represent the OCM (Open Component Model) component name of the module.
+	OCMComponentName string `json:"ocmComponentName,omitempty"`
 
 	// Channel tracks the active Channel of the Module. In Case it changes, the new Channel will have caused
 	// a new lookup to be necessary that maybe picks a different ModuleTemplate, which is why we need to reconcile.

--- a/api/v1beta2/kyma_types.go
+++ b/api/v1beta2/kyma_types.go
@@ -169,10 +169,10 @@ type ModuleStatus struct {
 	Name string `json:"name"`
 
 	// Deprecated: This field is deprecated and will be removed in the upcoming API version.
-	// Use the `ComponentName` field instead to track the OCM component name of the module.
+	// Use the `OCMComponentName` field instead to track the OCM component name of the module.
 	FQDN string `json:"fqdn,omitempty"`
 
-	// ComponentName represent the OCM (Open Component Model) component name of the module.
+	// OCMComponentName represents the OCM (Open Component Model) component name of the module.
 	OCMComponentName string `json:"ocmComponentName,omitempty"`
 
 	// Channel tracks the active Channel of the Module. In Case it changes, the new Channel will have caused

--- a/config/crd/bases/operator.kyma-project.io_kcpmodules.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kcpmodules.yaml
@@ -52,7 +52,7 @@ spec:
                 type: string
             type: object
           status:
-            description: ManifestStatus defines the observed state of Manifest.
+            description: KCPModuleStatus defines the observed state of KCPModule.
             properties:
               state:
                 allOf:
@@ -68,6 +68,7 @@ spec:
                   - Error
                   - Deleting
                   - Warning
+                description: KCPModuleState is the state of a KCPModule.
                 type: string
             required:
             - state
@@ -114,7 +115,7 @@ spec:
                 type: string
             type: object
           status:
-            description: ManifestStatus defines the observed state of Manifest.
+            description: KCPModuleStatus defines the observed state of KCPModule.
             properties:
               state:
                 allOf:
@@ -130,6 +131,7 @@ spec:
                   - Error
                   - Deleting
                   - Warning
+                description: KCPModuleState is the state of a KCPModule.
                 type: string
             required:
             - state

--- a/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -638,7 +638,7 @@ spec:
                     fqdn:
                       description: |-
                         Deprecated: This field is deprecated and will be removed in the upcoming API version.
-                        Use the `ComponentName` field instead to track the OCM component name of the module.
+                        Use the `OCMComponentName` field instead to track the OCM component name of the module.
                       type: string
                     maintenance:
                       default: false
@@ -707,7 +707,7 @@ spec:
                         It can be any kind of Reference format supported by Module.Name.
                       type: string
                     ocmComponentName:
-                      description: ComponentName represent the OCM (Open Component
+                      description: OCMComponentName represents the OCM (Open Component
                         Model) component name of the module.
                       type: string
                     resource:

--- a/config/crd/bases/operator.kyma-project.io_kymas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_kymas.yaml
@@ -637,9 +637,8 @@ spec:
                       type: string
                     fqdn:
                       description: |-
-                        FQDN is the fully qualified domain name of the module.
-                        In the ModuleTemplate it is located in .spec.descriptor.component.name of the ModuleTemplate
-                        FQDN is used to calculate Namespace and Name of the Manifest for tracking.
+                        Deprecated: This field is deprecated and will be removed in the upcoming API version.
+                        Use the `ComponentName` field instead to track the OCM component name of the module.
                       type: string
                     maintenance:
                       default: false
@@ -706,6 +705,10 @@ spec:
                       description: |-
                         Name defines the name of the Module in the Spec that the status is used for.
                         It can be any kind of Reference format supported by Module.Name.
+                      type: string
+                    ocmComponentName:
+                      description: ComponentName represent the OCM (Open Component
+                        Model) component name of the module.
                       type: string
                     resource:
                       description: Resource contains information about the created

--- a/config/crd/bases/operator.kyma-project.io_manifests.yaml
+++ b/config/crd/bases/operator.kyma-project.io_manifests.yaml
@@ -257,6 +257,8 @@ spec:
                   All resources that are synced are considered for orphan removal on configuration changes,
                   and it is used to determine effective differences from one state to the next.
                 items:
+                  description: Resource identifies a Kubernetes object by GroupVersionKind,
+                    name and namespace.
                   properties:
                     group:
                       type: string
@@ -560,6 +562,8 @@ spec:
                   All resources that are synced are considered for orphan removal on configuration changes,
                   and it is used to determine effective differences from one state to the next.
                 items:
+                  description: Resource identifies a Kubernetes object by GroupVersionKind,
+                    name and namespace.
                   properties:
                     group:
                       type: string

--- a/config/crd/bases/operator.kyma-project.io_modulereleasemetas.yaml
+++ b/config/crd/bases/operator.kyma-project.io_modulereleasemetas.yaml
@@ -49,6 +49,7 @@ spec:
                 default: false
                 description: |-
                   Beta indicates if the module is in beta state. Beta modules are only available for beta Kymas.
+
                   Deprecated: This field is deprecated and will be removed in the upcoming API version.
                 type: boolean
               channels:
@@ -80,6 +81,7 @@ spec:
                 default: false
                 description: |-
                   Internal indicates if the module is internal. Internal modules are only available for internal Kymas.
+
                   Deprecated: This field is deprecated and will be removed in the upcoming API version.
                 type: boolean
               mandatory:

--- a/config/crd/bases/operator.kyma-project.io_moduletemplates.yaml
+++ b/config/crd/bases/operator.kyma-project.io_moduletemplates.yaml
@@ -51,6 +51,7 @@ spec:
                 description: |-
                   Channel is the targeted channel of the ModuleTemplate. It will be used to directly assign a Template
                   to a target channel. It has to be provided at any given time.
+
                   Deprecated: This field is deprecated and will be removed in a future release.
                 maxLength: 32
                 pattern: ^$|^[a-z]{3,}$
@@ -184,6 +185,7 @@ spec:
                 description: |-
                   Channel is the targeted channel of the ModuleTemplate. It will be used to directly assign a Template
                   to a target channel. It has to be provided at any given time.
+
                   Deprecated: This field is deprecated and will be removed in a future release.
                 maxLength: 32
                 pattern: ^$|^[a-z]{3,}$

--- a/docs/contributor/resources/01-kyma.md
+++ b/docs/contributor/resources/01-kyma.md
@@ -169,7 +169,7 @@ status:
     version: 1.2.10
 ```
 
-The above example shows that not only is the module name resolved to a unique `ocmComponentName`, it also represents the active `channel`, `version`, and `state`, which is a direct tracking to the **.status.state** in the Manifest CR. The Kyma CR `Ready` state can only be achieved if all tracked modules are `Ready` themselves.
+The above example shows that not only is the module name resolved to a unique `ocmComponentName`, it also represents the active `channel`, `version`, and `state`, which is a direct tracking to the **.status.state** in the Manifest CR. During migration, the API may also still expose the deprecated `fqdn` field for backward compatibility, but `ocmComponentName` is the preferred field to use. The Kyma CR `Ready` state can only be achieved if all tracked modules are `Ready` themselves.
 
 The Manifest CR can be directly observed by looking at the **metadata**, **apiVersion**, and **kind**, which can be used to dynamically resolve the module.
 

--- a/docs/contributor/resources/01-kyma.md
+++ b/docs/contributor/resources/01-kyma.md
@@ -149,7 +149,7 @@ kind: Kyma
 status:
   modules:
   - channel: regular
-    fqdn: kyma.project.io/module/btp-operator
+    ocmComponentName: kyma.project.io/module/btp-operator
     manifest:
       apiVersion: operator.kyma-project.io/v1beta2
       kind: Manifest
@@ -169,7 +169,7 @@ status:
     version: 1.2.10
 ```
 
-The above example shows that not only is the module name resolved to a unique `fqdn`, it also represents the active `channel`, `version`, and `state`, which is a direct tracking to the **.status.state** in the Manifest CR. The Kyma CR `Ready` state can only be achieved if all tracked modules are `Ready` themselves.
+The above example shows that not only is the module name resolved to a unique `ocmComponentName`, it also represents the active `channel`, `version`, and `state`, which is a direct tracking to the **.status.state** in the Manifest CR. The Kyma CR `Ready` state can only be achieved if all tracked modules are `Ready` themselves.
 
 The Manifest CR can be directly observed by looking at the **metadata**, **apiVersion**, and **kind**, which can be used to dynamically resolve the module.
 

--- a/docs/contributor/resources/01-kyma.md
+++ b/docs/contributor/resources/01-kyma.md
@@ -149,7 +149,7 @@ kind: Kyma
 status:
   modules:
   - channel: regular
-    ocmComponentName: kyma.project.io/module/btp-operator
+    ocmComponentName: kyma-project.io/module/btp-operator
     manifest:
       apiVersion: operator.kyma-project.io/v1beta2
       kind: Manifest

--- a/docs/contributor/resources/02-manifest.md
+++ b/docs/contributor/resources/02-manifest.md
@@ -160,7 +160,7 @@ spec:
 
 ## Annotations
 
-* `operator.kyma-project.io/fqdn`: The fully-qualified domain name of the module.
+* `operator.kyma-project.io/ocm-component-name`: The OCM-compliant (Open Component Model) name of the module.
 * `sync-oci-ref`: A reference to the OCM installation resource that is installed in the Kyma runtime instance. 
 
 ## Finalizers

--- a/docs/contributor/resources/02-manifest.md
+++ b/docs/contributor/resources/02-manifest.md
@@ -161,6 +161,7 @@ spec:
 ## Annotations
 
 * `operator.kyma-project.io/ocm-component-name`: The OCM-compliant (Open Component Model) name of the module.
+* `operator.kyma-project.io/fqdn`: Deprecated. Still supported during migration for backward compatibility; use `operator.kyma-project.io/ocm-component-name` instead.
 * `sync-oci-ref`: A reference to the OCM installation resource that is installed in the Kyma runtime instance. 
 
 ## Finalizers

--- a/internal/descriptor/types/ocmidentity/ocmidentity.go
+++ b/internal/descriptor/types/ocmidentity/ocmidentity.go
@@ -8,7 +8,7 @@ import (
 var ErrValueNotProvided = errors.New("value not provided")
 
 // ComponentId uniquely identifies an OCM ComponentId.
-// See: https://ocm.software/docs/overview/important-terms/#component-identity
+// See: https://ocm.software/docs/concepts/component-identity/
 type ComponentId struct {
 	componentName    string
 	componentVersion string

--- a/internal/manifest/img/parse_test.go
+++ b/internal/manifest/img/parse_test.go
@@ -30,7 +30,7 @@ func TestParse(t *testing.T) {
 				LayerName: "raw-manifest",
 				LayerRepresentation: &img.OCI{
 					Repo: "europe-west3-docker.pkg.dev/sap-kyma-jellyfish-dev/template-operator/component-descriptors",
-					Name: testutils.DefaultFQDN,
+					Name: testutils.DefaultComponentName,
 					Ref:  "sha256:d2cc278224a71384b04963a83e784da311a268a2b3fa8732bc31e70ca0c5bc52",
 					Type: "oci-dir",
 				},
@@ -43,7 +43,7 @@ func TestParse(t *testing.T) {
 				LayerName: "raw-manifest",
 				LayerRepresentation: &img.OCI{
 					Repo: "europe-west3-docker.pkg.dev/sap-kyma-jellyfish-dev/template-operator/component-descriptors",
-					Name: testutils.DefaultFQDN,
+					Name: testutils.DefaultComponentName,
 					Ref:  "sha256:1ea2baf45791beafabfee533031b715af8f7a4ffdfbbf30d318f52f7652c36ca",
 					Type: "oci-ref",
 				},

--- a/internal/manifest/img/pathextractor_test.go
+++ b/internal/manifest/img/pathextractor_test.go
@@ -81,7 +81,7 @@ func TestPathExtractor_FetchLayerToFile(t *testing.T) {
 				LayerRepresentation: &img.OCI{
 					Repo: "normally-determined-by-OCM-component-descriptor-but-" +
 						"in-our-code-is-overridden-with-an-explicit-value",
-					Name: testutils.DefaultFQDN,
+					Name: testutils.DefaultComponentName,
 					Ref:  "sha256:d2cc278224a71384b04963a83e784da311a268a2b3fa8732bc31e70ca0c5bc52",
 					Type: "oci-dir",
 				},
@@ -95,7 +95,7 @@ func TestPathExtractor_FetchLayerToFile(t *testing.T) {
 				LayerRepresentation: &img.OCI{
 					Repo: "normally-determined-by-OCM-component-descriptor-but-" +
 						"in-our-code-is-overridden-with-an-explicit-value",
-					Name: testutils.DefaultFQDN,
+					Name: testutils.DefaultComponentName,
 					Ref:  "sha256:1ea2baf45791beafabfee533031b715af8f7a4ffdfbbf30d318f52f7652c36ca",
 					Type: "oci-ref",
 				},

--- a/internal/manifest/parser/template_to_module.go
+++ b/internal/manifest/parser/template_to_module.go
@@ -100,8 +100,8 @@ func (p *Parser) appendModuleWithInformation(module templatelookup.ModuleInfo, k
 		})
 		return modules
 	}
-	fqdn := descriptor.GetName()
-	name := modulecommon.CreateModuleName(fqdn, kyma.Name, module.Name)
+	componentName := descriptor.GetName()
+	name := modulecommon.CreateModuleName(componentName, kyma.Name, module.Name)
 	setNameAndNamespaceIfEmpty(template, name, p.remoteSyncNamespace)
 	var manifest *v1beta2.Manifest
 	if manifest, err = newManifestFromTemplate(module.Module,
@@ -120,12 +120,12 @@ func (p *Parser) appendModuleWithInformation(module templatelookup.ModuleInfo, k
 	// to have correct owner references, the manifest must always have the same namespace as kyma
 	manifest.SetNamespace(kyma.GetNamespace())
 	modules = append(modules, &modulecommon.Module{
-		ModuleName:   module.Name,
-		FQDN:         fqdn,
-		TemplateInfo: template,
-		Manifest:     manifest,
-		Enabled:      module.Enabled,
-		IsUnmanaged:  module.Unmanaged,
+		ModuleName:       module.Name,
+		OCMComponentName: componentName,
+		TemplateInfo:     template,
+		Manifest:         manifest,
+		Enabled:          module.Enabled,
+		IsUnmanaged:      module.Unmanaged,
 	})
 	return modules
 }

--- a/internal/service/kyma/status/modules/generator/fromerror/generator.go
+++ b/internal/service/kyma/status/modules/generator/fromerror/generator.go
@@ -74,7 +74,7 @@ func newDefaultErrorStatus(moduleName, desiredChannel, componentName string, err
 	return &v1beta2.ModuleStatus{
 		Name:             moduleName,
 		Channel:          desiredChannel,
-		FQDN:             componentName, // Deprecated in favor of ComponentName, but set for backward compatibility
+		FQDN:             componentName, // Deprecated in favor of OCMComponentName, but set for backward compatibility
 		OCMComponentName: componentName,
 		State:            shared.StateError,
 		Message:          err.Error(),

--- a/internal/service/kyma/status/modules/generator/fromerror/generator.go
+++ b/internal/service/kyma/status/modules/generator/fromerror/generator.go
@@ -12,7 +12,7 @@ import (
 
 var errFunctionCalledWitNilError = errors.New("can not generate a modulestatus without error")
 
-func GenerateModuleStatusFromError(err error, moduleName, desiredChannel, fqdn string,
+func GenerateModuleStatusFromError(err error, moduleName, desiredChannel, ocmComponentName string,
 	status *v1beta2.ModuleStatus,
 ) (*v1beta2.ModuleStatus, error) {
 	if err == nil {
@@ -20,7 +20,7 @@ func GenerateModuleStatusFromError(err error, moduleName, desiredChannel, fqdn s
 	}
 
 	if status == nil {
-		return newDefaultErrorStatus(moduleName, desiredChannel, fqdn, err), nil
+		return newDefaultErrorStatus(moduleName, desiredChannel, ocmComponentName, err), nil
 	}
 
 	if errorIsWaitingForMaintenanceWindow(err) {
@@ -44,7 +44,7 @@ func GenerateModuleStatusFromError(err error, moduleName, desiredChannel, fqdn s
 		return newModuleStatus, nil
 	}
 
-	newStatus := newDefaultErrorStatus(moduleName, desiredChannel, fqdn, err)
+	newStatus := newDefaultErrorStatus(moduleName, desiredChannel, ocmComponentName, err)
 
 	if errorIsTemplateNotFound(err) {
 		newStatus.State = shared.StateWarning
@@ -70,12 +70,13 @@ func errorIsTemplateNotFound(err error) bool {
 	return errors.Is(err, common.ErrNoTemplatesInListResult)
 }
 
-func newDefaultErrorStatus(moduleName, desiredChannel, fqdn string, err error) *v1beta2.ModuleStatus {
+func newDefaultErrorStatus(moduleName, desiredChannel, componentName string, err error) *v1beta2.ModuleStatus {
 	return &v1beta2.ModuleStatus{
-		Name:    moduleName,
-		Channel: desiredChannel,
-		FQDN:    fqdn,
-		State:   shared.StateError,
-		Message: err.Error(),
+		Name:             moduleName,
+		Channel:          desiredChannel,
+		FQDN:             componentName, // Deprecated in favor of ComponentName, but set for backward compatibility
+		OCMComponentName: componentName,
+		State:            shared.StateError,
+		Message:          err.Error(),
 	}
 }

--- a/internal/service/kyma/status/modules/generator/fromerror/generator_test.go
+++ b/internal/service/kyma/status/modules/generator/fromerror/generator_test.go
@@ -19,11 +19,12 @@ import (
 func TestGenerateModuleStatusFromError_WhenCalledWithAnyOtherError_ReturnsDefaultNewStatusWithStateError(t *testing.T) {
 	someModuleName := "some-module"
 	someChannel := "some-channel"
-	someFQDN := "some-fqdn"
+	someComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := errors.New("some error")
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel, someFQDN, status)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel,
+		someComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -32,7 +33,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithAnyOtherError_ReturnsDefaul
 	// Module info is used for creating a new status
 	assert.Equal(t, someModuleName, result.Name)
 	assert.Equal(t, someChannel, result.Channel)
-	assert.Equal(t, someFQDN, result.FQDN)
+	assert.Equal(t, someComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.Equal(t, someComponentName, result.OCMComponentName)
 
 	assert.Equal(t, shared.StateError, result.State)
 	assert.Equal(t, templateError.Error(), result.Message)
@@ -48,11 +50,12 @@ func TestGenerateModuleStatusFromError_WhenCalledWithMaintenanceWindowActiveErro
 ) {
 	someModuleName := "some-module"
 	someChannel := "some-channel"
-	someFQDN := "some-fqdn"
+	someComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := moduletemplateinfolookup.ErrWaitingForNextMaintenanceWindow
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel, someFQDN, status)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel,
+		someComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -65,7 +68,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithMaintenanceWindowActiveErro
 	// Passed module info is not used for new status, but the deep-copied object
 	assert.NotEqual(t, someModuleName, result.Name)
 	assert.NotEqual(t, someChannel, result.Channel)
-	assert.NotEqual(t, someFQDN, result.FQDN)
+	assert.NotEqual(t, someComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.NotEqual(t, someComponentName, result.OCMComponentName)
 }
 
 func TestGenerateModuleStatusFromError_WhenCalledWithMaintenanceWindowUnknownError_ReturnsDeepCopyAndStateError(
@@ -73,11 +77,12 @@ func TestGenerateModuleStatusFromError_WhenCalledWithMaintenanceWindowUnknownErr
 ) {
 	someModuleName := "some-module"
 	someChannel := "some-channel"
-	someFQDN := "some-fqdn"
+	someComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := moduletemplateinfolookup.ErrFailedToDetermineIfMaintenanceWindowIsActive
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel, someFQDN, status)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel,
+		someComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -90,7 +95,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithMaintenanceWindowUnknownErr
 	// Passed module info is not used for new status, but the deep-copied object
 	assert.NotEqual(t, someModuleName, result.Name)
 	assert.NotEqual(t, someChannel, result.Channel)
-	assert.NotEqual(t, someFQDN, result.FQDN)
+	assert.NotEqual(t, someComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.NotEqual(t, someComponentName, result.OCMComponentName)
 }
 
 func TestGenerateModuleStatusFromError_WhenCalledWithTemplateUpdateNotAllowedError_ReturnsDeepCopyAndStateWarning(
@@ -98,11 +104,12 @@ func TestGenerateModuleStatusFromError_WhenCalledWithTemplateUpdateNotAllowedErr
 ) {
 	someModuleName := "some-module"
 	someChannel := "some-channel"
-	someFQDN := "some-fqdn"
+	someComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := templatelookup.ErrTemplateUpdateNotAllowed
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel, someFQDN, status)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel,
+		someComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -115,7 +122,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithTemplateUpdateNotAllowedErr
 	// Passed module info is not used for new status, but the deep-copied object
 	assert.NotEqual(t, someModuleName, result.Name)
 	assert.NotEqual(t, someChannel, result.Channel)
-	assert.NotEqual(t, someFQDN, result.FQDN)
+	assert.NotEqual(t, someComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.NotEqual(t, someComponentName, result.OCMComponentName)
 }
 
 func TestGenerateModuleStatusFromError_WhenCalledWithErrNoModuleReleaseMeta_ReturnsDeepCopyAndStateWarning(
@@ -123,11 +131,12 @@ func TestGenerateModuleStatusFromError_WhenCalledWithErrNoModuleReleaseMeta_Retu
 ) {
 	someModuleName := "some-module"
 	someChannel := "some-channel"
-	someFQDN := "some-fqdn"
+	someComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := templatelookup.ErrNoModuleReleaseMeta
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel, someFQDN, status)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, someModuleName, someChannel,
+		someComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -140,7 +149,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithErrNoModuleReleaseMeta_Retu
 	// Passed module info is not used for new status, but the deep-copied object
 	assert.NotEqual(t, someModuleName, result.Name)
 	assert.NotEqual(t, someChannel, result.Channel)
-	assert.NotEqual(t, someFQDN, result.FQDN)
+	assert.NotEqual(t, someComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.NotEqual(t, someComponentName, result.OCMComponentName)
 }
 
 func TestGenerateModuleStatusFromError_WhenCalledWithNoTemplatesInListResultError_ReturnsNewStatusWithStateWarning(
@@ -148,12 +158,12 @@ func TestGenerateModuleStatusFromError_WhenCalledWithNoTemplatesInListResultErro
 ) {
 	expectedModuleName := "some-module"
 	expectedChannel := "some-channel"
-	expectedFQDN := "some-fqdn"
+	expectedComponentName := "example.org/some-module/backend"
 	status := createStatus()
 	templateError := common.ErrNoTemplatesInListResult
 
 	result, err := fromerror.GenerateModuleStatusFromError(templateError, expectedModuleName, expectedChannel,
-		expectedFQDN, status)
+		expectedComponentName, status)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
@@ -162,7 +172,8 @@ func TestGenerateModuleStatusFromError_WhenCalledWithNoTemplatesInListResultErro
 	// Module info is used for creating a new status
 	assert.Equal(t, expectedModuleName, result.Name)
 	assert.Equal(t, expectedChannel, result.Channel)
-	assert.Equal(t, expectedFQDN, result.FQDN)
+	assert.Equal(t, expectedComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.Equal(t, expectedComponentName, result.OCMComponentName)
 
 	assert.Equal(t, shared.StateWarning, result.State)
 	assert.Equal(t, templateError.Error(), result.Message)
@@ -181,32 +192,34 @@ func TestGenerateModuleStatusFromError_WhenCalledWithoutTemplateError_ReturnsErr
 func TestGenerateModuleStatusFromError_WhenCalledWithNilStatus_ReturnsNewDefaultModuleStatus(t *testing.T) {
 	expectedName := "some-module"
 	expectedChannel := "some-channel"
-	expectedFQDN := "some-fqdn"
+	expectedComponentName := "example.org/some-module/backend"
 	templateError := errors.New("some-error")
 
-	result, err := fromerror.GenerateModuleStatusFromError(templateError, expectedName, expectedChannel, expectedFQDN,
-		nil)
+	result, err := fromerror.GenerateModuleStatusFromError(templateError, expectedName, expectedChannel,
+		expectedComponentName, nil)
 
 	assert.NotNil(t, result)
 	require.NoError(t, err)
 	assert.Equal(t, expectedName, result.Name)
 	assert.Equal(t, expectedChannel, result.Channel)
-	assert.Equal(t, expectedFQDN, result.FQDN)
+	assert.Equal(t, expectedComponentName, result.FQDN) //nolint:staticcheck // Ensure backward compatibility
+	assert.Equal(t, expectedComponentName, result.OCMComponentName)
 }
 
 // Resource creator helper functions
 
 func createStatus() *v1beta2.ModuleStatus {
 	return &v1beta2.ModuleStatus{
-		Name:     "test-module",
-		Channel:  "test-channel",
-		FQDN:     "test-fqdn",
-		Version:  "test-version",
-		Message:  "test-message",
-		State:    shared.StateReady,
-		Manifest: createTrackingObject(),
-		Template: createTrackingObject(),
-		Resource: createTrackingObject(),
+		Name:             "test-module",
+		Channel:          "test-channel",
+		FQDN:             "example.org/default-module/backend", // Ensure backward compatibility
+		OCMComponentName: "example.org/default-module/backend",
+		Version:          "test-version",
+		Message:          "test-message",
+		State:            shared.StateReady,
+		Manifest:         createTrackingObject(),
+		Template:         createTrackingObject(),
+		Resource:         createTrackingObject(),
 	}
 }
 

--- a/internal/service/kyma/status/modules/generator/generator.go
+++ b/internal/service/kyma/status/modules/generator/generator.go
@@ -16,8 +16,8 @@ var (
 	ErrModuleNeedsManifest                = errors.New("module needs either manifest or template error")
 )
 
-type GenerateFromErrorFunc func(err error, moduleName, desiredChannel, fqdn string,
-	status *v1beta2.ModuleStatus) (*v1beta2.ModuleStatus, error)
+type GenerateFromErrorFunc func(err error, moduleName, desiredChannel,
+	ocmComponentName string, status *v1beta2.ModuleStatus) (*v1beta2.ModuleStatus, error)
 
 type ModuleStatusGenerator struct {
 	generateFromErrorFunc GenerateFromErrorFunc
@@ -43,7 +43,7 @@ func (m *ModuleStatusGenerator) GenerateModuleStatus(module *modulecommon.Module
 
 	if module.TemplateInfo.Err != nil {
 		return m.generateFromErrorFunc(module.TemplateInfo.Err, module.ModuleName, module.TemplateInfo.DesiredChannel,
-			module.FQDN, currentStatus)
+			module.OCMComponentName, currentStatus)
 	}
 
 	// This nil pointer check is for defensive programming and should never occur in a production environment.
@@ -56,11 +56,12 @@ func (m *ModuleStatusGenerator) GenerateModuleStatus(module *modulecommon.Module
 	manifestAPIVersion, manifestKind := manifest.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	templateAPIVersion, templateKind := module.TemplateInfo.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	moduleStatus := &v1beta2.ModuleStatus{
-		Name:    module.ModuleName,
-		FQDN:    module.FQDN,
-		State:   manifest.Status.State,
-		Channel: module.TemplateInfo.DesiredChannel,
-		Version: manifest.Spec.Version,
+		Name:             module.ModuleName,
+		FQDN:             module.OCMComponentName, // Set for backwards compatibility
+		OCMComponentName: module.OCMComponentName,
+		State:            manifest.Status.State,
+		Channel:          module.TemplateInfo.DesiredChannel,
+		Version:          manifest.Spec.Version,
 		Manifest: &v1beta2.TrackingObject{
 			PartialMeta: v1beta2.PartialMeta{
 				Name:       manifest.GetName(),

--- a/internal/service/kyma/status/modules/generator/generator_test.go
+++ b/internal/service/kyma/status/modules/generator/generator_test.go
@@ -115,7 +115,7 @@ func TestGenerateModuleStatus_WhenCalledWithTemplateAndManifest_CreatesMinimalMo
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, module.ModuleName, result.Name)
-	assert.Equal(t, module.FQDN, result.FQDN)
+	assert.Equal(t, module.OCMComponentName, result.OCMComponentName)
 	assert.Equal(t, shared.State("test-state"), result.State)
 	assert.Equal(t, "test-channel", result.Channel)
 
@@ -190,8 +190,8 @@ func TestGenerateModuleStatus_WhenModuleIsUnmanaged_StateIsUnmanagedAndTrackingO
 
 func createModule() *modulecommon.Module {
 	return &modulecommon.Module{
-		ModuleName: "test-module",
-		FQDN:       "test-fqdn",
+		ModuleName:       "test-module",
+		OCMComponentName: "example.org/some-module",
 		TemplateInfo: &templatelookup.ModuleTemplateInfo{
 			DesiredChannel: "test-channel",
 			ModuleTemplate: createModuleTemplate(),

--- a/internal/service/kyma/status/modules/generator/generator_test.go
+++ b/internal/service/kyma/status/modules/generator/generator_test.go
@@ -116,7 +116,7 @@ func TestGenerateModuleStatus_WhenCalledWithTemplateAndManifest_CreatesMinimalMo
 	assert.NotNil(t, result)
 	assert.Equal(t, module.ModuleName, result.Name)
 	assert.Equal(t, module.OCMComponentName, result.OCMComponentName)
-	assert.Equal(t, module.OCMComponentName, result.FQDN)
+	assert.Equal(t, module.OCMComponentName, result.FQDN) //nolint:staticcheck // Must be set for backward compatibility
 	assert.Equal(t, shared.State("test-state"), result.State)
 	assert.Equal(t, "test-channel", result.Channel)
 

--- a/internal/service/kyma/status/modules/generator/generator_test.go
+++ b/internal/service/kyma/status/modules/generator/generator_test.go
@@ -116,6 +116,7 @@ func TestGenerateModuleStatus_WhenCalledWithTemplateAndManifest_CreatesMinimalMo
 	assert.NotNil(t, result)
 	assert.Equal(t, module.ModuleName, result.Name)
 	assert.Equal(t, module.OCMComponentName, result.OCMComponentName)
+	assert.Equal(t, module.OCMComponentName, result.FQDN)
 	assert.Equal(t, shared.State("test-state"), result.State)
 	assert.Equal(t, "test-channel", result.Channel)
 

--- a/internal/service/kyma/status/modules/handler.go
+++ b/internal/service/kyma/status/modules/handler.go
@@ -58,10 +58,11 @@ func (m *StatusHandler) UpdateModuleStatuses(ctx context.Context, kyma *v1beta2.
 		newModuleStatus, err := m.statusGenerator.GenerateModuleStatus(module, moduleStatus)
 		if err != nil {
 			newModuleStatus = &v1beta2.ModuleStatus{
-				Name:    module.ModuleName,
-				FQDN:    module.FQDN,
-				State:   shared.StateError,
-				Message: err.Error(),
+				Name:             module.ModuleName,
+				FQDN:             module.OCMComponentName, // Set for backward compatibility
+				OCMComponentName: module.OCMComponentName,
+				State:            shared.StateError,
+				Message:          err.Error(),
 			}
 		}
 		if exists {

--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -16,18 +16,18 @@ import (
 type (
 	Modules []*Module
 	Module  struct {
-		ModuleName   string
-		FQDN         string
-		TemplateInfo *templatelookup.ModuleTemplateInfo
-		Manifest     *v1beta2.Manifest
-		Enabled      bool
-		IsUnmanaged  bool
+		ModuleName       string
+		OCMComponentName string
+		TemplateInfo     *templatelookup.ModuleTemplateInfo
+		Manifest         *v1beta2.Manifest
+		Enabled          bool
+		IsUnmanaged      bool
 	}
 )
 
 func (m *Module) Logger(base logr.Logger) logr.Logger {
 	return base.WithValues(
-		"fqdn", m.FQDN,
+		"componentName", m.OCMComponentName,
 		"module", m.Manifest.GetName(),
 		"channel", m.TemplateInfo.Spec.Channel, //nolint:staticcheck // legacy Channel field
 		"templateGeneration", m.TemplateInfo.GetGeneration(),
@@ -60,7 +60,8 @@ func (m *Module) ApplyDefaultMetaToManifest(kyma *v1beta2.Kyma) {
 	if anns == nil {
 		anns = make(map[string]string)
 	}
-	anns[shared.FQDN] = m.FQDN
+	anns[shared.FQDN] = m.OCMComponentName
+	anns[shared.OCMComponentName] = m.OCMComponentName
 	if m.IsUnmanaged {
 		anns[shared.UnmanagedAnnotation] = shared.EnableLabelValue
 	}
@@ -81,17 +82,22 @@ func (m *Module) ContainsExpectedOwnerReference(ownerName string) bool {
 
 const maxModuleNameLength = validation.DNS1035LabelMaxLength
 
-// CreateModuleName takes a FQDN and a prefix and generates a human-readable unique interpretation of
+// CreateModuleName takes an OCM Component Name and a prefix and generates a human-readable unique interpretation of
 // a name combination.
 // e.g. kyma-project.io/module/some-module and default-id => "default-id-some-module-34180237"
 // e.g. domain.com/some-module and default-id => "default-id-some-module-1238916".
-func CreateModuleName(fqdn, prefix, moduleName string) string {
-	splitFQDN := strings.Split(fqdn, "/")
-	lastPartOfFQDN := splitFQDN[len(splitFQDN)-1]
+func CreateModuleName(compName, prefix, moduleName string) string {
+	lastSeparatorIdx := strings.LastIndexByte(compName, '/')
+	var lastPart string
+	if lastSeparatorIdx != -1 {
+		lastPart = compName[lastSeparatorIdx+1:]
+	} else {
+		lastPart = compName
+	}
 	hash := fnv.New32()
-	_, _ = hash.Write([]byte(fqdn + moduleName))
-	hashedFQDN := hash.Sum32()
-	name := fmt.Sprintf("%s-%s-%v", prefix, lastPartOfFQDN, hashedFQDN)
+	_, _ = hash.Write([]byte(compName + moduleName))
+	hashed := hash.Sum32()
+	name := fmt.Sprintf("%s-%s-%v", prefix, lastPart, hashed)
 	if len(name) >= maxModuleNameLength {
 		name = name[:maxModuleNameLength-1]
 	}

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -124,30 +124,35 @@ func createModule() *modulecommon.Module {
 
 func TestCreateModuleName(t *testing.T) {
 	tests := []struct {
+		testName      string
 		componentName string
 		prefix        string
 		moduleName    string
 		expected      string
 	}{
 		{
+			testName:      "Standard component name",
 			componentName: "kyma-project.io/module/some-module",
 			prefix:        "default-id",
 			moduleName:    "module1",
 			expected:      "default-id-some-module-1831772875",
 		},
 		{
+			testName:      "Short component name",
 			componentName: "example.org/some-module",
 			prefix:        "default-id",
 			moduleName:    "module1",
 			expected:      "default-id-some-module-1457091198",
 		},
 		{
+			testName:      "Very long component name",
 			componentName: "example.org/this-is-a-very-long-component-name-that-exceeds-the-maximum-length",
 			prefix:        "default-id",
 			moduleName:    "module1",
 			expected:      "default-id-this-is-a-very-long-component-name-that-exceeds-the",
 		},
 		{
+			testName:      "Component name with invalid structure",
 			componentName: "simple-component",
 			prefix:        "default-id",
 			moduleName:    "module1",
@@ -156,7 +161,7 @@ func TestCreateModuleName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.moduleName, func(t *testing.T) {
+		t.Run(tt.testName, func(t *testing.T) {
 			result := modulecommon.CreateModuleName(tt.componentName, tt.prefix, tt.moduleName)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -95,6 +95,7 @@ func TestApplyDefaultMetaToManifest_WhenCalled_SetsOCMAnnotation(t *testing.T) {
 
 	resultAnnotations := module.Manifest.GetAnnotations()
 	assert.Equal(t, "example.org/some-module/backend", resultAnnotations["operator.kyma-project.io/ocm-component-name"])
+	assert.Equal(t, "example.org/some-module/backend", resultAnnotations["operator.kyma-project.io/fqdn"])
 }
 
 func TestApplyDefaultMetaToManifest_WhenCalledWithUnmanaged_SetsUnmanagedAnnotation(t *testing.T) {

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -86,15 +86,15 @@ func TestApplyDefaultMetaToManifest_WhenCalled_SetsManagedByLabel(t *testing.T) 
 	assert.Equal(t, "lifecycle-manager", resultLabels["operator.kyma-project.io/managed-by"])
 }
 
-func TestApplyDefaultMetaToManifest_WhenCalled_SetsFQDNAnnotation(t *testing.T) {
+func TestApplyDefaultMetaToManifest_WhenCalled_SetsOCMAnnotation(t *testing.T) {
 	module := createModule()
-	module.FQDN = "some-fqdn"
+	module.OCMComponentName = "example.org/some-module/backend"
 	kyma := &v1beta2.Kyma{}
 
 	module.ApplyDefaultMetaToManifest(kyma)
 
 	resultAnnotations := module.Manifest.GetAnnotations()
-	assert.Equal(t, "some-fqdn", resultAnnotations["operator.kyma-project.io/fqdn"])
+	assert.Equal(t, "example.org/some-module/backend", resultAnnotations["operator.kyma-project.io/ocm-component-name"])
 }
 
 func TestApplyDefaultMetaToManifest_WhenCalledWithUnmanaged_SetsUnmanagedAnnotation(t *testing.T) {
@@ -118,5 +118,46 @@ func createModule() *modulecommon.Module {
 				ObjectMeta: apimetav1.ObjectMeta{},
 			},
 		},
+	}
+}
+
+func TestCreateModuleName(t *testing.T) {
+	tests := []struct {
+		componentName string
+		prefix        string
+		moduleName    string
+		expected      string
+	}{
+		{
+			componentName: "kyma-project.io/module/some-module",
+			prefix:        "default-id",
+			moduleName:    "module1",
+			expected:      "default-id-some-module-1831772875",
+		},
+		{
+			componentName: "example.org/some-module",
+			prefix:        "default-id",
+			moduleName:    "module1",
+			expected:      "default-id-some-module-1457091198",
+		},
+		{
+			componentName: "example.org/this-is-a-very-long-component-name-that-exceeds-the-maximum-length",
+			prefix:        "default-id",
+			moduleName:    "module1",
+			expected:      "default-id-this-is-a-very-long-component-name-that-exceeds-the",
+		},
+		{
+			componentName: "simple-component",
+			prefix:        "default-id",
+			moduleName:    "module1",
+			expected:      "default-id-simple-component-3590401810",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.moduleName, func(t *testing.T) {
+			result := modulecommon.CreateModuleName(tt.componentName, tt.prefix, tt.moduleName)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/pkg/templatelookup/regular.go
+++ b/pkg/templatelookup/regular.go
@@ -171,7 +171,7 @@ func markInvalidSkewUpdate(ctx context.Context, moduleTemplateInfo *ModuleTempla
 	}
 
 	logger := logf.FromContext(ctx)
-	checkLog := logger.WithValues("module", moduleStatus.FQDN,
+	checkLog := logger.WithValues("module", moduleStatus.OCMComponentName,
 		"template", moduleTemplateInfo.Name,
 		"newTemplateGeneration", moduleTemplateInfo.GetGeneration(),
 		"previousTemplateGeneration", moduleStatus.Template.GetGeneration(),

--- a/pkg/templatelookup/regular.go
+++ b/pkg/templatelookup/regular.go
@@ -173,7 +173,7 @@ func markInvalidSkewUpdate(ctx context.Context, moduleTemplateInfo *ModuleTempla
 	logger := logf.FromContext(ctx)
 	ocmComponentName := moduleStatus.OCMComponentName
 	if ocmComponentName == "" {
-		ocmComponentName = moduleStatus.FQDN // nolint:staticcheck // Fallback for the time of migration
+		ocmComponentName = moduleStatus.FQDN //nolint:staticcheck // Fallback for the time of migration
 	}
 	checkLog := logger.WithValues("module", ocmComponentName,
 		"template", moduleTemplateInfo.Name,

--- a/pkg/templatelookup/regular.go
+++ b/pkg/templatelookup/regular.go
@@ -171,7 +171,11 @@ func markInvalidSkewUpdate(ctx context.Context, moduleTemplateInfo *ModuleTempla
 	}
 
 	logger := logf.FromContext(ctx)
-	checkLog := logger.WithValues("module", moduleStatus.OCMComponentName,
+	ocmComponentName := moduleStatus.OCMComponentName
+	if ocmComponentName == "" {
+		ocmComponentName = moduleStatus.FQDN // nolint:staticcheck // Fallback for the time of migration
+	}
+	checkLog := logger.WithValues("module", ocmComponentName,
 		"template", moduleTemplateInfo.Name,
 		"newTemplateGeneration", moduleTemplateInfo.GetGeneration(),
 		"previousTemplateGeneration", moduleStatus.Template.GetGeneration(),

--- a/pkg/testutils/ocm.go
+++ b/pkg/testutils/ocm.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/descriptor/types/ocmidentity"
 )
 
-const DefaultFQDN = "kyma-project.io/module/template-operator"
+const DefaultComponentName = "kyma-project.io/module/template-operator"
 
 // MustNewComponentId is a convenience ComponentId constructor that panics if name or version are not provided.
 func MustNewComponentId(name, version string) *ocmidentity.ComponentId {

--- a/tests/integration/controller/kyma/manifest_test.go
+++ b/tests/integration/controller/kyma/manifest_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Modules can only be referenced via module name", Ordered, func
 	moduleReferencedWithLabel := NewTestModule("random-module", v1beta2.DefaultChannel)
 	moduleReferencedWithNamespacedName := NewTestModule(
 		v1beta2.DefaultChannel+shared.Separator+"random-module", v1beta2.DefaultChannel)
-	moduleReferencedWithFQDN := NewTestModuleWithFixName("kyma-project.io/module/"+"random-module",
+	moduleReferencedWithComponentName := NewTestModuleWithFixName("kyma-project.io/module/"+"random-module",
 		v1beta2.DefaultChannel, "")
 	kyma.Spec.Modules = append(kyma.Spec.Modules, moduleReferencedWithLabel)
 	RegisterDefaultLifecycleForKyma(kyma)
@@ -273,11 +273,11 @@ var _ = Describe("Modules can only be referenced via module name", Ordered, func
 		})
 	})
 
-	Context("When operator is referenced by FQDN", func() {
+	Context("When operator is referenced by Component Name", func() {
 		It("cannot find the operator", func() {
 			Eventually(ModuleTemplateExists).
 				WithContext(ctx).
-				WithArguments(kcpClient, moduleReferencedWithFQDN, kyma).
+				WithArguments(kcpClient, moduleReferencedWithComponentName, kyma).
 				Should(Equal(ErrNotFound))
 		})
 	})

--- a/tests/integration/controller/mandatorymodule/deletion/controller_test.go
+++ b/tests/integration/controller/mandatorymodule/deletion/controller_test.go
@@ -39,6 +39,10 @@ var _ = Describe("Mandatory Module Deletion", Ordered, func() {
 					WithContext(ctx).
 					WithArguments(kcpClient, shared.FQDN, FullOCMName(mandatoryModuleName)).
 					Should(Succeed())
+				Eventually(MandatoryManifestExistsWithLabelAndAnnotation).
+					WithContext(ctx).
+					WithArguments(kcpClient, shared.OCMComponentName, FullOCMName(mandatoryModuleName)).
+					Should(Succeed())
 				By("And mandatory finalizer is added to the mandatory ModuleReleaseMeta", func() {
 					Eventually(mandatoryMrmFinalizerExists).
 						WithContext(ctx).
@@ -59,7 +63,11 @@ var _ = Describe("Mandatory Module Deletion", Ordered, func() {
 		It("Then mandatory Manifest is deleted", func() {
 			Eventually(MandatoryManifestExistsWithLabelAndAnnotation).
 				WithContext(ctx).
-				WithArguments(kcpClient, shared.FQDN, DefaultFQDN).
+				WithArguments(kcpClient, shared.FQDN, DefaultComponentName).
+				Should(Not(Succeed()))
+			Eventually(MandatoryManifestExistsWithLabelAndAnnotation).
+				WithContext(ctx).
+				WithArguments(kcpClient, shared.OCMComponentName, DefaultComponentName).
 				Should(Not(Succeed()))
 			By("And finalizer is removed from mandatory ModuleReleaseMeta", func() {
 				Eventually(mandatoryMrmFinalizerExists).
@@ -87,7 +95,10 @@ func registerControlPlaneLifecycleForKyma(kyma *v1beta2.Kyma, mandatoryModuleNam
 
 	mandatoryManifest := NewTestManifest("mandatory-module")
 	mandatoryManifest.Labels[shared.IsMandatoryModule] = "true"
-	mandatoryManifest.Annotations = map[string]string{shared.FQDN: moduleReleaseMeta.Spec.OcmComponentName}
+	mandatoryManifest.Annotations = map[string]string{
+		shared.FQDN:             moduleReleaseMeta.Spec.OcmComponentName,
+		shared.OCMComponentName: moduleReleaseMeta.Spec.OcmComponentName,
+	}
 	mandatoryManifest.Spec.Version = mandatoryModuleVersion
 
 	BeforeAll(func() {

--- a/tests/integration/controller/mandatorymodule/installation/controller_test.go
+++ b/tests/integration/controller/mandatorymodule/installation/controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Skipping Mandatory Module Installation", Ordered, func() {
 		It("When Kyma has 'skip-reconciliation' label, then no Mandatory Module Manifest should be created", func() {
 			Eventually(checkMandatoryManifestForKyma).
 				WithContext(ctx).
-				WithArguments(kyma, DefaultFQDN).
+				WithArguments(kyma, DefaultComponentName).
 				Should(Equal(ErrNoMandatoryManifest))
 		})
 	})
@@ -126,7 +126,7 @@ func registerControlPlaneLifecycleForKyma(kyma *v1beta2.Kyma, mandatoryModuleNam
 	})
 }
 
-func checkMandatoryManifestForKyma(ctx context.Context, kyma *v1beta2.Kyma, fqdn string) error {
+func checkMandatoryManifestForKyma(ctx context.Context, kyma *v1beta2.Kyma, componentName string) error {
 	manifestList := v1beta2.ManifestList{}
 	if err := kcpClient.List(ctx, &manifestList, &client.ListOptions{
 		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.KymaName: kyma.Name}),
@@ -135,7 +135,8 @@ func checkMandatoryManifestForKyma(ctx context.Context, kyma *v1beta2.Kyma, fqdn
 	}
 	for _, manifest := range manifestList.Items {
 		if manifest.OwnerReferences[0].Name == kyma.Name &&
-			manifest.Annotations[shared.FQDN] == fqdn {
+			manifest.Annotations[shared.FQDN] == componentName &&
+			manifest.Annotations[shared.OCMComponentName] == componentName {
 			return nil
 		}
 	}


### PR DESCRIPTION
**Description**
Instead of changing existing identifiers in our API, this PR just adds new names, keeping the old ones still working. It's a first step in the migration process. The migration is not as safe as a proper K8s API version upgrade, but should be "safe enough" to avoid any outages due to a contract broken on our side.

For comparison, the direct name change of Kyma attribute and/or Manifest annotation name could:
- break any external logic that is currently using that data - and we're not aware of it.
- leave the objects in K8s etcd in an inconsistent state: The "new CRD" would not have the "old" field, but the objects already stored in etcd contain it. 

Changes proposed in this pull request:

- Introduce new attribute in Kyma module status: `ocmComponentName`
- Introduce new annotation in Manifest CR: `operator.kyma-project.io/ocm-component-name`
- Old attribute/annotation still works - for the time of migration - but are marked as deprecated
- Rename `fqdn` identifiers in the source code accordingly (this can be done safely)
- Update documentation

**Related issue(s)**
#2625
