### PR TITLE
chore: Introduce `bump-go-version.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,3 +192,7 @@ lint: install-golangci-lint ## Run golangci-lint against code.
 .PHONY: lint-yaml
 lint-yaml: ## Run yamllint against repository. Assumes yamllint is installed. Install via 'brew install yamllint' or 'pip install yamllint'.
 	yamllint -c .yamllint.yml --no-warnings  .
+
+.PHONY: bump-go-version
+bump-go-version: ## Bump Go version. Usage: make bump-go-version GO_VERSION=1.26.3
+	./scripts/bump-go-version.sh $(GO_VERSION)

--- a/scripts/bump-go-version.sh
+++ b/scripts/bump-go-version.sh
@@ -19,14 +19,13 @@ done
 
 # 2. Resolve Docker image index digest (validates the image exists on the registry)
 IMAGE="golang:${NEW_VERSION}-alpine"
-echo "  Resolving digest for ${IMAGE}..."
 DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{println .Manifest.Digest}}')
 
 if [[ -z "${DIGEST}" ]]; then
-  echo "  ✗ Failed to resolve digest for ${IMAGE}. Does this Go version exist?" >&2
+  echo "  ✗ Failed to resolve digest for ${IMAGE} image. Does this Go version exist?" >&2
   exit 1
 fi
-echo "  ✓ Verified ${IMAGE} exists (${DIGEST})"
+echo "  ✓ Verified ${IMAGE} image exists (${DIGEST})"
 
 # 3. Update versions.yaml
 yq e -i ".go = \"${NEW_VERSION}\"" "${REPO_ROOT}/versions.yaml"

--- a/scripts/bump-go-version.sh
+++ b/scripts/bump-go-version.sh
@@ -8,6 +8,15 @@ NEW_VERSION="${1:?Usage: $0 <new-go-version>}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Helper function to handle sed -i differences between GNU and BSD (macOS)
+sedi() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
 echo "Bumping Go version to ${NEW_VERSION}..."
 
 # 1. Update all go.mod files using 'go mod edit'
@@ -32,7 +41,7 @@ yq e -i ".go = \"${NEW_VERSION}\"" "${REPO_ROOT}/versions.yaml"
 echo "  ✓ versions.yaml"
 
 # 4. Update Dockerfile with new version and resolved digest
-sed -i'' -e "s|golang:[0-9]\+\.[0-9]\+\.[0-9]\+-alpine@sha256:[a-f0-9]\+|golang:${NEW_VERSION}-alpine@${DIGEST}|" "${REPO_ROOT}/Dockerfile"
+sedi "s|golang:[0-9]\+\.[0-9]\+\.[0-9]\+-alpine@sha256:[a-f0-9]\+|golang:${NEW_VERSION}-alpine@${DIGEST}|" "${REPO_ROOT}/Dockerfile"
 echo "  ✓ Dockerfile (golang:${NEW_VERSION}-alpine@${DIGEST})"
 
 echo ""

--- a/scripts/bump-go-version.sh
+++ b/scripts/bump-go-version.sh
@@ -6,7 +6,13 @@ set -euo pipefail
 
 NEW_VERSION="${1:?Usage: $0 <new-go-version>}"
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# When piped to bash (e.g. curl ... | bash), BASH_SOURCE[0] is not a file path,
+# so fall back to the current working directory as the repo root.
+if [[ -f "${BASH_SOURCE[0]:-}" ]]; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+else
+  REPO_ROOT="$(pwd)"
+fi
 
 # Helper function to handle sed -i differences between GNU and BSD (macOS)
 sedi() {

--- a/scripts/bump-go-version.sh
+++ b/scripts/bump-go-version.sh
@@ -21,10 +21,11 @@ echo "Bumping Go version to ${NEW_VERSION}..."
 
 # 1. Update all go.mod files using 'go mod edit'
 #    This validates quickly that the Go version is recognized by the toolchain.
-for moddir in "${REPO_ROOT}" "${REPO_ROOT}/api" "${REPO_ROOT}/maintenancewindows"; do
+while IFS= read -r modfile; do
+  moddir="$(dirname "${modfile}")"
   (cd "${moddir}" && go mod edit -go="${NEW_VERSION}")
-  echo "  ✓ ${moddir#${REPO_ROOT}/}/go.mod"
-done
+  echo "  ✓ ${modfile#${REPO_ROOT}/}"
+done < <(find "${REPO_ROOT}" -name "go.mod" -not -path "*/vendor/*")
 
 # 2. Resolve Docker image index digest (validates the image exists on the registry)
 IMAGE="golang:${NEW_VERSION}-alpine"
@@ -36,13 +37,18 @@ if [[ -z "${DIGEST}" ]]; then
 fi
 echo "  ✓ Verified ${IMAGE} image exists (${DIGEST})"
 
-# 3. Update versions.yaml
-yq e -i ".go = \"${NEW_VERSION}\"" "${REPO_ROOT}/versions.yaml"
-echo "  ✓ versions.yaml"
+# 3. Update versions.yaml (optional: only if the file exists and contains a "go" entry)
+VERSIONS_YAML="${REPO_ROOT}/versions.yaml"
+if [[ -f "${VERSIONS_YAML}" ]] && yq e '.go' "${VERSIONS_YAML}" | grep -qv '^null$'; then
+  yq e -i ".go = \"${NEW_VERSION}\"" "${VERSIONS_YAML}"
+  echo "  ✓ versions.yaml"
+fi
 
-# 4. Update Dockerfile with new version and resolved digest
-sedi "s|golang:[0-9]\+\.[0-9]\+\.[0-9]\+-alpine@sha256:[a-f0-9]\+|golang:${NEW_VERSION}-alpine@${DIGEST}|" "${REPO_ROOT}/Dockerfile"
-echo "  ✓ Dockerfile (golang:${NEW_VERSION}-alpine@${DIGEST})"
+# 4. Update all Dockerfiles with new version and resolved digest
+while IFS= read -r dockerfile; do
+  sedi "s|golang:[0-9]\+\.[0-9]\+\.[0-9]\+-alpine@sha256:[a-f0-9]\+|golang:${NEW_VERSION}-alpine@${DIGEST}|" "${dockerfile}"
+  echo "  ✓ ${dockerfile#${REPO_ROOT}/} (golang:${NEW_VERSION}-alpine@${DIGEST})"
+done < <(find "${REPO_ROOT}" -name "Dockerfile" -not -path "*/vendor/*")
 
 echo ""
 echo "Done! Go version bumped to ${NEW_VERSION}."

--- a/scripts/bump-go-version.sh
+++ b/scripts/bump-go-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/bump-go-version.sh <new-go-version>
+# Example: ./scripts/bump-go-version.sh 1.26.3
+
+NEW_VERSION="${1:?Usage: $0 <new-go-version>}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Bumping Go version to ${NEW_VERSION}..."
+
+# 1. Update all go.mod files using 'go mod edit'
+#    This validates quickly that the Go version is recognized by the toolchain.
+for moddir in "${REPO_ROOT}" "${REPO_ROOT}/api" "${REPO_ROOT}/maintenancewindows"; do
+  (cd "${moddir}" && go mod edit -go="${NEW_VERSION}")
+  echo "  ✓ ${moddir#${REPO_ROOT}/}/go.mod"
+done
+
+# 2. Resolve Docker image index digest (validates the image exists on the registry)
+IMAGE="golang:${NEW_VERSION}-alpine"
+echo "  Resolving digest for ${IMAGE}..."
+DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{println .Manifest.Digest}}')
+
+if [[ -z "${DIGEST}" ]]; then
+  echo "  ✗ Failed to resolve digest for ${IMAGE}. Does this Go version exist?" >&2
+  exit 1
+fi
+echo "  ✓ Verified ${IMAGE} exists (${DIGEST})"
+
+# 3. Update versions.yaml
+yq e -i ".go = \"${NEW_VERSION}\"" "${REPO_ROOT}/versions.yaml"
+echo "  ✓ versions.yaml"
+
+# 4. Update Dockerfile with new version and resolved digest
+sed -i'' -e "s|golang:[0-9]\+\.[0-9]\+\.[0-9]\+-alpine@sha256:[a-f0-9]\+|golang:${NEW_VERSION}-alpine@${DIGEST}|" "${REPO_ROOT}/Dockerfile"
+echo "  ✓ Dockerfile (golang:${NEW_VERSION}-alpine@${DIGEST})"
+
+echo ""
+echo "Done! Go version bumped to ${NEW_VERSION}."


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- script that helps us consistently bumping Go version
- see https://github.com/kyma-project/lifecycle-manager/pull/3251 which has been created with this script
  - note that the version was already inconsistent
  - note that the digest in the Dockerfile is the Manifest index digest which is also used by depandabot https://github.com/kyma-project/lifecycle-manager/pull/3250 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
