### PR TITLE
chore: Introduce `--module-upgrade-rollout-max-delay` flag

### DIFF
--- a/.github/actions/deploy-lifecycle-manager-e2e/action.yml
+++ b/.github/actions/deploy-lifecycle-manager-e2e/action.yml
@@ -122,7 +122,10 @@ runs:
           value: --kyma-requeue-error-interval=1h
         - op: add
           path: /spec/template/spec/containers/0/args/-
-          value: --kyma-requeue-busy-interval=1s" >> requeue-interval-patch.yaml
+          value: --kyma-requeue-busy-interval=1s
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: --module-update-rollout-max-delay=10s" >> requeue-interval-patch.yaml
         cat requeue-interval-patch.yaml
         kustomize edit add patch --path requeue-interval-patch.yaml --kind Deployment
         popd

--- a/.github/actions/deploy-lifecycle-manager-e2e/action.yml
+++ b/.github/actions/deploy-lifecycle-manager-e2e/action.yml
@@ -125,7 +125,7 @@ runs:
           value: --kyma-requeue-busy-interval=1s
         - op: add
           path: /spec/template/spec/containers/0/args/-
-          value: --module-update-rollout-max-delay=10s" >> requeue-interval-patch.yaml
+          value: --module-upgrade-rollout-max-delay=10s" >> requeue-interval-patch.yaml
         cat requeue-interval-patch.yaml
         kustomize edit add patch --path requeue-interval-patch.yaml --kind Deployment
         popd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -268,8 +268,7 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 	mtRepo := mtrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace)
 	manifestRepo := manifestrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace)
 
-	mrmEventHandler := watchcmpse.ComposeMrmEventHandler(kymaRepo,
-		flagVar.KymaRequeueSuccessInterval) // re-using the success interval as the max delay for spreading out requeues
+	mrmEventHandler := watchcmpse.ComposeMrmEventHandler(kymaRepo, flagVar.ModuleUpdateRolloutMaxDelay)
 	mtEventHandlerMapFunc := watchcmpse.ComposeTemplateChangeHandlerMapFunc(kymaRepo)
 	mandatoryMrmHandlerMapFunc := watchcmpse.ComposeMandatoryMrmChangeHandlerMapFunc(mrmRepo, kymaRepo)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -268,7 +268,7 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 	mtRepo := mtrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace)
 	manifestRepo := manifestrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace)
 
-	mrmEventHandler := watchcmpse.ComposeMrmEventHandler(kymaRepo, flagVar.ModuleUpdateRolloutMaxDelay)
+	mrmEventHandler := watchcmpse.ComposeMrmEventHandler(kymaRepo, flagVar.ModuleUpgradeRolloutMaxDelay)
 	mtEventHandlerMapFunc := watchcmpse.ComposeTemplateChangeHandlerMapFunc(kymaRepo)
 	mandatoryMrmHandlerMapFunc := watchcmpse.ComposeMandatoryMrmChangeHandlerMapFunc(mrmRepo, kymaRepo)
 

--- a/docs/contributor/12-klm-arguments.md
+++ b/docs/contributor/12-klm-arguments.md
@@ -29,7 +29,7 @@ This document provides a list of flags that can be set to control some specific 
 | `manifest-requeue-jitter-percentage`                 | float    | 0.02          | Percentage range for the jitter applied to the requeue interval e.g. 0.1 means +/- 10% of the interval         |
 | `mandatory-module-deletion-requeue-success-interval` | duration | 30s           | Duration after which a Kyma CR in the Ready state is enqueued for mandatory module deletion reconciliation     |
 | `watcher-requeue-success-interval`                   | duration | 30s           | Duration after which a Watcher CR in the Ready state is enqueued for reconciliation                            |
-| `module-upgrade-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
+| `module-upgrade-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a new version is assigned to a channel in a ModuleReleaseMeta, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
 | `istio-gateway-secret-requeue-success-interval`      | duration | 5m            | Duration after which the Istio Gateway Secret is enqueued after successful reconciliation                      |
 | `istio-gateway-secret-requeue-error-interval`        | duration | 2s            | Duration after which the Istio Gateway Secret is enqueued after unsuccessful reconciliation                    |
 

