### PR TITLE
refactor: Drop ModuleTemplateBuilder.WithChannel from tests

### DIFF
--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -29,7 +29,6 @@ func (m *Module) Logger(base logr.Logger) logr.Logger {
 	return base.WithValues(
 		"componentName", m.OCMComponentName,
 		"module", m.Manifest.GetName(),
-		"channel", m.TemplateInfo.Spec.Channel, //nolint:staticcheck // legacy Channel field
 		"templateGeneration", m.TemplateInfo.GetGeneration(),
 	)
 }

--- a/pkg/templatelookup/regular_test.go
+++ b/pkg/templatelookup/regular_test.go
@@ -911,6 +911,7 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 					DesiredChannel: testModule.Channel,
 					Err:            nil,
 					ModuleTemplate: builder.NewModuleTemplateBuilder().
+						WithName(fmt.Sprintf("%s-%s", testModule.Name, moduleVersion)).
 						WithModuleName(testModule.Name).
 						WithVersion(moduleVersion).
 						Build(),
@@ -937,7 +938,9 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 					DesiredChannel: testModule.Channel,
 					Err:            nil,
 					ModuleTemplate: builder.NewModuleTemplateBuilder().
+						WithName(fmt.Sprintf("%s-%s", testModule.Name, moduleVersion)).
 						WithModuleName(testModule.Name).
+						WithVersion(moduleVersion).
 						Build(),
 				},
 			},
@@ -980,8 +983,8 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 				require.ErrorIs(t, module.Err, wantModule.Err)
 				if wantModule.ModuleTemplate != nil {
 					require.NotNil(t, module.ModuleTemplate)
-					assert.Equal(t, wantModule.ModuleTemplate.Name, module.ModuleTemplate.Name)
-					assert.Equal(t, wantModule.ModuleTemplate.Spec.Version, module.ModuleTemplate.Spec.Version)
+					assert.Equal(t, wantModule.Name, module.Name)
+					assert.Equal(t, wantModule.Spec.Version, module.Spec.Version)
 				}
 			}
 		})

--- a/pkg/templatelookup/regular_test.go
+++ b/pkg/templatelookup/regular_test.go
@@ -978,6 +978,11 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 				assert.True(t, ok)
 				assert.Equal(t, wantModule.DesiredChannel, module.DesiredChannel)
 				require.ErrorIs(t, module.Err, wantModule.Err)
+				if wantModule.ModuleTemplate != nil {
+					require.NotNil(t, module.ModuleTemplate)
+					assert.Equal(t, wantModule.ModuleTemplate.Name, module.ModuleTemplate.Name)
+					assert.Equal(t, wantModule.ModuleTemplate.Spec.Version, module.ModuleTemplate.Spec.Version)
+				}
 			}
 		})
 	}

--- a/pkg/templatelookup/regular_test.go
+++ b/pkg/templatelookup/regular_test.go
@@ -439,7 +439,7 @@ func TestTemplateLookup_GetRegularTemplates_WhenSwitchModuleChannel(t *testing.T
 						},
 					},
 				}).Build(),
-			availableModuleTemplate: generateModuleTemplateListWithModule(testModule.Name, "",
+			availableModuleTemplate: generateModuleTemplateListWithModule(testModule.Name,
 				version2),
 			availableModuleReleaseMeta: generateModuleReleaseMetaList(testModule.Name,
 				[]v1beta2.ChannelVersionAssignment{
@@ -467,7 +467,7 @@ func TestTemplateLookup_GetRegularTemplates_WhenSwitchModuleChannel(t *testing.T
 						},
 					},
 				}).Build(),
