### PR TITLE
fix: Split image build for local testing into two workflows

### DIFF
--- a/.github/workflows/build-image-local.yml
+++ b/.github/workflows/build-image-local.yml
@@ -1,10 +1,11 @@
 name: Build Image (Local testing / ghcr.io)
 
-# Builds and publishes lifecycle-manager images to ghcr.io/kyma-project for fast
-# local testing, especially on Apple M-series (arm64) machines.
+# Builds lifecycle-manager multi-platform images for local testing.
+# The image is exported as an OCI tarball and uploaded as an artifact.
+# A separate workflow (publish-image-local.yml) pushes it to ghcr.io.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths-ignore:
       - "docs/**"
@@ -26,72 +27,60 @@ on:
         required: false
         default: ""
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # QEMU provides arm64 emulation on the amd64 GitHub-hosted runner.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Tag strategy:
-      #   PR            → pr-<number>  and  sha-<short>
-      #   push to main  → latest       and  sha-<short>
-      #   manual        → <input-tag>  and  sha-<short>   (sha only if no input)
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-        with:
-          images: ghcr.io/kyma-project/lifecycle-manager
-          tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request_target' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' }}
-            type=sha,format=short
-
-      - name: Build and push image
-        id: build
+      - name: Build image (OCI tarball)
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Align TAG_default_tag with the Dockerfile ARG used by the official builder.
+          push: false
+          outputs: type=oci,dest=/tmp/image.tar
           build-args: |
-            TAG_default_tag=${{ github.event.pull_request.head.sha || github.sha }}
-          # GitHub Actions cache keeps layer rebuilds fast across PR pushes.
+            TAG_default_tag=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Print published image
+      - name: Write build metadata
         run: |
