### PR TITLE
feat: Enable Restricted Modules when defaulted

### DIFF
--- a/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
+++ b/.github/actions/deploy-template-operator-with-modulereleasemeta/action.yml
@@ -24,7 +24,8 @@ runs:
       if: ${{ matrix.e2e-test != 'mandatory-module' &&
         matrix.e2e-test != 'mandatory-module-metrics' &&
         matrix.e2e-test != 'watcher-zero-downtime' &&
-        matrix.e2e-test != 'oci-reg-cred-secret'
+        matrix.e2e-test != 'oci-reg-cred-secret' &&
+        matrix.e2e-test != 'restricted-default-module'
         }}
       shell: bash
       run: |
@@ -44,7 +45,8 @@ runs:
       if: ${{ matrix.e2e-test != 'mandatory-module' &&
         matrix.e2e-test != 'mandatory-module-metrics' &&
         matrix.e2e-test != 'watcher-zero-downtime' &&
-        matrix.e2e-test != 'oci-reg-cred-secret'
+        matrix.e2e-test != 'oci-reg-cred-secret' &&
+        matrix.e2e-test != 'restricted-default-module'
         }}
       shell: bash
       run: |
@@ -65,7 +67,8 @@ runs:
       if: ${{ matrix.e2e-test != 'mandatory-module' &&
         matrix.e2e-test != 'mandatory-module-metrics' &&
         matrix.e2e-test != 'watcher-zero-downtime' &&
-        matrix.e2e-test != 'oci-reg-cred-secret'
+        matrix.e2e-test != 'oci-reg-cred-secret' &&
+        matrix.e2e-test != 'restricted-default-module'
         }}
       shell: bash
       run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -90,6 +90,7 @@ jobs:
           - simulate-skr-secret-rotation-evict-client-cache
           - skr-image-pull-secret-sync
           - gateway-secret-server-cert-metric
+          - restricted-default-module
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -120,7 +121,8 @@ jobs:
           cache-dependency-path: lifecycle-manager/go.sum
       - name: Setup test clusters
         if: ${{ matrix.e2e-test != 'mandatory-module' &&
-                matrix.e2e-test != 'mandatory-module-metrics' }}
+                matrix.e2e-test != 'mandatory-module-metrics' &&
+                matrix.e2e-test != 'restricted-default-module' }}
         uses: ./lifecycle-manager/.github/actions/setup-test-clusters
         with:
           k8s_version: ${{ steps.configuration.outputs.k8s_version }}
@@ -133,7 +135,8 @@ jobs:
       - name: Deploy lifecycle-manager
         if: ${{ matrix.e2e-test != 'mandatory-module' &&
                 matrix.e2e-test != 'mandatory-module-metrics'&&
-                matrix.e2e-test != 'gateway-secret-server-cert-metric'  }}
+                matrix.e2e-test != 'gateway-secret-server-cert-metric' &&
+                matrix.e2e-test != 'restricted-default-module' }}
         uses: ./lifecycle-manager/.github/actions/deploy-lifecycle-manager-e2e
         with:
           klm_version_tag: ${{ steps.configuration.outputs.klm_version_tag }}
