### PR TITLE
chore: Add `lifecycle-manager` tailored `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -96,7 +96,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["go: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "semver",
@@ -104,7 +104,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["istio: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -112,7 +112,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["certManager: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -120,7 +120,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["gardenerCertManager: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -128,7 +128,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["controllerTools: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -136,7 +136,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["docker: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -144,7 +144,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["golangciLint: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -152,7 +152,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["k3d: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -160,7 +160,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["k8s: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -168,7 +168,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["envtest_k8s: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -176,7 +176,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["kubectl: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -184,7 +184,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["kustomize: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -193,7 +193,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["modulectl: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -201,7 +201,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["ocm-cli: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -209,7 +209,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["template-operator: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -217,7 +217,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["yq: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
@@ -225,7 +225,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "managerFilePatterns": ["^versions\\.yaml$"],
       "matchStrings": ["applyconfiguration_gen: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",

--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "All Kubernetes packages",
-      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
     },
     {
       "matchManagers": ["gomod"],
@@ -83,12 +83,12 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "All Istio packages",
-      "matchPackagePrefixes": ["istio.io/"]
+      "matchPackageNames": ["istio.io/**"]
     },
     {
       "description": "envtest in versions.yaml is intentionally untracked: it mirrors the controller-runtime minor version and must be bumped manually alongside sigs.k8s.io/controller-runtime upgrades.",
       "matchManagers": ["regex"],
-      "matchFileNames": ["versions.yaml"],
+      "matchFileNames": ["^versions\\.yaml$"],
       "matchDepNames": ["envtest"],
       "enabled": false
     }
@@ -234,7 +234,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github/actions/get-configuration/action\\.yml$/"
+        "^\\.github/actions/get-configuration/action\\.yml$"
       ],
       "matchStrings": ["yq_version: (?<currentValue>[\\d.]+)"],
       "datasourceTemplate": "github-releases",

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,11 @@
       "rangeStrategy": "bump"
     },
     {
+      "groupName": "Go version",
+      "matchPackageNames": ["go", "golang"],
+      "matchDatasources": ["golang-version", "docker"]
+    },
+    {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,226 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "osvVulnerabilityAlerts": true,
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScopeDisabled",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": ["area/dependency", "kind/chore"],
+  "gomod": {
+    "postUpdateOptions": ["gomodTidy"],
+    "enabled": true
+  },
+  "kustomize": {
+    "enabled": false
+  },
+  "dockerfile": {
+    "enabled": true
+  },
+  "helm-values": {
+    "enabled": false
+  },
+  "github-actions": {
+    "enabled": true
+  },
+  "ignorePaths": ["docs/**"],
+  "packageRules": [
+    {
+      "matchCategories": ["golang"],
+      "postUpdateOptions": ["gomodTidy"],
+      "enabled": true
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": "every month",
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All opentelemetry collector packages",
+      "matchSourceUrls": [
+        "https://go.opentelemetry.io/collector{/,}**",
+        "https://github.com/open-telemetry/opentelemetry-collector{/,}**",
+        "https://github.com/open-telemetry/opentelemetry-collector-contrib{/,}**"
+      ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Kubernetes packages",
+      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "ginkgo and gomega",
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2",
+        "github.com/onsi/gomega"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["go: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["istio: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "istio/istio"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["certManager: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "cert-manager/cert-manager"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["gardenerCertManager: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "gardener/cert-management"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["controllerTools: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes-sigs/controller-tools"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["docker: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "moby/moby"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["golangciLint: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "golangci/golangci-lint"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["k3d: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "k3d-io/k3d"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["k8s: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes/kubernetes"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["envtest_k8s: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes/kubernetes"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["kubectl: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes/kubernetes"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["kustomize: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes-sigs/kustomize"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["modulectl: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kyma-project/modulectl"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["ocm-cli: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "open-component-model/ocm"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["template-operator: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kyma-project/template-operator"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["yq: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "mikefarah/yq"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^versions\\.yaml$/"],
+      "matchStrings": ["applyconfiguration_gen: \"(?<currentValue>[\\d.]+)\""],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "kubernetes/code-generator"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/actions/get-configuration/action\\.yml$/"
+      ],
+      "matchStrings": ["yq_version: (?<currentValue>[\\d.]+)"],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "depNameTemplate": "mikefarah/yq"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,12 @@
   "commitMessagePrefix": "chore(renovate):",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
-    "enabled": true
+    "enabled": true,
+    "managerFilePatterns": [
+      "/go\\.mod$/",
+      "/api/go\\.mod$/",
+      "/maintenancewindows/go\\.mod$/"
+    ]
   },
   "kustomize": {
     "enabled": false
@@ -74,6 +79,18 @@
         "github.com/onsi/ginkgo/v2",
         "github.com/onsi/gomega"
       ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "All Istio packages",
+      "matchPackagePrefixes": ["istio.io/"]
+    },
+    {
+      "description": "envtest in versions.yaml is intentionally untracked: it mirrors the controller-runtime minor version and must be bumped manually alongside sigs.k8s.io/controller-runtime upgrades.",
+      "matchManagers": ["regex"],
+      "matchFileNames": ["versions.yaml"],
+      "matchDepNames": ["envtest"],
+      "enabled": false
     }
   ],
   "customManagers": [
@@ -171,7 +188,8 @@
       "matchStrings": ["kustomize: \"(?<currentValue>[\\d.]+)\""],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
-      "depNameTemplate": "kubernetes-sigs/kustomize"
+      "depNameTemplate": "kubernetes-sigs/kustomize",
+      "extractVersionTemplate": "^kustomize\\/v(?<version>.*)$"
     },
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["area/dependency", "kind/chore"],
+  "commitMessagePrefix": "chore(renovate):",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,6 @@
   "osvVulnerabilityAlerts": true,
   "extends": [
     "config:recommended",
-    ":semanticCommits",
-    ":semanticCommitTypeAll(chore)",
-    ":semanticCommitScopeDisabled",
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["area/dependency", "kind/chore"],

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,4 +16,4 @@ modulectl: "3.1.0"
 ocm-cli: "0.32.0"
 template-operator: "1.0.5"
 yq: "4.45.1"
-envtest: "0.21"
+envtest: "0.21" # tracks controller-runtime minor version (sigs.k8s.io/controller-runtime/tools/setup-envtest@release-<minor>); bump manually alongside controller-runtime upgrades


### PR DESCRIPTION
**Description**

Here I introduce `renovate.json` tailored for `lifecycle-manager`.

**Related issue(s)**
[Lifecycle Manager Issue 2995](https://github.com/kyma-project/lifecycle-manager/issues/2995)