-			availableModuleTemplate: generateModuleTemplateListWithModule(testModule.Name, "",
+			availableModuleTemplate: generateModuleTemplateListWithModule(testModule.Name,
 				version1),
 			availableModuleReleaseMeta: generateModuleReleaseMetaList(testModule.Name,
 				[]v1beta2.ChannelVersionAssignment{
@@ -512,12 +512,9 @@ func TestTemplateLookup_GetRegularTemplates_WhenSwitchBetweenModuleVersions(t *t
 	moduleToInstall := moduleToInstallByVersion("module1", version2)
 
 	availableModuleTemplates := (&ModuleTemplateListBuilder{}).
-		Add(moduleToInstall.Name, "regular", version1).
-		Add(moduleToInstall.Name, "fast", version2).
-		Add(moduleToInstall.Name, "experimental", version3).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version1).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version2).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version3).
+		Add(moduleToInstall.Name, version1).
+		Add(moduleToInstall.Name, version2).
+		Add(moduleToInstall.Name, version3).
 		Build()
 
 	availableModuleReleaseMetas := generateModuleReleaseMetaList(moduleToInstall.Name,
@@ -586,12 +583,9 @@ func TestTemplateLookup_GetRegularTemplates_WhenSwitchFromChannelToVersion(t *te
 	t.Skip("This test verifies install-by-version which is not supported yet in the logic based on ModuleReleaseMeta")
 	moduleToInstall := moduleToInstallByVersion("module1", version2)
 	availableModuleTemplates := (&ModuleTemplateListBuilder{}).
-		Add(moduleToInstall.Name, "regular", version1).
-		Add(moduleToInstall.Name, "fast", version2).
-		Add(moduleToInstall.Name, "experimental", version3).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version1).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version2).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version3).
+		Add(moduleToInstall.Name, version1).
+		Add(moduleToInstall.Name, version2).
+		Add(moduleToInstall.Name, version3).
 		Build()
 
 	availableModuleReleaseMetas := v1beta2.ModuleReleaseMetaList{}
@@ -656,12 +650,9 @@ func TestTemplateLookup_GetRegularTemplates_WhenSwitchFromChannelToVersion(t *te
 func TestTemplateLookup_GetRegularTemplates_WhenSwitchFromVersionToChannel(t *testing.T) {
 	moduleToInstall := testutils.NewTestModule("module1", "new_channel")
 	availableModuleTemplates := (&ModuleTemplateListBuilder{}).
-		Add(moduleToInstall.Name, "regular", version1).
-		Add(moduleToInstall.Name, "new_channel", version2).
-		Add(moduleToInstall.Name, "fast", version3).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version1).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version2).
-		Add(moduleToInstall.Name, string(shared.NoneChannel), version3).
+		Add(moduleToInstall.Name, version1).
+		Add(moduleToInstall.Name, version2).
+		Add(moduleToInstall.Name, version3).
 		Build()
 
 	availableModuleReleaseMetas := generateModuleReleaseMetaList(
@@ -786,7 +777,6 @@ func TestNewTemplateLookup_GetRegularTemplates_WhenModuleTemplateContainsInvalid
 					*builder.NewModuleTemplateBuilder().
 						WithName(fmt.Sprintf("%s-%s", module.Name, testModule.Version)).
 						WithModuleName(module.Name).
-						WithChannel(module.Channel).
 						WithDescriptor(nil).
 						WithRawDescriptor([]byte("{invalid_json}")).Build())
 
@@ -908,16 +898,14 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 	require.NoError(t, err)
 
 	tests := []struct {
-		name     string
-		kyma     *v1beta2.Kyma
-		mrmExist bool
-		want     templatelookup.ModuleTemplatesByModuleName
+		name string
+		kyma *v1beta2.Kyma
+		want templatelookup.ModuleTemplatesByModuleName
 	}{
 		{
 			name: "When module enabled in Spec, then return expected moduleTemplateInfo, with ModuleReleaseMeta",
 			kyma: builder.NewKymaBuilder().
 				WithEnabledModule(testModule).Build(),
-			mrmExist: true,
 			want: templatelookup.ModuleTemplatesByModuleName{
 				testModule.Name: &templatelookup.ModuleTemplateInfo{
 					DesiredChannel: testModule.Channel,
@@ -925,7 +913,6 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 					ModuleTemplate: builder.NewModuleTemplateBuilder().
 						WithModuleName(testModule.Name).
 						WithVersion(moduleVersion).
-						WithChannel("").
 						Build(),
 				},
 			},
@@ -945,14 +932,12 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 					},
 					Version: "1.0.0",
 				}).Build(),
-			mrmExist: true,
 			want: templatelookup.ModuleTemplatesByModuleName{
 				testModule.Name: &templatelookup.ModuleTemplateInfo{
 					DesiredChannel: testModule.Channel,
 					Err:            nil,
 					ModuleTemplate: builder.NewModuleTemplateBuilder().
 						WithModuleName(testModule.Name).
-						WithChannel("").
 						Build(),
 				},
 			},
