### PR TITLE
chore: Split the 'Build Image' workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,8 +14,6 @@ on:
         required: false
         type: string
         default: ""
-  pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   get-custom-tags:
@@ -33,22 +31,12 @@ jobs:
             tags="latest"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tags="${{ inputs.tag }}"
-          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            tags="${{ github.event.pull_request.head.sha }}"
           fi
           echo "Using custom tags: '$tags'"
           echo "tags=$tags" >> $GITHUB_OUTPUT
 
-  restricted-gate:
-    needs: get-custom-tags
-    runs-on: ubuntu-latest
-    environment:
-      name: restricted
-    steps:
-      - run: echo "'build-image' job approval granted"
-
   build-image:
-    needs: [get-custom-tags, restricted-gate]
+    needs: [get-custom-tags]
     permissions:
       id-token: write # This is required for requesting the JWT token
       contents: read # This is required for actions/checkout

--- a/.github/workflows/build-pr-image.yml
+++ b/.github/workflows/build-pr-image.yml
@@ -1,0 +1,32 @@
+name: Build PR Image
+
+permissions:
+  contents: read # This is required for actions/checkout
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+jobs:
+  restricted-gate:
+    runs-on: ubuntu-latest
+    environment:
+      name: restricted
+    steps:
+      - run: echo "'build-pr-image' job approval granted"
+
+  build-pr-image:
+    needs: restricted-gate
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: lifecycle-manager
+      dockerfile: Dockerfile
+      context: .
+      platforms: |
+        linux/amd64
+      # tags are additional tags that will be added to the image on top of the default ones
+      # default tags are documented here: https://github.com/kyma-project/test-infra/tree/main/cmd/image-builder#default-tags
+      tags: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
**Description**

Split the `build-image.yml` workflow into two separate workflows:
- "Build Image" that runs on `push-to-main` and during release builds. This one doesn't need `restricted-gate` protection because an attacker can't inject malicious code (there is no external, untrusted PR involved)
- "Build PR Image" that is triggered on `pull-request-target`. This one needs the `restricted-gate` protection to prevent PR-based workflow poisoning attacks.

This split was necessary because otherwise `push-to-main` runs were also blocked by `restricted-gate`, which is not correct behavior. We could handle it via some conditional logic, but we decided not to: This increases complexity, makes it harder to verify if the solution is secure, adds a chance for an attack based on exploiting potential flaws in the conditional logic. The less logic to fiddle with, the better.

See also: #3285 

Changes proposed in this pull request:

- Split the `build-image.yml` workflow into two separate ones.
- Simplify the `build-pr-image` workflow to be minimal