--- a/docs/contributor/12-klm-arguments.md
+++ b/docs/contributor/12-klm-arguments.md
@@ -29,7 +29,7 @@ This document provides a list of flags that can be set to control some specific 
 | `manifest-requeue-jitter-percentage`                 | float    | 0.02          | Percentage range for the jitter applied to the requeue interval e.g. 0.1 means +/- 10% of the interval         |
 | `mandatory-module-deletion-requeue-success-interval` | duration | 30s           | Duration after which a Kyma CR in the Ready state is enqueued for mandatory module deletion reconciliation     |
 | `watcher-requeue-success-interval`                   | duration | 30s           | Duration after which a Watcher CR in the Ready state is enqueued for reconciliation                            |
-| `module-upgrade-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a new version is assigned to a channel in a ModuleReleaseMeta, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
+| `module-upgrade-rollout-max-delay`                    | duration | 5m            | Maximum random delay added when requeueing Kyma CRs after a new module version is assigned to a channel in a ModuleReleaseMeta. Spreads reconciliations over time to avoid rate-limiting bursts. Set to `0` to disable spreading. |
 | `istio-gateway-secret-requeue-success-interval`      | duration | 5m            | Duration after which the Istio Gateway Secret is enqueued after successful reconciliation                      |
 | `istio-gateway-secret-requeue-error-interval`        | duration | 2s            | Duration after which the Istio Gateway Secret is enqueued after unsuccessful reconciliation                    |
 

--- a/docs/contributor/12-klm-arguments.md
+++ b/docs/contributor/12-klm-arguments.md
@@ -29,7 +29,7 @@ This document provides a list of flags that can be set to control some specific 
 | `manifest-requeue-jitter-percentage`                 | float    | 0.02          | Percentage range for the jitter applied to the requeue interval e.g. 0.1 means +/- 10% of the interval         |
 | `mandatory-module-deletion-requeue-success-interval` | duration | 30s           | Duration after which a Kyma CR in the Ready state is enqueued for mandatory module deletion reconciliation     |
 | `watcher-requeue-success-interval`                   | duration | 30s           | Duration after which a Watcher CR in the Ready state is enqueued for reconciliation                            |
-| `module-update-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
+| `module-upgrade-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
 | `istio-gateway-secret-requeue-success-interval`      | duration | 5m            | Duration after which the Istio Gateway Secret is enqueued after successful reconciliation                      |
 | `istio-gateway-secret-requeue-error-interval`        | duration | 2s            | Duration after which the Istio Gateway Secret is enqueued after unsuccessful reconciliation                    |
 

--- a/docs/contributor/12-klm-arguments.md
+++ b/docs/contributor/12-klm-arguments.md
@@ -29,6 +29,7 @@ This document provides a list of flags that can be set to control some specific 
 | `manifest-requeue-jitter-percentage`                 | float    | 0.02          | Percentage range for the jitter applied to the requeue interval e.g. 0.1 means +/- 10% of the interval         |
 | `mandatory-module-deletion-requeue-success-interval` | duration | 30s           | Duration after which a Kyma CR in the Ready state is enqueued for mandatory module deletion reconciliation     |
 | `watcher-requeue-success-interval`                   | duration | 30s           | Duration after which a Watcher CR in the Ready state is enqueued for reconciliation                            |
+| `module-update-rollout-max-delay`                    | duration | 5m            | Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading |
 | `istio-gateway-secret-requeue-success-interval`      | duration | 5m            | Duration after which the Istio Gateway Secret is enqueued after successful reconciliation                      |
 | `istio-gateway-secret-requeue-error-interval`        | duration | 2s            | Duration after which the Istio Gateway Secret is enqueued after unsuccessful reconciliation                    |
 

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -151,9 +151,9 @@ func DefineFlagVar() *FlagVar {
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
 	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
 		DefaultModuleUpgradeRolloutMaxDelay,
-		"Upper bound for the random delay applied when requeueing Kymas after a"+
-			" ModuleReleaseMeta channel update, to spread reconciliations and avoid"+
-			" rate-limiting bursts. Set to 0 to disable spreading.")
+		"Upper bound for the random delay applied when requeueing Kymas after a "+
+			"new version is assigned to a channel in a ModuleReleaseMeta, to spread reconciliations and "+
+			"avoid rate-limiting bursts. Set to 0 to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
 		DefaultMandatoryModuleRequeueSuccessInterval,
 		"Duration after which a Kyma in Ready state is enqueued for mandatory module installation reconciliation.")

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -149,10 +149,11 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.KymaRequeueBusyInterval, "kyma-requeue-busy-interval",
 		DefaultKymaRequeueBusyInterval,
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
-	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
+	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-update-rollout-max-delay",
 		DefaultModuleUpgradeRolloutMaxDelay,
-		"Upper bound for the random delay applied when requeueing Kymas after a new version is assigned to a channel in a"+
-			" ModuleReleaseMeta, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading.")
+		"Upper bound for the random delay applied when requeueing Kymas after a"+
+			" ModuleReleaseMeta channel update, to spread reconciliations and avoid"+
+			" rate-limiting bursts. Set to 0 to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
 		DefaultMandatoryModuleRequeueSuccessInterval,
 		"Duration after which a Kyma in Ready state is enqueued for mandatory module installation reconciliation.")

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -149,7 +149,7 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.KymaRequeueBusyInterval, "kyma-requeue-busy-interval",
 		DefaultKymaRequeueBusyInterval,
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
-	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-update-rollout-max-delay",
+	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
 		DefaultModuleUpgradeRolloutMaxDelay,
 		"Upper bound for the random delay applied when requeueing Kymas after a"+
 			" ModuleReleaseMeta channel update, to spread reconciliations and avoid"+

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -28,7 +28,7 @@ const (
 	DefaultMandatoryModuleRequeueSuccessInterval                        = 30 * time.Second
 	DefaultMandatoryModuleDeletionRequeueSuccessInterval                = 30 * time.Second
 	DefaultWatcherRequeueSuccessInterval                                = 1 * time.Minute
-	DefaultModuleUpdateRolloutMaxDelay                                  = 5 * time.Minute
+	DefaultModuleUpgradeRolloutMaxDelay                                 = 5 * time.Minute
 	DefaultClientQPS                                                    = 1000
 	DefaultClientBurst                                                  = 2000
 	DefaultSkrClientQPS                                                 = 50
@@ -149,8 +149,8 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.KymaRequeueBusyInterval, "kyma-requeue-busy-interval",
 		DefaultKymaRequeueBusyInterval,
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
-	flag.DurationVar(&flagVar.ModuleUpdateRolloutMaxDelay, "module-update-rollout-max-delay",
-		DefaultModuleUpdateRolloutMaxDelay,
+	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
+		DefaultModuleUpgradeRolloutMaxDelay,
 		"Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update,"+
 			" to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
@@ -327,7 +327,7 @@ type FlagVar struct {
 	KymaRequeueErrInterval                         time.Duration
 	KymaRequeueBusyInterval                        time.Duration
 	KymaRequeueWarningInterval                     time.Duration
-	ModuleUpdateRolloutMaxDelay                    time.Duration
+	ModuleUpgradeRolloutMaxDelay                   time.Duration
 	ManifestRequeueSuccessInterval                 time.Duration
 	ManifestRequeueErrInterval                     time.Duration
 	ManifestRequeueBusyInterval                    time.Duration

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -151,8 +151,8 @@ func DefineFlagVar() *FlagVar {
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
 	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
 		DefaultModuleUpgradeRolloutMaxDelay,
-		"Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update,"+
-			" to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading.")
+		"Upper bound for the random delay applied when requeueing Kymas after a new version is assigned to a channel in a"+
+			" ModuleReleaseMeta, to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
 		DefaultMandatoryModuleRequeueSuccessInterval,
 		"Duration after which a Kyma in Ready state is enqueued for mandatory module installation reconciliation.")

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -151,9 +151,9 @@ func DefineFlagVar() *FlagVar {
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
 	flag.DurationVar(&flagVar.ModuleUpgradeRolloutMaxDelay, "module-upgrade-rollout-max-delay",
 		DefaultModuleUpgradeRolloutMaxDelay,
-		"Upper bound for the random delay applied when requeueing Kymas after a "+
-			"new version is assigned to a channel in a ModuleReleaseMeta, to spread reconciliations and "+
-			"avoid rate-limiting bursts. Set to 0 to disable spreading.")
+		"Maximum random delay added when requeueing Kyma CRs after a new module version is "+
+			"assigned to a channel in a ModuleReleaseMeta. Spreads reconciliations over time to avoid "+
+			"rate-limiting bursts. Set to `0` to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
 		DefaultMandatoryModuleRequeueSuccessInterval,
 		"Duration after which a Kyma in Ready state is enqueued for mandatory module installation reconciliation.")

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -28,6 +28,7 @@ const (
 	DefaultMandatoryModuleRequeueSuccessInterval                        = 30 * time.Second
 	DefaultMandatoryModuleDeletionRequeueSuccessInterval                = 30 * time.Second
 	DefaultWatcherRequeueSuccessInterval                                = 1 * time.Minute
+	DefaultModuleUpdateRolloutMaxDelay                                  = 5 * time.Minute
 	DefaultClientQPS                                                    = 1000
 	DefaultClientBurst                                                  = 2000
 	DefaultSkrClientQPS                                                 = 50
@@ -148,6 +149,10 @@ func DefineFlagVar() *FlagVar {
 	flag.DurationVar(&flagVar.KymaRequeueBusyInterval, "kyma-requeue-busy-interval",
 		DefaultKymaRequeueBusyInterval,
 		"Duration after which a Kyma in Processing state is enqueued for reconciliation.")
+	flag.DurationVar(&flagVar.ModuleUpdateRolloutMaxDelay, "module-update-rollout-max-delay",
+		DefaultModuleUpdateRolloutMaxDelay,
+		"Upper bound for the random delay applied when requeueing Kymas after a ModuleReleaseMeta channel update,"+
+			" to spread reconciliations and avoid rate-limiting bursts. Set to 0 to disable spreading.")
 	flag.DurationVar(&flagVar.MandatoryModuleRequeueSuccessInterval, "mandatory-module-requeue-success-interval",
 		DefaultMandatoryModuleRequeueSuccessInterval,
 		"Duration after which a Kyma in Ready state is enqueued for mandatory module installation reconciliation.")
@@ -322,6 +327,7 @@ type FlagVar struct {
 	KymaRequeueErrInterval                         time.Duration
 	KymaRequeueBusyInterval                        time.Duration
 	KymaRequeueWarningInterval                     time.Duration
+	ModuleUpdateRolloutMaxDelay                    time.Duration
 	ManifestRequeueSuccessInterval                 time.Duration
 	ManifestRequeueErrInterval                     time.Duration
 	ManifestRequeueBusyInterval                    time.Duration

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -84,6 +84,11 @@ func Test_ConstantFlags(t *testing.T) {
 			expectedValue: (1 * time.Minute).String(),
 		},
 		{
+			constName:     "DefaultModuleUpdateRolloutMaxDelay",
+			constValue:    DefaultModuleUpdateRolloutMaxDelay.String(),
+			expectedValue: (5 * time.Minute).String(),
+		},
+		{
 			constName:     "DefaultClientQPS",
 			constValue:    strconv.Itoa(DefaultClientQPS),
 			expectedValue: "1000",

--- a/internal/pkg/flags/flags_test.go
+++ b/internal/pkg/flags/flags_test.go
@@ -84,8 +84,8 @@ func Test_ConstantFlags(t *testing.T) {
 			expectedValue: (1 * time.Minute).String(),
 		},
 		{
-			constName:     "DefaultModuleUpdateRolloutMaxDelay",
-			constValue:    DefaultModuleUpdateRolloutMaxDelay.String(),
+			constName:     "DefaultModuleUpgradeRolloutMaxDelay",
+			constValue:    DefaultModuleUpgradeRolloutMaxDelay.String(),
 			expectedValue: (5 * time.Minute).String(),
 		},
 		{

--- a/tests/e2e/modulereleasemeta_watch_trigger_test.go
+++ b/tests/e2e/modulereleasemeta_watch_trigger_test.go
@@ -9,9 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// This test is disabled because watch mechanism now has a random delay between 0 and the kyma success requeue interval
-// The kyma success requeue interval is set to 1 hour for this test. The test, therefore, times out.
-var _ = PDescribe("ModuleReleaseMeta Watch Trigger", Ordered, func() {
+var _ = Describe("ModuleReleaseMeta Watch Trigger", Ordered, func() {
 	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
 	module := NewTemplateOperator(v1beta2.DefaultChannel)
 	moduleCR := NewTestModuleCR(RemoteNamespace)


### PR DESCRIPTION
**Introduce `--module-upgrade-rollout-max-delay` flag**

Adds a dedicated flag to control the upper bound of the random jitter applied when spreading Kyma reconciliations after a `ModuleReleaseMeta` channel update. Previously, `KymaRequeueSuccessInterval` (default 5m) was reused for this purpose, which caused the `modulereleasemeta-watch-trigger` e2e test to time out since Kymas could be delayed up to 1 hour before reconciliation.

**Changes:**
- New flag `--module-upgrade-rollout-max-delay` (default `5m`) replaces the reused success interval in `MrmEventHandler`
- Re-enables the previously skipped `modulereleasemeta-watch-trigger` test
- E2e test patches the flag to `10s` for the `modulereleasemeta-watch-trigger` test, making it reliable again