@@ -964,27 +949,18 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 			moduleReleaseMetas := v1beta2.ModuleReleaseMetaList{}
 			const moduleTemplateVersion = "1.0.0"
 			for _, module := range templatelookup.FetchModuleInfo(testCase.kyma) {
-				if testCase.mrmExist {
-					givenTemplateList.Items = append(givenTemplateList.Items, *builder.NewModuleTemplateBuilder().
-						WithName(fmt.Sprintf("%s-%s", module.Name, moduleTemplateVersion)).
+				givenTemplateList.Items = append(givenTemplateList.Items, *builder.NewModuleTemplateBuilder().
+					WithName(fmt.Sprintf("%s-%s", module.Name, moduleTemplateVersion)).
+					WithModuleName(module.Name).
+					WithVersion(moduleTemplateVersion).
+					Build())
+				moduleReleaseMetas.Items = append(moduleReleaseMetas.Items,
+					*builder.NewModuleReleaseMetaBuilder().
 						WithModuleName(module.Name).
-						WithVersion(moduleTemplateVersion).
-						Build())
-					moduleReleaseMetas.Items = append(moduleReleaseMetas.Items,
-						*builder.NewModuleReleaseMetaBuilder().
-							WithModuleName(module.Name).
-							WithOcmComponentName(testutils.FullOCMName(module.Name)).
-							WithModuleChannelAndVersions([]v1beta2.ChannelVersionAssignment{
-								{Channel: module.Channel, Version: moduleTemplateVersion},
-							}).Build())
-				} else {
-					givenTemplateList.Items = append(givenTemplateList.Items, *builder.NewModuleTemplateBuilder().
-						WithName(fmt.Sprintf("%s-%s", module.Name, moduleTemplateVersion)).
-						WithModuleName(module.Name).
-						WithVersion(moduleTemplateVersion).
-						WithChannel(module.Channel).
-						Build())
-				}
+						WithOcmComponentName(testutils.FullOCMName(module.Name)).
+						WithModuleChannelAndVersions([]v1beta2.ChannelVersionAssignment{
+							{Channel: module.Channel, Version: moduleTemplateVersion},
+						}).Build())
 			}
 			reader := NewFakeModuleTemplateReader(*givenTemplateList,
 				moduleReleaseMetas)
@@ -1002,13 +978,6 @@ func TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists(t *testing.
 				assert.True(t, ok)
 				assert.Equal(t, wantModule.DesiredChannel, module.DesiredChannel)
 				require.ErrorIs(t, module.Err, wantModule.Err)
-				if !testCase.mrmExist {
-					assert.Equal(
-						t,
-						wantModule.Spec.Channel, //nolint:staticcheck    // legacy Channel field
-						module.Spec.Channel,     //nolint:staticcheck    // legacy Channel field
-					)
-				}
 			}
 		})
 	}
@@ -1102,12 +1071,11 @@ func executeGetRegularTemplatesTestCases(t *testing.T,
 	}
 }
 