@@ -141,7 +144,8 @@ jobs:
       - name: Deploy template-operator
         if: ${{ matrix.e2e-test != 'mandatory-module' &&
                 matrix.e2e-test != 'mandatory-module-metrics'&&
-                matrix.e2e-test != 'gateway-secret-server-cert-metric'  }}
+                matrix.e2e-test != 'gateway-secret-server-cert-metric' &&
+                matrix.e2e-test != 'restricted-default-module' }}
         uses: ./lifecycle-manager/.github/actions/deploy-template-operator-with-modulereleasemeta
         with:
           module_version: ${{ steps.configuration.outputs.template_operator_version }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -125,6 +125,8 @@ linters:
           alias: kymalookupcmpse
         - pkg: github.com/kyma-project/lifecycle-manager/cmd/composition/watch
           alias: watchcmpse
+        - pkg: github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule
+          alias: restrictedmodulecmpse
         - pkg: github.com/kyma-project/lifecycle-manager/tests/integration/commontestutils/skrcontextimpl
           alias: testskrcontext
         - pkg: github.com/kyma-project/lifecycle-manager/internal/errors
@@ -171,6 +173,8 @@ linters:
           alias: kymadeletionsvc
         - pkg: github.com/kyma-project/lifecycle-manager/internal/service/kyma/lookup
           alias: kymalookupsvc
+        - pkg: github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule
+          alias: restrictedmodulesvc
         - pkg: github.com/kyma-project/lifecycle-manager/internal/repository/watcher/certificate/errors
           alias: certerror
         - pkg: github.com/kyma-project/lifecycle-manager/internal/repository/watcher/certificate/certmanager/certificate

--- a/cmd/composition/service/restrictedmodule/defaulter.go
+++ b/cmd/composition/service/restrictedmodule/defaulter.go
@@ -1,15 +1,15 @@
 package restrictedmodule
 
-import "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
+import restrictedmodulesvc "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
 
 func ComposeDefaulter(restrictedDefaultModules []string,
-	moduleReleaseMetaRepo restrictedmodule.ModuleReleaseMetaRepository,
-	kymaRepo restrictedmodule.KymaRepository,
-) *restrictedmodule.Defaulter {
-	return restrictedmodule.NewDefaulter(
+	moduleReleaseMetaRepo restrictedmodulesvc.ModuleReleaseMetaRepository,
+	kymaRepo restrictedmodulesvc.KymaRepository,
+) *restrictedmodulesvc.Defaulter {
+	return restrictedmodulesvc.NewDefaulter(
 		restrictedDefaultModules,
 		moduleReleaseMetaRepo,
 		kymaRepo,
-		restrictedmodule.RestrictedModuleMatch,
+		restrictedmodulesvc.RestrictedModuleMatch,
 	)
 }

--- a/cmd/composition/service/restrictedmodule/defaulter.go
+++ b/cmd/composition/service/restrictedmodule/defaulter.go
@@ -1,0 +1,15 @@
+package restrictedmodule
+
+import "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
+
+func ComposeDefaulter(restrictedDefaultModules []string,
+	moduleReleaseMetaRepo restrictedmodule.ModuleReleaseMetaRepository,
+	kymaRepo restrictedmodule.KymaRepository,
+) *restrictedmodule.Defaulter {
+	return restrictedmodule.NewDefaulter(
+		restrictedDefaultModules,
+		moduleReleaseMetaRepo,
+		kymaRepo,
+		restrictedmodule.RestrictedModuleMatch,
+	)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ import (
 	kymalookupcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/kyma/lookup"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/mandatorymodule/deletion"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/mandatorymodule/installation"
+	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
 	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
 	"github.com/kyma-project/lifecycle-manager/internal"
@@ -94,6 +95,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator/fromerror"
 	"github.com/kyma-project/lifecycle-manager/internal/service/manifest/orphan"
+	restrictedmodulesvc "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/internal/service/skrclient"
 	skrclientcache "github.com/kyma-project/lifecycle-manager/internal/service/skrclient/cache"
 	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
@@ -294,9 +296,15 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 
 	kymaLookupSvc := kymalookupcmpse.ComposeKymaLookupService(kymaRepo)
 
+	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(
+		flagVar.GetRestrictedDefaultModules(),
+		mrmRepo,
+		kymaRepo,
+	)
+
 	setupKymaReconciler(mgr, descriptorProvider, skrContextProvider, eventRecorder, flagVar, options, skrWebhookManager,
 		kymaMetrics, logger, maintenanceWindow, ociRegistry.GetReference(), kymaDeletionSvc, kymaLookupSvc,
-		mtEventHandlerMapFunc, mrmEventHandler)
+		mtEventHandlerMapFunc, mrmEventHandler, restrictedModuleDefaulter)
 	setupManifestReconciler(mgr, flagVar, options, sharedMetrics, mandatoryModulesMetrics, accessManagerService, logger,
 		eventRecorder, kymaRepo)
 	setupMandatoryModuleReconciler(mgr, descriptorProvider, mrmRepo, mtRepo, flagVar, options, mandatoryModulesMetrics,
@@ -424,6 +432,7 @@ func setupKymaReconciler(mgr ctrl.Manager, descriptorProvider *provider.CachedDe
 	setupLog logr.Logger, maintenanceWindow maintenancewindows.MaintenanceWindow, ociRegistry string,
 	kymaDeletionSvc *kymadeletionsvc.Service, kymaLookupSvc *kymalookupsvc.Service,
 	mtEventHandlerMapFunc handler.MapFunc, mrmEventHandler *mrmwatch.EventHandler,
+	restrictedModuleDefaulter *restrictedmodulesvc.Defaulter,
 ) {
 	options.RateLimiter = internal.RateLimiter(flagVar.FailureBaseDelay,
 		flagVar.FailureMaxDelay, flagVar.RateLimiterFrequency, flagVar.RateLimiterBurst)
@@ -473,11 +482,12 @@ func setupKymaReconciler(mgr ctrl.Manager, descriptorProvider *provider.CachedDe
 			flagVar.RemoteSyncNamespace),
 		TemplateLookup: templatelookup.NewTemplateLookup(kcpClient, descriptorProvider,
 			moduleTemplateInfoLookup),
-		Config:          kymaReconcilerConfig,
-		DeletionMetrics: deletionMetricsWriter,
-		DeletionEvents:  resultEventRecorder,
-		DeletionService: kymaDeletionSvc,
-		LookupService:   kymaLookupSvc,
+		Config:            kymaReconcilerConfig,
+		DeletionMetrics:   deletionMetricsWriter,
+		DeletionEvents:    resultEventRecorder,
+		DeletionService:   kymaDeletionSvc,
+		LookupService:     kymaLookupSvc,
+		RestrictedModules: restrictedModuleDefaulter,
 	}).SetupWithManager(
 		mgr, options, kyma.SetupOptions{
 			ListenerAddr:   flagVar.KymaListenerAddr,

--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -139,6 +139,8 @@ type Reconciler struct {
 // Reconcile reconciles Kyma resources.
 //
 // See https://github.com/kyma-project/lifecycle-manager/issues/2943.
+//
+//nolint:funlen // disable for kyma controller until further refactoring
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logf.FromContext(ctx)
 	logger.V(log.DebugLevel).Info("Kyma reconciliation started")

--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -99,6 +99,10 @@ type SkrSyncService interface {
 	SyncImagePullSecret(ctx context.Context, kyma types.NamespacedName) error
 }
 
+type RestrictedModules interface {
+	Default(ctx context.Context, kyma *v1beta2.Kyma) error
+}
+
 // ReconcilerConfig holds configuration values for the Kyma Reconciler.
 // Usually read from flags or environment variables.
 type ReconcilerConfig struct {
@@ -125,10 +129,11 @@ type Reconciler struct {
 	RemoteCatalog  *remote.RemoteCatalog
 	TemplateLookup *templatelookup.TemplateLookup
 
-	DeletionMetrics DeletionMetricWriter
-	DeletionEvents  DeletionEventRecorder
-	DeletionService DeletionService
-	LookupService   LookupService
+	DeletionMetrics   DeletionMetricWriter
+	DeletionEvents    DeletionEventRecorder
+	DeletionService   DeletionService
+	LookupService     LookupService
+	RestrictedModules RestrictedModules
 }
 
 // Reconcile reconciles Kyma resources.
@@ -152,6 +157,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("KymaController: %w", err)
 	}
 
+	err := r.RestrictedModules.Default(ctx, kyma)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("KymaController: failed to default restricted modules: %w", err)
+	}
+
 	status.InitConditions(kyma, r.WatcherEnabled(), r.SkrImagePullSecretSyncEnabled())
 
 	if kyma.SkipReconciliation() && kyma.DeletionTimestamp.IsZero() {
@@ -159,7 +169,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: r.Success}, nil
 	}
 
-	err := r.SkrContextFactory.Init(ctx, kyma.GetNamespacedName())
+	err = r.SkrContextFactory.Init(ctx, kyma.GetNamespacedName())
 	if !kyma.DeletionTimestamp.IsZero() && errors.Is(err, accessmanager.ErrAccessSecretNotFound) {
 		return r.handleDeletedSkr(ctx, req, kyma)
 	}

--- a/internal/repository/kyma/kyma_repo.go
+++ b/internal/repository/kyma/kyma_repo.go
@@ -78,3 +78,10 @@ func (r *Repository) DropFinalizer(ctx context.Context, kymaName string, finaliz
 		),
 	)
 }
+
+func (r *Repository) Update(ctx context.Context, kyma *v1beta2.Kyma) error {
+	if err := r.client.Update(ctx, kyma); err != nil {
+		return fmt.Errorf("failed to update Kyma %s in namespace %s: %w", kyma.Name, r.namespace, err)
+	}
+	return nil
+}

--- a/internal/repository/kyma/kyma_repo_update_test.go
+++ b/internal/repository/kyma/kyma_repo_update_test.go
@@ -63,6 +63,7 @@ func newKyma(name, namespace string) *v1beta2.Kyma {
 
 type writerStub struct {
 	client.Client
+
 	err error
 }
 

--- a/internal/repository/kyma/kyma_repo_update_test.go
+++ b/internal/repository/kyma/kyma_repo_update_test.go
@@ -1,0 +1,71 @@
+package kyma_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+)
+
+func Test_Update_WhenClientReturnsNotFound_ReturnNotFoundError(t *testing.T) {
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{
+		Group:    "v1beta2",
+		Resource: "kyma",
+	}, kymaName)
+	kymaClient := kymarepo.NewRepository(&writerStub{err: notFoundErr}, kymaNamespace)
+	kyma := newKyma(kymaName, kymaNamespace)
+
+	err := kymaClient.Update(t.Context(), kyma)
+
+	require.Error(t, err)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func Test_Update_WhenClientReturnsGenericError_ReturnError(t *testing.T) {
+	kymaClient := kymarepo.NewRepository(&writerStub{err: assert.AnError}, kymaNamespace)
+	kyma := newKyma(kymaName, kymaNamespace)
+
+	err := kymaClient.Update(t.Context(), kyma)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func Test_Update_WhenClientSucceeds_ReturnNoError(t *testing.T) {
+	kymaClient := kymarepo.NewRepository(&writerStub{}, kymaNamespace)
+	kyma := newKyma(kymaName, kymaNamespace)
+
+	err := kymaClient.Update(t.Context(), kyma)
+
+	require.NoError(t, err)
+}
+
+// Helper functions
+
+func newKyma(name, namespace string) *v1beta2.Kyma {
+	return &v1beta2.Kyma{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+// Writer stub
+
+type writerStub struct {
+	client.Client
+	err error
+}
+
+func (c *writerStub) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return c.err
+}

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -42,12 +42,16 @@ func NewDefaulter(restrictedDefaultModules []string,
 // Default adds restricted default modules to Kyma if they are not already enabled and
 // if the kymaSelector defined in the module's ModuleReleaseMeta matches the provided Kyma.
 func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
+	if !kyma.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
 	// nothing to do
 	if len(d.restrictedDefaultModules) == 0 {
 		return nil
 	}
 
-	numEnabledModules := len(kyma.Spec.Modules)
+	alreadyDefaultedModules := len(kyma.Spec.Modules)
 
 	// First try to append all default modules and then update the Kyma if there are any changes.
 	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail
@@ -81,7 +85,7 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	}
 
 	// nothing to do
-	if numEnabledModules == len(kyma.Spec.Modules) {
+	if alreadyDefaultedModules == len(kyma.Spec.Modules) {
 		return nil
 	}
 

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -1,0 +1,112 @@
+package restrictedmodule
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type ModuleReleaseMetaRepository interface {
+	Get(ctx context.Context, moduleName string) (*v1beta2.ModuleReleaseMeta, error)
+}
+
+type KymaRepository interface {
+	Update(ctx context.Context, kyma *v1beta2.Kyma) error
+}
+
+type RestrictedModuleMatchFunc = func(mrm *v1beta2.ModuleReleaseMeta, kyma *v1beta2.Kyma) (bool, error)
+
+type Defaulter struct {
+	restrictedDefaultModules []string
+	moduleReleaseMetaRepo    ModuleReleaseMetaRepository
+	kymaRepo                 KymaRepository
+	matchFunc                RestrictedModuleMatchFunc
+}
+
+func NewDefaulter(restrictedDefaultModules []string,
+	moduleReleaseMetaRepo ModuleReleaseMetaRepository,
+	kymaRepo KymaRepository,
+	matchFunc RestrictedModuleMatchFunc,
+) *Defaulter {
+	return &Defaulter{
+		restrictedDefaultModules: restrictedDefaultModules,
+		moduleReleaseMetaRepo:    moduleReleaseMetaRepo,
+		kymaRepo:                 kymaRepo,
+		matchFunc:                matchFunc,
+	}
+}
+
+// Default adds restricted default modules to Kyma if they are not already enabled and
+// if the kymaSelector defined in the module's ModuleReleaseMeta matches the provided Kyma.
+func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
+	// nothing to do
+	if len(d.restrictedDefaultModules) == 0 {
+		return nil
+	}
+
+	numEnabledModules := len(kyma.Spec.Modules)
+
+	// we first try to append all default modules and then update the Kyma if there are any changes.
+	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail.
+	for _, moduleName := range d.restrictedDefaultModules {
+		log := logf.FromContext(ctx).WithValues("module", moduleName, "kyma", kyma.Name)
+
+		if skipAlreadyEnabled(kyma, moduleName) {
+			log.Info("Skipping defaulting as module is already enabled")
+			continue
+		}
+
+		log.Info("Defaulting restricted module")
+
+		mrm, err := d.moduleReleaseMetaRepo.Get(ctx, moduleName)
+		if err != nil {
+			log.Error(err, "Failed to get ModuleReleaseMeta")
+			continue
+		}
+
+		match, err := d.matchFunc(mrm, kyma)
+		if err != nil {
+			log.Error(err, "Failed to match ModuleReleaseMeta")
+			continue
+		}
+
+		if !match {
+			continue
+		}
+
+		addModule(kyma, moduleName)
+	}
+
+	// only if updating the Kyma with the defaulted modules fails, we return an error.
+	if numEnabledModules != len(kyma.Spec.Modules) {
+		if err := d.kymaRepo.Update(ctx, kyma); err != nil {
+			logf.FromContext(ctx).Error(err, "Failed to update Kyma with defaulted restricted module")
+			return fmt.Errorf("Failed to update Kyma %s with defaulted restricted modules %s: %w",
+				kyma.Name,
+				d.restrictedDefaultModules,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func skipAlreadyEnabled(kyma *v1beta2.Kyma, moduleName string) bool {
+	for _, module := range kyma.Spec.Modules {
+		if module.Name == moduleName {
+			return true
+		}
+	}
+	return false
+}
+
+func addModule(kyma *v1beta2.Kyma, moduleName string) {
+	kyma.Spec.Modules = append(kyma.Spec.Modules, v1beta2.Module{
+		Name:                 moduleName,
+		CustomResourcePolicy: v1beta2.CustomResourcePolicyCreateAndDelete,
+		Managed:              true,
+	})
+}

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -42,12 +42,19 @@ func NewDefaulter(restrictedDefaultModules []string,
 // Default adds restricted default modules to Kyma if they are not already enabled and
 // if the kymaSelector defined in the module's ModuleReleaseMeta matches the provided Kyma.
 func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
+	log := logf.FromContext(ctx).WithValues(
+		"kyma", kyma.Name,
+		"service", "restricted module defaulter",
+	)
+
 	if !kyma.GetDeletionTimestamp().IsZero() {
+		log.Info("Skipping as Kyma is Deleting")
 		return nil
 	}
 
 	// nothing to do
 	if len(d.restrictedDefaultModules) == 0 {
+		log.Info("Skipping as there are no restriced default modules configured")
 		return nil
 	}
 
@@ -56,34 +63,31 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	// First try to append all default modules and then update the Kyma if there are any changes.
 	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail
 	for _, moduleName := range d.restrictedDefaultModules {
-		log := logf.FromContext(ctx).WithValues(
-			"module", moduleName,
-			"kyma", kyma.Name,
-			"service", "restricted module defaulter",
-		)
+		moduleLog := log.WithValues("module", moduleName)
 
 		if skipAlreadyEnabled(kyma, moduleName) {
-			log.Info("Skipping as module is already enabled")
+			moduleLog.Info("Skipping as module is already enabled")
 			continue
 		}
 
 		mrm, err := d.moduleReleaseMetaRepo.Get(ctx, moduleName)
 		if err != nil {
-			log.Error(err, "Failed to get ModuleReleaseMeta")
+			moduleLog.Error(err, "Failed to get ModuleReleaseMeta")
 			continue
 		}
 
 		match, err := d.matchFunc(mrm, kyma)
 		if err != nil {
-			log.Error(err, "Failed to get Kyma selector from ModuleReleaseMeta")
+			moduleLog.Error(err, "Failed to get Kyma selector from ModuleReleaseMeta")
 			continue
 		}
 
 		if !match {
-			log.Info("Kyma does not match selector from ModuleReleaseMeta")
+			moduleLog.Info("Kyma does not match selector from ModuleReleaseMeta")
 			continue
 		}
 
+		moduleLog.Info("Adding restricted default module to Kyma spec")
 		addModule(kyma, moduleName)
 	}
 
@@ -94,15 +98,9 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 
 	// only if updating the Kyma with the restricted default modules fails, we return an error.
 	if err := d.kymaRepo.Update(ctx, kyma); err != nil {
-		logf.FromContext(ctx).
-			WithValues("kyma", kyma.Name,
-				"modules", d.restrictedDefaultModules,
-				"service", "restricted module defaulter",
-			).
-			Error(err, "Failed to update Kyma")
-		return fmt.Errorf("failed to update Kyma %s with restricted default modules %v: %w",
+		log.Error(err, "Failed to update Kyma")
+		return fmt.Errorf("failed to update Kyma %s with restricted default modules: %w",
 			kyma.Name,
-			d.restrictedDefaultModules,
 			err,
 		)
 	}

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -48,13 +48,10 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	)
 
 	if !kyma.GetDeletionTimestamp().IsZero() {
-		log.Info("Skipping as Kyma is Deleting")
 		return nil
 	}
 
-	// nothing to do
 	if len(d.restrictedDefaultModules) == 0 {
-		log.Info("Skipping as there are no restriced default modules configured")
 		return nil
 	}
 
@@ -65,8 +62,7 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	for _, moduleName := range d.restrictedDefaultModules {
 		moduleLog := log.WithValues("module", moduleName)
 
-		if skipAlreadyEnabled(kyma, moduleName) {
-			moduleLog.Info("Skipping as module is already enabled")
+		if isAlreadyEnabled(kyma, moduleName) {
 			continue
 		}
 
@@ -83,7 +79,6 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 		}
 
 		if !match {
-			moduleLog.Info("Kyma does not match selector from ModuleReleaseMeta")
 			continue
 		}
 
@@ -108,7 +103,7 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	return nil
 }
 
-func skipAlreadyEnabled(kyma *v1beta2.Kyma, moduleName string) bool {
+func isAlreadyEnabled(kyma *v1beta2.Kyma, moduleName string) bool {
 	for _, module := range kyma.Spec.Modules {
 		if module.Name == moduleName {
 			return true

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -56,14 +56,16 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	// First try to append all default modules and then update the Kyma if there are any changes.
 	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail
 	for _, moduleName := range d.restrictedDefaultModules {
-		log := logf.FromContext(ctx).WithValues("module", moduleName, "kyma", kyma.Name)
+		log := logf.FromContext(ctx).WithValues(
+			"module", moduleName,
+			"kyma", kyma.Name,
+			"service", "restricted module defaulter",
+		)
 
 		if skipAlreadyEnabled(kyma, moduleName) {
-			log.Info("Skipping defaulting as module is already enabled")
+			log.Info("Skipping as module is already enabled")
 			continue
 		}
-
-		log.Info("Defaulting restricted module")
 
 		mrm, err := d.moduleReleaseMetaRepo.Get(ctx, moduleName)
 		if err != nil {
@@ -73,18 +75,19 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 
 		match, err := d.matchFunc(mrm, kyma)
 		if err != nil {
-			log.Error(err, "Kyma does not match ModuleReleaseMeta")
+			log.Error(err, "Failed to get Kyma selector from ModuleReleaseMeta")
 			continue
 		}
 
 		if !match {
+			log.Info("Kyma does not match selector from ModuleReleaseMeta")
 			continue
 		}
 
 		addModule(kyma, moduleName)
 	}
 
-	// nothing to do
+	// nothing updated
 	if alreadyDefaultedModules == len(kyma.Spec.Modules) {
 		return nil
 	}
@@ -92,9 +95,12 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 	// only if updating the Kyma with the restricted default modules fails, we return an error.
 	if err := d.kymaRepo.Update(ctx, kyma); err != nil {
 		logf.FromContext(ctx).
-			WithValues("kyma", kyma.Name, "modules", d.restrictedDefaultModules).
-			Error(err, "Failed to update Kyma with restricted default modules")
-		return fmt.Errorf("failed to update Kyma %s with restricted default modules %s: %w",
+			WithValues("kyma", kyma.Name,
+				"modules", d.restrictedDefaultModules,
+				"service", "restricted module defaulter",
+			).
+			Error(err, "Failed to update Kyma")
+		return fmt.Errorf("failed to update Kyma %s with restricted default modules %v: %w",
 			kyma.Name,
 			d.restrictedDefaultModules,
 			err,

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 )
 
 type ModuleReleaseMetaRepository interface {
@@ -48,8 +49,8 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 
 	numEnabledModules := len(kyma.Spec.Modules)
 
-	// we first try to append all default modules and then update the Kyma if there are any changes.
-	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail.
+	// First try to append all default modules and then update the Kyma if there are any changes.
+	// failing to determine if a module should be defaulted or not should not cause the whole defaulting process to fail
 	for _, moduleName := range d.restrictedDefaultModules {
 		log := logf.FromContext(ctx).WithValues("module", moduleName, "kyma", kyma.Name)
 
@@ -89,7 +90,7 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 		logf.FromContext(ctx).
 			WithValues("kyma", kyma.Name, "modules", d.restrictedDefaultModules).
 			Error(err, "Failed to update Kyma with restricted default modules")
-		return fmt.Errorf("Failed to update Kyma %s with restricted default modules modules %s: %w",
+		return fmt.Errorf("failed to update Kyma %s with restricted default modules %s: %w",
 			kyma.Name,
 			d.restrictedDefaultModules,
 			err,

--- a/internal/service/restrictedmodule/defaulter.go
+++ b/internal/service/restrictedmodule/defaulter.go
@@ -68,7 +68,7 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 
 		match, err := d.matchFunc(mrm, kyma)
 		if err != nil {
-			log.Error(err, "Failed to match ModuleReleaseMeta")
+			log.Error(err, "Kyma does not match ModuleReleaseMeta")
 			continue
 		}
 
@@ -79,16 +79,21 @@ func (d *Defaulter) Default(ctx context.Context, kyma *v1beta2.Kyma) error {
 		addModule(kyma, moduleName)
 	}
 
-	// only if updating the Kyma with the defaulted modules fails, we return an error.
-	if numEnabledModules != len(kyma.Spec.Modules) {
-		if err := d.kymaRepo.Update(ctx, kyma); err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to update Kyma with defaulted restricted module")
-			return fmt.Errorf("Failed to update Kyma %s with defaulted restricted modules %s: %w",
-				kyma.Name,
-				d.restrictedDefaultModules,
-				err,
-			)
-		}
+	// nothing to do
+	if numEnabledModules == len(kyma.Spec.Modules) {
+		return nil
+	}
+
+	// only if updating the Kyma with the restricted default modules fails, we return an error.
+	if err := d.kymaRepo.Update(ctx, kyma); err != nil {
+		logf.FromContext(ctx).
+			WithValues("kyma", kyma.Name, "modules", d.restrictedDefaultModules).
+			Error(err, "Failed to update Kyma with restricted default modules")
+		return fmt.Errorf("Failed to update Kyma %s with restricted default modules modules %s: %w",
+			kyma.Name,
+			d.restrictedDefaultModules,
+			err,
+		)
 	}
 
 	return nil

--- a/internal/service/restrictedmodule/defaulter_test.go
+++ b/internal/service/restrictedmodule/defaulter_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
-	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	restrictedmodulesvc "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
 
 var (
@@ -22,13 +22,13 @@ var (
 
 func Test_Default_Skips_WhenKymaIsBeingDeleted(t *testing.T) {
 	kyma := &v1beta2.Kyma{}
-	now := metav1.NewTime(time.Now())
+	now := apimetav1.NewTime(time.Now())
 	kyma.SetDeletionTimestamp(&now)
 
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc)
@@ -46,7 +46,7 @@ func Test_Default_Skips_WhenNoRestrictedDefaultModules(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter([]string{},
+	defaulter := restrictedmodulesvc.NewDefaulter([]string{},
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc)
@@ -71,7 +71,7 @@ func Test_Default_Skips_WhenAlreadyEnabled(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc)
@@ -83,7 +83,7 @@ func Test_Default_Skips_WhenAlreadyEnabled(t *testing.T) {
 	assert.False(t, kymaRepo.called)
 }
 
-func Test_Defualt_Skips_WhenFailedToGetModuleReleaseMeta(t *testing.T) {
+func Test_Default_Skips_WhenFailedToGetModuleReleaseMeta(t *testing.T) {
 	kyma := &v1beta2.Kyma{}
 
 	mrmRepo := &mrmStub{
@@ -91,7 +91,7 @@ func Test_Defualt_Skips_WhenFailedToGetModuleReleaseMeta(t *testing.T) {
 	}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc)
@@ -110,7 +110,7 @@ func Test_Default_Skips_WhenMatchFuncReturnsError(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		errorMatchFunc,
@@ -130,7 +130,7 @@ func Test_Default_Skips_WhenMatchFuncReturnsFalse(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		negativeMatchFunc,
@@ -152,7 +152,7 @@ func Test_Default_ReturnsError_WhenFailedToUpdateKyma(t *testing.T) {
 		err: assert.AnError,
 	}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc,
@@ -173,7 +173,7 @@ func Test_Default_AppendsModulesAndUpdatesKyma(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc,
@@ -193,7 +193,7 @@ func Test_Default_AppendsModulesAndUpdatesKyma(t *testing.T) {
 	}
 }
 
-func Test_Defualt_AppendsOnlyMissingModules(t *testing.T) {
+func Test_Default_AppendsOnlyMissingModuleAndUpdatesKyma(t *testing.T) {
 	kyma := &v1beta2.Kyma{
 		Spec: v1beta2.KymaSpec{
 			Modules: []v1beta2.Module{
@@ -209,7 +209,7 @@ func Test_Defualt_AppendsOnlyMissingModules(t *testing.T) {
 	mrmRepo := &mrmStub{}
 	kymaRepo := &kymaStub{}
 
-	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+	defaulter := restrictedmodulesvc.NewDefaulter(restrictedDefaultModules,
 		mrmRepo,
 		kymaRepo,
 		positiveMatchFunc,
@@ -242,7 +242,7 @@ func errorMatchFunc(_ *v1beta2.ModuleReleaseMeta, _ *v1beta2.Kyma) (bool, error)
 }
 
 type mrmStub struct {
-	restrictedmodule.ModuleReleaseMetaRepository
+	restrictedmodulesvc.ModuleReleaseMetaRepository
 
 	called      bool
 	moduleNames []string
@@ -257,7 +257,7 @@ func (r *mrmStub) Get(_ context.Context, moduleName string) (*v1beta2.ModuleRele
 }
 
 type kymaStub struct {
-	restrictedmodule.KymaRepository
+	restrictedmodulesvc.KymaRepository
 
 	called bool
 	kyma   *v1beta2.Kyma

--- a/internal/service/restrictedmodule/defaulter_test.go
+++ b/internal/service/restrictedmodule/defaulter_test.go
@@ -1,0 +1,271 @@
+package restrictedmodule_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	"github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	module1                  = random.Name()
+	module2                  = random.Name()
+	restrictedDefaultModules = []string{module1, module2}
+)
+
+func Test_Default_Skips_WhenKymaIsBeingDeleted(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+	now := metav1.NewTime(time.Now())
+	kyma.SetDeletionTimestamp(&now)
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.False(t, mrmRepo.called)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Default_Skips_WhenNoRestrictedDefaultModules(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter([]string{},
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.False(t, mrmRepo.called)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Default_Skips_WhenAlreadyEnabled(t *testing.T) {
+	kyma := &v1beta2.Kyma{
+		Spec: v1beta2.KymaSpec{
+			Modules: []v1beta2.Module{
+				{Name: module1},
+				{Name: module2},
+			},
+		},
+	}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.False(t, mrmRepo.called)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Defualt_Skips_WhenFailedToGetModuleReleaseMeta(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{
+		err: assert.AnError,
+	}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, restrictedDefaultModules)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Default_Skips_WhenMatchFuncReturnsError(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		errorMatchFunc,
+	)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, restrictedDefaultModules)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Default_Skips_WhenMatchFuncReturnsFalse(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		negativeMatchFunc,
+	)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, restrictedDefaultModules)
+	assert.False(t, kymaRepo.called)
+}
+
+func Test_Default_ReturnsError_WhenFailedToUpdateKyma(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{
+		err: assert.AnError,
+	}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc,
+	)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.Error(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, restrictedDefaultModules)
+	assert.True(t, kymaRepo.called)
+	assert.Equal(t, kyma, kymaRepo.kyma)
+}
+
+func Test_Default_AppendsModulesAndUpdatesKyma(t *testing.T) {
+	kyma := &v1beta2.Kyma{}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc,
+	)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, restrictedDefaultModules)
+	assert.True(t, kymaRepo.called)
+	assert.Len(t, kymaRepo.kyma.Spec.Modules, len(restrictedDefaultModules))
+	for _, module := range kymaRepo.kyma.Spec.Modules {
+		assert.Contains(t, restrictedDefaultModules, module.Name)
+		assert.True(t, module.Managed)
+		assert.Equal(t, v1beta2.CustomResourcePolicyCreateAndDelete, string(module.CustomResourcePolicy))
+	}
+}
+
+func Test_Defualt_AppendsOnlyMissingModules(t *testing.T) {
+	kyma := &v1beta2.Kyma{
+		Spec: v1beta2.KymaSpec{
+			Modules: []v1beta2.Module{
+				{
+					Name:                 module1,
+					Managed:              true,
+					CustomResourcePolicy: v1beta2.CustomResourcePolicyCreateAndDelete,
+				},
+			},
+		},
+	}
+
+	mrmRepo := &mrmStub{}
+	kymaRepo := &kymaStub{}
+
+	defaulter := restrictedmodule.NewDefaulter(restrictedDefaultModules,
+		mrmRepo,
+		kymaRepo,
+		positiveMatchFunc,
+	)
+
+	err := defaulter.Default(context.Background(), kyma)
+
+	require.NoError(t, err)
+	assert.True(t, mrmRepo.called)
+	assert.ElementsMatch(t, mrmRepo.moduleNames, []string{module2})
+	assert.True(t, kymaRepo.called)
+	assert.Len(t, kymaRepo.kyma.Spec.Modules, len(restrictedDefaultModules))
+	for _, module := range kymaRepo.kyma.Spec.Modules {
+		assert.Contains(t, restrictedDefaultModules, module.Name)
+		assert.True(t, module.Managed)
+		assert.Equal(t, v1beta2.CustomResourcePolicyCreateAndDelete, string(module.CustomResourcePolicy))
+	}
+}
+
+func positiveMatchFunc(_ *v1beta2.ModuleReleaseMeta, _ *v1beta2.Kyma) (bool, error) {
+	return true, nil
+}
+
+func negativeMatchFunc(_ *v1beta2.ModuleReleaseMeta, _ *v1beta2.Kyma) (bool, error) {
+	return false, nil
+}
+
+func errorMatchFunc(_ *v1beta2.ModuleReleaseMeta, _ *v1beta2.Kyma) (bool, error) {
+	return false, assert.AnError
+}
+
+type mrmStub struct {
+	restrictedmodule.ModuleReleaseMetaRepository
+
+	called      bool
+	moduleNames []string
+	mrm         *v1beta2.ModuleReleaseMeta
+	err         error
+}
+
+func (r *mrmStub) Get(_ context.Context, moduleName string) (*v1beta2.ModuleReleaseMeta, error) {
+	r.called = true
+	r.moduleNames = append(r.moduleNames, moduleName)
+	return r.mrm, r.err
+}
+
+type kymaStub struct {
+	restrictedmodule.KymaRepository
+
+	called bool
+	kyma   *v1beta2.Kyma
+	err    error
+}
+
+func (r *kymaStub) Update(_ context.Context, kyma *v1beta2.Kyma) error {
+	r.called = true
+	r.kyma = kyma
+	return r.err
+}

--- a/internal/service/restrictedmodule/match_test.go
+++ b/internal/service/restrictedmodule/match_test.go
@@ -8,13 +8,13 @@ import (
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-	"github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
+	restrictedmodulesvc "github.com/kyma-project/lifecycle-manager/internal/service/restrictedmodule"
 )
 
 func TestRestrictedModuleMatch_NilModuleReleaseMeta(t *testing.T) {
 	kyma := &v1beta2.Kyma{}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(nil, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(nil, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -23,7 +23,7 @@ func TestRestrictedModuleMatch_NilModuleReleaseMeta(t *testing.T) {
 func TestRestrictedModuleMatch_NilKyma(t *testing.T) {
 	mrm := &v1beta2.ModuleReleaseMeta{Spec: v1beta2.ModuleReleaseMetaSpec{}}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, nil)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, nil)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -33,7 +33,7 @@ func TestRestrictedModuleMatch_NilSelector(t *testing.T) {
 	mrm := &v1beta2.ModuleReleaseMeta{Spec: v1beta2.ModuleReleaseMetaSpec{KymaSelector: nil}}
 	kyma := &v1beta2.Kyma{}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -45,7 +45,7 @@ func TestRestrictedModuleMatch_EmptySelector(t *testing.T) {
 	}
 	kyma := &v1beta2.Kyma{}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -62,7 +62,7 @@ func TestRestrictedModuleMatch_NilLabelsOnKyma(t *testing.T) {
 	kyma := &v1beta2.Kyma{}
 	kyma.SetLabels(nil)
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -80,7 +80,7 @@ func TestRestrictedModuleMatch_MatchLabels_Matches(t *testing.T) {
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"foo": "val1", "env": "production"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.True(t, matched)
@@ -98,7 +98,7 @@ func TestRestrictedModuleMatch_MatchLabels_NoMatch(t *testing.T) {
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"foo": "val2", "env": "staging"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -118,7 +118,7 @@ func TestRestrictedModuleMatch_MatchExpressions_Matches(t *testing.T) {
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"foo": "val3", "tier": "backend"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.True(t, matched)
@@ -138,7 +138,7 @@ func TestRestrictedModuleMatch_MatchExpressions_NoMatch(t *testing.T) {
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"tier": "database"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -163,7 +163,7 @@ func TestRestrictedModuleMatch_MatchLabelsAndExpressions_BothMatch(t *testing.T)
 		}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.True(t, matched)
@@ -184,7 +184,7 @@ func TestRestrictedModuleMatch_MatchLabelsAndExpressions_LabelMatchesExpressionD
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"env": "production", "tier": "database"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -205,7 +205,7 @@ func TestRestrictedModuleMatch_MatchLabelsAndExpressions_ExpressionMatchesLabels
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"env": "staging", "tier": "backend"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	require.NoError(t, err)
 	assert.False(t, matched)
@@ -225,11 +225,11 @@ func TestRestrictedModuleMatch_MatchLabelsAndExpressions_ParseError(t *testing.T
 		ObjectMeta: apimetav1.ObjectMeta{Labels: map[string]string{"env": "production", "tier": "backend"}},
 	}
 
-	matched, err := restrictedmodule.RestrictedModuleMatch(mrm, kyma)
+	matched, err := restrictedmodulesvc.RestrictedModuleMatch(mrm, kyma)
 
 	assert.False(t, matched)
 	require.Error(t, err)
-	require.ErrorIs(t, err, restrictedmodule.ErrSelectorParse)
+	require.ErrorIs(t, err, restrictedmodulesvc.ErrSelectorParse)
 	require.ErrorContains(t, err, "InvalidOperator")
 	require.ErrorContains(t, err, "operator")
 }

--- a/scripts/tests/deploy_modulereleasemeta.sh
+++ b/scripts/tests/deploy_modulereleasemeta.sh
@@ -4,6 +4,10 @@ set -o errexit
 set -E
 set -o pipefail
 
+# Set KEEP_FILE=true to keep the generated module-release-meta.yaml file after deployment.
+# Example: KEEP_FILE=true ./deploy_modulereleasemeta.sh my-module regular:1.0.0
+KEEP_FILE=${KEEP_FILE:-false}
+
 MODULE_NAME=$1
 shift 1
 CHANNELS=("$@")
@@ -29,7 +33,9 @@ done
 kubectl apply -f module-release-meta.yaml
 
 echo "ModuleReleaseMeta created successfully"
-rm -f module-release-meta.yaml
+if [[ "${KEEP_FILE}" != "true" ]]; then
+  rm -f module-release-meta.yaml
+fi
 
 kubectl get modulereleasemeta "${MODULE_NAME}" -n kcp-system -o yaml
 kubectl get moduletemplate -n kcp-system

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -213,3 +213,6 @@ skr-image-pull-secret-sync:
 
 module-api-upgrade-under-blocked-deletion:
 	$(GO_TEST) "Module API Upgrade Under Blocked Deletion"
+
+restricted-default-module:
+	$(MAKE) -f $(MAKEFILE_DIR)/restricted_default_module_test.mk test

--- a/tests/e2e/restricted_default_module_test.go
+++ b/tests/e2e/restricted_default_module_test.go
@@ -30,9 +30,8 @@ var _ = Describe("Restricted Default Modules", Ordered, func() {
 			By("And Module Operator Deployment is ready")
 			Eventually(DeploymentIsReady).
 				WithContext(ctx).
-				WithArguments(skrClient, ModuleResourceName, TestModuleResourceNamespace).
+				WithArguments(skrClient, ModuleDeploymentNameInOlderVersion, TestModuleResourceNamespace).
 				Should(Succeed())
-
 			By("And KCP Kyma CR is in \"Ready\" State")
 			Eventually(KymaIsInState).
 				WithContext(ctx).

--- a/tests/e2e/restricted_default_module_test.go
+++ b/tests/e2e/restricted_default_module_test.go
@@ -1,0 +1,43 @@
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
+	. "github.com/kyma-project/lifecycle-manager/tests/e2e/commontestutils"
+)
+
+var _ = Describe("Restricted Default Modules", Ordered, func() {
+	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	// this global account id is added to the module release meta in the Makefile
+	kyma.Labels["kyma-project.io/global-account-id"] = "f6e5d4c3-b2a1-9087-6543-210fedcba987"
+	moduleCR := NewTestModuleCR(RemoteNamespace)
+
+	InitEmptyKymaBeforeAll(kyma)
+	CleanupKymaAfterAll(kyma)
+
+	Context("Given SKR Cluster", func() {
+		It("Then Module Resources are deployed on SKR cluster", func() {
+			By("And Module CR exists")
+			Eventually(ModuleCRExists).
+				WithContext(ctx).
+				WithArguments(skrClient, moduleCR).
+				Should(Succeed())
+			By("And Module Operator Deployment is ready")
+			Eventually(DeploymentIsReady).
+				WithContext(ctx).
+				WithArguments(skrClient, ModuleResourceName, TestModuleResourceNamespace).
+				Should(Succeed())
+
+			By("And KCP Kyma CR is in \"Ready\" State")
+			Eventually(KymaIsInState).
+				WithContext(ctx).
+				WithArguments(kyma.GetName(), kyma.GetNamespace(), kcpClient, shared.StateReady).
+				Should(Succeed())
+		})
+	})
+})

--- a/tests/e2e/restricted_default_module_test.go
+++ b/tests/e2e/restricted_default_module_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 
 	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
@@ -21,21 +20,26 @@ var _ = Describe("Restricted Default Modules", Ordered, func() {
 	CleanupKymaAfterAll(kyma)
 
 	Context("Given SKR Cluster", func() {
-		It("Then Module Resources are deployed on SKR cluster", func() {
-			By("And Module CR exists")
+		// InitEmptyKymaBeforeAll verified that the Kyma CR is in Ready state on both SKR and KCP
+		It("Then the matching restricted module is enabled on the KCP cluster", func() {
+			Eventually(ContainsModuleInSpec).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), TestModuleName).
+				Should(Succeed())
+			By("And the non-matching restricted module is not enabled on the KCP cluster")
+			Eventually(NotContainsModuleInSpec).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "not-"+TestModuleName).
+				Should(Succeed())
+			By("And the Module CR has been installed on the SKR cluster")
 			Eventually(ModuleCRExists).
 				WithContext(ctx).
 				WithArguments(skrClient, moduleCR).
 				Should(Succeed())
-			By("And Module Operator Deployment is ready")
+			By("And the Module Operator Deployment is ready on the SKR cluster")
 			Eventually(DeploymentIsReady).
 				WithContext(ctx).
 				WithArguments(skrClient, ModuleDeploymentNameInOlderVersion, TestModuleResourceNamespace).
-				Should(Succeed())
-			By("And KCP Kyma CR is in \"Ready\" State")
-			Eventually(KymaIsInState).
-				WithContext(ctx).
-				WithArguments(kyma.GetName(), kyma.GetNamespace(), kcpClient, shared.StateReady).
 				Should(Succeed())
 		})
 	})

--- a/tests/e2e/restricted_default_module_test.mk
+++ b/tests/e2e/restricted_default_module_test.mk
@@ -1,0 +1,51 @@
+.DEFAULT_GOAL := test
+.PHONY: test $(MAKECMDGOALS)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
+
+RESTRICTED_DEFAULT_MODULES ?= template-operator
+GLOBAL_ACCOUNT_ID_1 ?= a1c1d2e3-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+# this global account id is added to the Kyma labels in the test
+GLOBAL_ACCOUNT_ID_2 ?= f6e5d4c3-b2a1-9087-6543-210fedcba987
+
+.PHONY: klm-patch
+klm-patch: kustomize-install
+	@echo "::group::KLM patch"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(LIFECYCLE_MANAGER_DIR)/config/watcher_local_test > /dev/null
+	kustomize edit add patch --kind Deployment --patch \
+		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=$(RESTRICTED_DEFAULT_MODULES)"}]'
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: module-setup
+module-setup:
+	@echo "::group::Test-specific module metadata setup"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(TEMPLATE_OPERATOR_DIR) > /dev/null
+	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh --module-name $(MODULE_NAME) --version $(MODULE_OLDER_VERSION) --deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) --deployable-version $(MODULE_DEPLOYABLE_VERSION)
+	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
+	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["$(GLOBAL_ACCOUNT_ID_1)", "$(GLOBAL_ACCOUNT_ID_2)"]}]' module-release-meta.yaml
+	kubectl apply -f module-release-meta.yaml
+	rm -f module-release-meta.yaml
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: test-run
+test-run: log-tool-versions
+	@echo "::group::Setting kubeconfig variables"
+	@export KCP_KUBECONFIG=$(shell k3d kubeconfig write kcp)
+	@export SKR_KUBECONFIG=$(shell k3d kubeconfig write skr)
+	@echo "::endgroup::"
+
+	@echo "::group::E2E test: Restricted Default Modules"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(E2E_TESTS_DIR) > /dev/null
+	set +e; $(GO) test -timeout 20m -ginkgo.v -ginkgo.focus "Restricted Default Modules"; status=$$?; set -e
+	@popd > /dev/null
+	@echo "::endgroup::"
+	exit $${status}
+
+
+.PHONY: test
+test: create-clusters klm-patch deploy-klm module-setup test-run

--- a/tests/e2e/restricted_default_module_test.mk
+++ b/tests/e2e/restricted_default_module_test.mk
@@ -3,7 +3,7 @@
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
 
-RESTRICTED_DEFAULT_MODULES ?= template-operator
+RESTRICTED_DEFAULT_MODULES ?= $(MODULE_NAME),not-$(MODULE_NAME)
 GLOBAL_ACCOUNT_ID_1 ?= a1c1d2e3-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 # this global account id is added to the Kyma labels in the test
 GLOBAL_ACCOUNT_ID_2 ?= f6e5d4c3-b2a1-9087-6543-210fedcba987
@@ -23,9 +23,17 @@ module-setup:
 	@echo "::group::Test-specific module metadata setup"
 	@export PATH=$(LOCALBIN):$$PATH
 	@pushd $(TEMPLATE_OPERATOR_DIR) > /dev/null
+# First module that matches on the Kyma and therefore should be defaulted
 	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh --module-name $(MODULE_NAME) --version $(MODULE_OLDER_VERSION) --deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) --deployable-version $(MODULE_DEPLOYABLE_VERSION)
 	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
 	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["$(GLOBAL_ACCOUNT_ID_1)", "$(GLOBAL_ACCOUNT_ID_2)"]}]' module-release-meta.yaml
+	kubectl apply -f module-release-meta.yaml
+	rm -f module-release-meta.yaml
+
+# Second module that won't match on the Kyma and therefore should not be defaulted
+	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh --module-name not-$(MODULE_NAME) --version $(MODULE_OLDER_VERSION) --deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) --deployable-version $(MODULE_DEPLOYABLE_VERSION)
+	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh not-$(MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
+	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["DOES-NOT-MATCH"]}]' module-release-meta.yaml
 	kubectl apply -f module-release-meta.yaml
 	rm -f module-release-meta.yaml
 	@popd > /dev/null

--- a/tests/integration/controller/kcp/suite_test.go
+++ b/tests/integration/controller/kcp/suite_test.go
@@ -43,11 +43,13 @@ import (
 	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
 	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
 	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 
 	"github.com/kyma-project/lifecycle-manager/api"
 	"github.com/kyma-project/lifecycle-manager/api/shared"
+	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/internal/controller/kyma"
 	kymadeletionctrl "github.com/kyma-project/lifecycle-manager/internal/controller/kyma/deletion"
 	"github.com/kyma-project/lifecycle-manager/internal/crd"
@@ -222,6 +224,10 @@ var _ = BeforeSuite(func() {
 		flagVar,
 	)
 
+	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
+		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
+
 	err = (&kyma.Reconciler{
 		Client:               kcpClient,
 		SkrContextFactory:    testSkrContextFactory,
@@ -236,10 +242,11 @@ var _ = BeforeSuite(func() {
 		TemplateLookup: templatelookup.NewTemplateLookup(kcpClient,
 			descriptorProvider,
 			moduletemplateinfolookup.NewLookup(kcpClient)),
-		Config:          kymaReconcilerConfig,
-		DeletionMetrics: deletionMetrics,
-		DeletionEvents:  deletionEvents,
-		DeletionService: deletionService,
+		Config:            kymaReconcilerConfig,
+		DeletionMetrics:   deletionMetrics,
+		DeletionEvents:    deletionEvents,
+		DeletionService:   deletionService,
+		RestrictedModules: restrictedModuleDefaulter,
 	}).SetupWithManager(mgr, ctrlruntime.Options{},
 		kyma.SetupOptions{ListenerAddr: UseRandomPort},
 		watchcmpse.ComposeTemplateChangeHandlerMapFunc(

--- a/tests/integration/controller/kcp/suite_test.go
+++ b/tests/integration/controller/kcp/suite_test.go
@@ -29,6 +29,7 @@ import (
 	machineryaml "k8s.io/apimachinery/pkg/util/yaml"
 	k8sclientscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	compdescv2 "ocm.software/ocm/api/ocm/compdesc/versions/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -37,19 +38,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	compdescv2 "ocm.software/ocm/api/ocm/compdesc/versions/v2"
-
-	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
-	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
-	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
-	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
-	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
-	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
-	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
-
 	"github.com/kyma-project/lifecycle-manager/api"
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
+	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
+	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
 	"github.com/kyma-project/lifecycle-manager/internal/controller/kyma"
 	kymadeletionctrl "github.com/kyma-project/lifecycle-manager/internal/controller/kyma/deletion"
 	"github.com/kyma-project/lifecycle-manager/internal/crd"
@@ -59,15 +52,20 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/flags"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
 	"github.com/kyma-project/lifecycle-manager/internal/remote"
+	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
+	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+	mrmrepo "github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	resultevent "github.com/kyma-project/lifecycle-manager/internal/result/event"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator/fromerror"
+	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
 	"github.com/kyma-project/lifecycle-manager/internal/setup"
 	"github.com/kyma-project/lifecycle-manager/pkg/log"
 	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 	"github.com/kyma-project/lifecycle-manager/pkg/templatelookup"
 	"github.com/kyma-project/lifecycle-manager/pkg/templatelookup/moduletemplateinfolookup"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/service/componentdescriptor"
 	"github.com/kyma-project/lifecycle-manager/tests/integration"
 	testskrcontext "github.com/kyma-project/lifecycle-manager/tests/integration/commontestutils/skrcontextimpl"
@@ -75,10 +73,9 @@ import (
 
 	_ "ocm.software/ocm/api/ocm"
 
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -225,7 +222,7 @@ var _ = BeforeSuite(func() {
 	)
 
 	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
-		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		mrmrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
 		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
 
 	err = (&kyma.Reconciler{

--- a/tests/integration/controller/kyma/suite_test.go
+++ b/tests/integration/controller/kyma/suite_test.go
@@ -38,10 +38,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
 	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
 	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
 	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 
@@ -223,6 +225,10 @@ var _ = BeforeSuite(func() {
 		flagVar,
 	)
 
+	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
+		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
+
 	err = (&kyma.Reconciler{
 		Client:               kcpClient,
 		Event:                testEventRec,
@@ -236,10 +242,11 @@ var _ = BeforeSuite(func() {
 		Metrics: kymaMetrics,
 		TemplateLookup: templatelookup.NewTemplateLookup(kcpClient, descriptorProvider,
 			moduletemplateinfolookup.NewLookup(kcpClient)),
-		Config:          kymaReconcilerConfig,
-		DeletionMetrics: deletionMetrics,
-		DeletionEvents:  deletionEvents,
-		DeletionService: deletionService,
+		Config:            kymaReconcilerConfig,
+		DeletionMetrics:   deletionMetrics,
+		DeletionEvents:    deletionEvents,
+		DeletionService:   deletionService,
+		RestrictedModules: restrictedModuleDefaulter,
 	}).SetupWithManager(mgr, ctrlruntime.Options{},
 		kyma.SetupOptions{ListenerAddr: randomPort},
 		watchcmpse.ComposeTemplateChangeHandlerMapFunc(

--- a/tests/integration/controller/kyma/suite_test.go
+++ b/tests/integration/controller/kyma/suite_test.go
@@ -38,17 +38,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/kyma-project/lifecycle-manager/api"
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
 	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
-	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
-	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
-	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
-	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
-	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
-
-	"github.com/kyma-project/lifecycle-manager/api"
-	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/internal/controller/kyma"
 	kymadeletionctrl "github.com/kyma-project/lifecycle-manager/internal/controller/kyma/deletion"
 	"github.com/kyma-project/lifecycle-manager/internal/crd"
@@ -58,15 +52,20 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/flags"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
 	"github.com/kyma-project/lifecycle-manager/internal/remote"
+	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
+	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+	mrmrepo "github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	resultevent "github.com/kyma-project/lifecycle-manager/internal/result/event"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator/fromerror"
+	"github.com/kyma-project/lifecycle-manager/internal/service/skrsync"
 	"github.com/kyma-project/lifecycle-manager/internal/setup"
 	"github.com/kyma-project/lifecycle-manager/pkg/log"
 	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 	"github.com/kyma-project/lifecycle-manager/pkg/templatelookup"
 	"github.com/kyma-project/lifecycle-manager/pkg/templatelookup/moduletemplateinfolookup"
+	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/service/componentdescriptor"
 	"github.com/kyma-project/lifecycle-manager/tests/integration"
 	testskrcontext "github.com/kyma-project/lifecycle-manager/tests/integration/commontestutils/skrcontextimpl"
@@ -74,10 +73,9 @@ import (
 
 	_ "ocm.software/ocm/api/ocm"
 
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -226,7 +224,7 @@ var _ = BeforeSuite(func() {
 	)
 
 	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
-		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		mrmrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
 		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
 
 	err = (&kyma.Reconciler{

--- a/tests/integration/controller/withwatcher/suite_test.go
+++ b/tests/integration/controller/withwatcher/suite_test.go
@@ -51,7 +51,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/remote"
 	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
 	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
-	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
+	mrmrepo "github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	resultevent "github.com/kyma-project/lifecycle-manager/internal/result/event"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator"
@@ -64,10 +64,9 @@ import (
 	testskrcontext "github.com/kyma-project/lifecycle-manager/tests/integration/commontestutils/skrcontextimpl"
 	"github.com/kyma-project/lifecycle-manager/tests/integration/controller/composition"
 
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -203,7 +202,7 @@ var _ = BeforeSuite(func() {
 	)
 
 	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
-		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		mrmrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
 		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
 
 	err = (&kyma.Reconciler{

--- a/tests/integration/controller/withwatcher/suite_test.go
+++ b/tests/integration/controller/withwatcher/suite_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api"
 	"github.com/kyma-project/lifecycle-manager/api/shared"
+	restrictedmodulecmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/service/restrictedmodule"
 	"github.com/kyma-project/lifecycle-manager/cmd/composition/service/skrwebhook"
 	watchcmpse "github.com/kyma-project/lifecycle-manager/cmd/composition/watch"
 	"github.com/kyma-project/lifecycle-manager/internal/controller/kyma"
@@ -50,6 +51,7 @@ import (
 	"github.com/kyma-project/lifecycle-manager/internal/remote"
 	"github.com/kyma-project/lifecycle-manager/internal/repository/istiogateway"
 	kymarepo "github.com/kyma-project/lifecycle-manager/internal/repository/kyma"
+	"github.com/kyma-project/lifecycle-manager/internal/repository/modulereleasemeta"
 	resultevent "github.com/kyma-project/lifecycle-manager/internal/result/event"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/status/modules/generator"
@@ -200,6 +202,10 @@ var _ = BeforeSuite(func() {
 		flagVar,
 	)
 
+	restrictedModuleDefaulter := restrictedmodulecmpse.ComposeDefaulter(flagVar.GetRestrictedDefaultModules(),
+		modulereleasemeta.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),
+		kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace))
+
 	err = (&kyma.Reconciler{
 		Client:               kcpClient,
 		SkrContextFactory:    testSkrContextFactory,
@@ -212,10 +218,11 @@ var _ = BeforeSuite(func() {
 		Metrics:              kymaMetrics,
 		RemoteCatalog: remote.NewRemoteCatalogFromKyma(kcpClient, testSkrContextFactory,
 			flags.DefaultRemoteSyncNamespace),
-		Config:          kymaReconcilerConfig,
-		DeletionMetrics: deletionMetrics,
-		DeletionEvents:  deletionEvents,
-		DeletionService: deletionService,
+		Config:            kymaReconcilerConfig,
+		DeletionMetrics:   deletionMetrics,
+		DeletionEvents:    deletionEvents,
+		DeletionService:   deletionService,
+		RestrictedModules: restrictedModuleDefaulter,
 	}).SetupWithManager(mgr, ctrlruntime.Options{}, kyma.SetupOptions{ListenerAddr: listenerAddr},
 		watchcmpse.ComposeTemplateChangeHandlerMapFunc(
 			kymarepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace),


### PR DESCRIPTION
Implements a defaulter adding restriced modules configured in `--restricted-default-modules` to the KCP Kyma spec if the KCP Kyma matches the kymaSelector from the related ModuleReleaseMeta.

Notes:

- in a general context, the logging may be a bit verbose but in this context I would prefer to have a good amount of logs so we can reason about (miss-)behavior.

closes #3214 