### PR TITLE
docs: Add documentation-style.md Claude rule

### DIFF
--- a/.claude/rules/documentation-style.md
+++ b/.claude/rules/documentation-style.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.md"
+---
+
+When reviewing or editing documentation files, load the SAP/Kyma technical writing styleguide:
+
+https://raw.githubusercontent.com/kyma-project/community/refs/heads/main/docs/guidelines/content-guidelines/agentic.md
+
+- If the styleguide fails to load, inform the user before proceeding. Do NOT proceed with editing or reviewing the documentation without the styleguide. 
+- For **routine edits**: apply Pass 1 (formatting) and Pass 2 (language). Silently fix typos, grammar, and formatting issues without asking for confirmation.
+- For **new documentation or major rewrites**: apply all four passes (formatting, language, terminology, and reconciliation). List structural changes in a summary.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adds a Claude rule to adhere to styleguide whenever touching `.md` files.
- tested by updating https://github.com/kyma-project/lifecycle-manager/pull/3270
  - <img width="1277" height="1214" alt="image" src="https://github.com/user-attachments/assets/4b9c0eaf-257d-419f-904c-398b1dee2b7b" />
- when the styleguide doesn't resolve
  - <img width="868" height="488" alt="image" src="https://github.com/user-attachments/assets/d0defa4f-a7ce-42b4-b74e-c3dcae0859df" />



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