-func generateModuleTemplateListWithModule(moduleName, moduleChannel, moduleVersion string) v1beta2.ModuleTemplateList {
+func generateModuleTemplateListWithModule(moduleName, moduleVersion string) v1beta2.ModuleTemplateList {
 	templateList := v1beta2.ModuleTemplateList{}
 	templateList.Items = append(templateList.Items, *builder.NewModuleTemplateBuilder().
 		WithName(v1beta2.CreateModuleTemplateName(moduleName, moduleVersion)).
 		WithModuleName(moduleName).
-		WithChannel(moduleChannel).
 		WithVersion(moduleVersion).
 		Build())
 	return templateList
@@ -1129,8 +1097,8 @@ type ModuleTemplateListBuilder struct {
 	ModuleTemplates []v1beta2.ModuleTemplate
 }
 
-func (mtlb *ModuleTemplateListBuilder) Add(moduleName, moduleChannel, moduleVersion string) *ModuleTemplateListBuilder {
-	list := generateModuleTemplateListWithModule(moduleName, moduleChannel, moduleVersion)
+func (mtlb *ModuleTemplateListBuilder) Add(moduleName, moduleVersion string) *ModuleTemplateListBuilder {
+	list := generateModuleTemplateListWithModule(moduleName, moduleVersion)
 	mtlb.ModuleTemplates = append(mtlb.ModuleTemplates, list.Items...)
 	return mtlb
 }

--- a/pkg/testutils/builder/moduletemplate.go
+++ b/pkg/testutils/builder/moduletemplate.go
@@ -76,11 +76,6 @@ func (m ModuleTemplateBuilder) WithGeneration(generation int) ModuleTemplateBuil
 	return m
 }
 
-func (m ModuleTemplateBuilder) WithChannel(channel string) ModuleTemplateBuilder {
-	m.moduleTemplate.Spec.Channel = channel //nolint:staticcheck // legacy tests still rely on the deprecated field
-	return m
-}
-
 func (m ModuleTemplateBuilder) WithMandatory(mandatory bool) ModuleTemplateBuilder {
 	m.moduleTemplate.Spec.Mandatory = mandatory
 	return m

--- a/tests/integration/controller/kcp/helper_test.go
+++ b/tests/integration/controller/kcp/helper_test.go
@@ -89,7 +89,6 @@ func DeployModuleTemplates(ctx context.Context, kcpClient client.Client, kyma *v
 		template := builder.NewModuleTemplateBuilder().
 			WithNamespace(ControlPlaneNamespace).
 			WithModuleName(module.Name).
-			WithChannel(module.Channel).
 			WithName(moduleTemplateName).
 			Build()
 		Eventually(kcpClient.Create, Timeout, Interval).WithContext(ctx).

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -264,7 +264,6 @@ var _ = Describe("Kyma sync default module list into Remote Cluster", Ordered, f
 		WithName(fmt.Sprintf("%s-%s", moduleInKCP.Name, moduleVersion)).
 		WithNamespace(ControlPlaneNamespace).
 		WithModuleName(moduleInKCP.Name).
-		WithChannel(moduleInKCP.Channel).
 		WithVersion(moduleVersion).
 		Build()
 

--- a/tests/integration/controller/kyma/moduletemplate_install_test.go
+++ b/tests/integration/controller/kyma/moduletemplate_install_test.go
@@ -122,8 +122,7 @@ func givenKymaAndModuleTemplateCondition(
 		for _, module := range skrKyma.Spec.Modules {
 			mtBuilder := builder.NewModuleTemplateBuilder().
 				WithNamespace(ControlPlaneNamespace).
-				WithModuleName(module.Name).
-				WithChannel(module.Channel)
+				WithModuleName(module.Name)
 			if isModuleTemplateInternal {
 				mtBuilder.WithLabel(shared.InternalLabel, shared.EnableLabelValue)
 			}

--- a/tests/integration/controller/moduletemplate/moduletemplate_test.go
+++ b/tests/integration/controller/moduletemplate/moduletemplate_test.go
@@ -30,7 +30,6 @@ var _ = Describe("ModuleTemplate version is not empty", Ordered, func() {
 				WithNamespace(ControlPlaneNamespace).
 				WithVersion(givenVersion).
 				WithModuleName("").
-				WithChannel(module.Channel).
 				Build()
 
 			err := kcpClient.Create(ctx, template)
@@ -125,7 +124,6 @@ var _ = Describe("ModuleTemplate version is not empty", Ordered, func() {
 				WithNamespace(ControlPlaneNamespace).
 				WithModuleName(givenModuleName).
 				WithVersion("").
-				WithChannel(module.Channel).
 				Build()
 
 			err := kcpClient.Create(ctx, template)


### PR DESCRIPTION
## Summary

- Channel-to-version mapping has been relocated from `ModuleTemplate` to `ModuleReleaseMeta`. This PR removes the last test helper (`ModuleTemplateBuilder.WithChannel`) that was still writing to the deprecated `ModuleTemplate.Spec.Channel` field, so the field can be retired cleanly in a follow-up.
- Incidental `WithChannel(...)` uses across integration tests are dropped. Tests that genuinely exercise channel resolution already wire it via MRM; the redundant `WithChannel` calls were leftovers and have been removed.
- The legacy MT-only branch in `TestTemplateLookup_GetRegularTemplates_WhenModuleTemplateExists` (and its `mrmExist=false` toggle) is removed - the parallel MRM-driven cases provide the canonical coverage. Helper signatures `generateModuleTemplateListWithModule` and `ModuleTemplateListBuilder.Add` lose their `moduleChannel` parameter accordingly.
- The only non-test reader of `ModuleTemplate.Spec.Channel` (a `WithValues("channel", ...)` log pair in `pkg/module/common/module.go`) is also removed.

Closes #2711