-          echo "### Published image" >> "$GITHUB_STEP_SUMMARY"
-          echo "Digest: \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
-          echo '${{ steps.meta.outputs.tags }}' | while read tag; do
-            echo "- \`${tag}\`" >> "$GITHUB_STEP_SUMMARY"
-          done
+          cat > /tmp/metadata.json <<EOF
+          {
+            "event_name": "${{ github.event_name }}",
+            "sha": "${{ github.sha }}",
+            "pr_number": "${{ github.event.pull_request.number }}",
+            "dispatch_tag": "${{ inputs.tag }}",
+            "ref": "${{ github.ref }}"
+          }
+          EOF
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: image-oci
+          path: /tmp/image.tar
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: image-metadata
+          path: /tmp/metadata.json
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/build-image-local.yml
+++ b/.github/workflows/build-image-local.yml
@@ -57,30 +57,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Write build metadata
-        run: |
-          cat > /tmp/metadata.json <<EOF
-          {
-            "event_name": "${{ github.event_name }}",
-            "sha": "${{ github.sha }}",
-            "pr_number": "${{ github.event.pull_request.number }}",
-            "dispatch_tag": "${{ inputs.tag }}",
-            "ref": "${{ github.ref }}"
-          }
-          EOF
-
       - name: Upload image artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: image-oci
           path: /tmp/image.tar
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload metadata artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: image-metadata
-          path: /tmp/metadata.json
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/publish-image-local.yml
+++ b/.github/workflows/publish-image-local.yml
@@ -1,0 +1,98 @@
+name: Publish Image (Local testing / ghcr.io)
+
+# Triggered by a successful "Build Image (Local testing / ghcr.io)" run.
+# Downloads the OCI tarball artifact and pushes it to ghcr.io.
+# This workflow never checks out untrusted code — it only handles the
+# pre-built image, which keeps the privileged context safe from supply-chain attacks.
+
+on:
+  workflow_run:
+    workflows: ["Build Image (Local testing / ghcr.io)"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  push:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      actions: read
+
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: image-oci
+          path: /tmp/artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download metadata artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: image-metadata
+          path: /tmp/metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          metadata=$(cat /tmp/metadata/metadata.json)
+          event_name=$(echo "$metadata" | jq -r '.event_name')
+          sha=$(echo "$metadata" | jq -r '.sha')
+          pr_number=$(echo "$metadata" | jq -r '.pr_number')
+          dispatch_tag=$(echo "$metadata" | jq -r '.dispatch_tag')
+          ref=$(echo "$metadata" | jq -r '.ref')
+          short_sha=${sha:0:7}
+
+          image="ghcr.io/kyma-project/lifecycle-manager"
+          tags=""
+
+          if [[ "$event_name" == "push" && "$ref" == "refs/heads/main" ]]; then
+            tags="${image}:latest,${image}:sha-${short_sha}"
+          elif [[ "$event_name" == "pull_request" ]]; then
+            tags="${image}:pr-${pr_number},${image}:sha-${short_sha}"
+          elif [[ "$event_name" == "workflow_dispatch" ]]; then
+            if [[ -n "$dispatch_tag" && "$dispatch_tag" != "" ]]; then
+              tags="${image}:${dispatch_tag},${image}:sha-${short_sha}"
+            else
+              tags="${image}:sha-${short_sha}"
+            fi
+          fi
+
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+          echo "Computed tags: $tags"
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push image to ghcr.io
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          first_tag="${TAG_ARRAY[0]}"
+
+          # Push with the first tag
+          skopeo copy --all oci-archive:/tmp/artifacts/image.tar "docker://${first_tag}"
+
+          # Add additional tags by copying from the first
+          for tag in "${TAG_ARRAY[@]:1}"; do
+            skopeo copy --all "docker://${first_tag}" "docker://${tag}"
+          done
+
+      - name: Print published image
+        run: |
+          echo "### Published image" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for tag in "${TAG_ARRAY[@]}"; do
+            echo "- \`${tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/publish-image-local.yml
+++ b/.github/workflows/publish-image-local.yml
@@ -4,6 +4,9 @@ name: Publish Image (Local testing / ghcr.io)
 # Downloads the OCI tarball artifact and pushes it to ghcr.io.
 # This workflow never checks out untrusted code — it only handles the
 # pre-built image, which keeps the privileged context safe from supply-chain attacks.
+#
+# Tag decisions are derived entirely from github.event.workflow_run context
+# (trusted) — never from PR-produced artifacts, which could be forged by a fork.
 
 on:
   workflow_run:
@@ -40,27 +43,24 @@ jobs:
       - name: Compute image tags
         id: tags
         run: |
-          metadata=$(cat /tmp/metadata/metadata.json)
-          event_name=$(echo "$metadata" | jq -r '.event_name')
-          sha=$(echo "$metadata" | jq -r '.sha')
-          pr_number=$(echo "$metadata" | jq -r '.pr_number')
-          dispatch_tag=$(echo "$metadata" | jq -r '.dispatch_tag')
-          ref=$(echo "$metadata" | jq -r '.ref')
-          short_sha=${sha:0:7}
+          event="${{ github.event.workflow_run.event }}"
+          sha="${{ github.event.workflow_run.head_sha }}"
+          short_sha="${sha:0:7}"
+          head_branch="${{ github.event.workflow_run.head_branch }}"
+          # pull_requests is only populated for same-repo PRs, empty for forks.
+          pr_number=$(jq -r '.workflow_run.pull_requests[0].number // ""' "$GITHUB_EVENT_PATH")
 
           image="ghcr.io/kyma-project/lifecycle-manager"
           tags=""
 
-          if [[ "$event_name" == "push" && "$ref" == "refs/heads/main" ]]; then
+          if [[ "$event" == "push" && "$head_branch" == "main" ]]; then
             tags="${image}:latest,${image}:sha-${short_sha}"
-          elif [[ "$event_name" == "pull_request" ]]; then
+          elif [[ "$event" == "pull_request" && -n "$pr_number" ]]; then
             tags="${image}:pr-${pr_number},${image}:sha-${short_sha}"
-          elif [[ "$event_name" == "workflow_dispatch" ]]; then
-            if [[ -n "$dispatch_tag" && "$dispatch_tag" != "" ]]; then
-              tags="${image}:${dispatch_tag},${image}:sha-${short_sha}"
-            else
-              tags="${image}:sha-${short_sha}"
-            fi
+          elif [[ "$event" == "pull_request" || "$event" == "workflow_dispatch" ]]; then
+            # Fork PRs: pr_number unavailable from workflow_run context.
+            # workflow_dispatch: custom tag not passed through for security.
+            tags="${image}:sha-${short_sha}"
           fi
 
           if [[ -z "$tags" ]]; then

--- a/.github/workflows/publish-image-local.yml
+++ b/.github/workflows/publish-image-local.yml
@@ -63,6 +63,10 @@ jobs:
             fi
           fi
 
+          if [[ -z "$tags" ]]; then
+            echo "::error::No tags computed for event '$event_name'" && exit 1
+          fi
+
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
           echo "Computed tags: $tags"
 
@@ -78,21 +82,18 @@ jobs:
       - name: Push image to ghcr.io
         run: |
           IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          first_tag="${TAG_ARRAY[0]}"
-
-          # Push with the first tag
-          skopeo copy --all oci-archive:/tmp/artifacts/image.tar "docker://${first_tag}"
-
-          # Add additional tags by copying from the first
-          for tag in "${TAG_ARRAY[@]:1}"; do
-            skopeo copy --all "docker://${first_tag}" "docker://${tag}"
+          for tag in "${TAG_ARRAY[@]}"; do
+            skopeo copy --all oci-archive:/tmp/artifacts/image.tar "docker://${tag}"
           done
 
       - name: Print published image
         run: |
           echo "### Published image" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
           IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          first_tag="${TAG_ARRAY[0]}"
+          digest=$(skopeo inspect --raw "docker://${first_tag}" | jq -r '.manifests[0].digest // .Digest')
+          echo "Digest: \`${digest}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tags:" >> "$GITHUB_STEP_SUMMARY"
           for tag in "${TAG_ARRAY[@]}"; do
             echo "- \`${tag}\`" >> "$GITHUB_STEP_SUMMARY"
           done

--- a/.github/workflows/publish-image-local.yml
+++ b/.github/workflows/publish-image-local.yml
@@ -32,21 +32,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Download metadata artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: image-metadata
-          path: /tmp/metadata
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
       - name: Compute image tags
         id: tags
+        env:
+          WR_EVENT: ${{ github.event.workflow_run.event }}
+          WR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          event="${{ github.event.workflow_run.event }}"
-          sha="${{ github.event.workflow_run.head_sha }}"
+          event="$WR_EVENT"
+          sha="$WR_HEAD_SHA"
           short_sha="${sha:0:7}"
-          head_branch="${{ github.event.workflow_run.head_branch }}"
+          head_branch="$WR_HEAD_BRANCH"
           # pull_requests is only populated for same-repo PRs, empty for forks.
           pr_number=$(jq -r '.workflow_run.pull_requests[0].number // ""' "$GITHUB_EVENT_PATH")
 
@@ -64,7 +60,7 @@ jobs:
           fi
 
           if [[ -z "$tags" ]]; then
-            echo "::error::No tags computed for event '$event_name'" && exit 1
+            echo "::error::No tags computed for event '$event'" && exit 1
           fi
 
           echo "tags=$tags" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The build workflow for local test images has a critical security warning:
https://github.com/kyma-project/lifecycle-manager/security/code-scanning/98

- This PR splits the workflow in two, and designs the build step without pull_request_target

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
