### PR TITLE
fix: Prevent `image-builder` Pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   ],
   "labels": ["area/dependency", "kind/chore"],
   "commitMessagePrefix": "chore(renovate):",
+  "minimumReleaseAge": "3 days",
   "gomod": {
     "postUpdateOptions": ["gomodTidy"],
     "enabled": true,
@@ -20,7 +21,7 @@
     "enabled": false
   },
   "dockerfile": {
-    "enabled": true
+    "pinDigests": true
   },
   "helm-values": {
     "enabled": false
@@ -30,6 +31,24 @@
   },
   "ignorePaths": ["docs/**"],
   "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["kyma-project/test-infra"],
+      "matchFileNames": [
+        ".github/workflows/build-image.yml",
+        ".github/workflows/build-pr-image.yml"
+      ],
+      "pinDigests": false
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker maintenance"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
+    },
     {
       "matchCategories": ["golang"],
       "postUpdateOptions": ["gomodTidy"],
@@ -76,7 +95,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "groupName": "ginkgo and gomega",
+      "groupName": "All ginkgo and gomega packages",
       "matchPackageNames": [
         "github.com/onsi/ginkgo/v2",
         "github.com/onsi/gomega"


### PR DESCRIPTION
**Description**

For security / technical reasons, when having the SHA hash of `kyma-project/test-infra` `image-builder` on the GitHub Workflow files, it's not able to fetch the secret anymore. Only having a `@main` allows it to fetch the secret.

**Changes proposed in this pull request:**

- To mitigate this, a rule exception to bypass exactly the `kyma-project/test-infra` `image-builder` dependency has been introduced.
- `Dockerfile` digest pinning
- Setting `minimumReleaseAge` to 3 days