### PR TITLE
fix: Update RBAC for new eventing API

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -35,3 +35,10 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -24,6 +24,16 @@ rules:
       - patch
       - watch
   - apiGroups:
+      - "events.k8s.io"
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
       - ""
     resources:
       - secrets

--- a/tests/e2e/rbac_privileges_test.go
+++ b/tests/e2e/rbac_privileges_test.go
@@ -56,6 +56,12 @@ var _ = Describe("RBAC Privileges", func() {
 					Resources: []string{"events"},
 					Verbs:     []string{"create", "patch"},
 				},
+				{
+					APIGroups: []string{"events.k8s.io"},
+					Resources: []string{"events"},
+					Verbs:     []string{"create", "patch"},
+				},
+
 			}
 			Expect(GetRoleBindingRolePolicyRules(ctx,
 				kcpClient,
@@ -72,6 +78,11 @@ var _ = Describe("RBAC Privileges", func() {
 				},
 				{
 					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs:     []string{"create", "get", "list", "patch", "watch"},
+				},
+				{
+					APIGroups: []string{"events.k8s.io"},
 					Resources: []string{"events"},
 					Verbs:     []string{"create", "get", "list", "patch", "watch"},
 				},


### PR DESCRIPTION

**Description**

Add RBAC for new eventing API that we "enabled" when bumping `controller-runtime` version in #3099 
Note: I haven't removed access to the "old" (core) events API, as it's hard to tell if it's really never used by the controller-runtime internally. In addition I don't think this is a problem.

Changes proposed in this pull request:

- Add missing RBAC for `events.k8s.io`.

