### PR TITLE
poc: RestrictedDefaultModuleImagePullSecretTransform

### DIFF
--- a/api/shared/operator_annotations.go
+++ b/api/shared/operator_annotations.go
@@ -11,4 +11,7 @@ const (
 	OwnedByFormat             = "%s/%s"
 	IsClusterScopedAnnotation = OperatorGroup + Separator + "is-cluster-scoped"
 	UnmanagedAnnotation       = OperatorGroup + Separator + "is-unmanaged"
+	// ReplaceFromKCPAnnotation on a Secret resource indicates its data should be replaced
+	// with the matching secret from the KCP control plane namespace.
+	ReplaceFromKCPAnnotation = OperatorGroup + Separator + "replace-from-kcp"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,7 +306,7 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 		kymaMetrics, logger, maintenanceWindow, ociRegistry.GetReference(), kymaDeletionSvc, kymaLookupSvc,
 		mtEventHandlerMapFunc, mrmEventHandler, restrictedModuleDefaulter)
 	setupManifestReconciler(mgr, flagVar, options, sharedMetrics, mandatoryModulesMetrics, accessManagerService, logger,
-		eventRecorder, kymaRepo)
+		eventRecorder, kymaRepo, secretRepo)
 	setupMandatoryModuleReconciler(mgr, descriptorProvider, mrmRepo, mtRepo, flagVar, options, mandatoryModulesMetrics,
 		logger, ociRegistry.GetReference(), mandatoryMrmHandlerMapFunc)
 	setupMandatoryModuleDeletionReconciler(mgr, eventRecorder, mrmRepo, manifestRepo, flagVar, options, logger)
@@ -537,6 +537,7 @@ func setupManifestReconciler(mgr ctrl.Manager,
 	setupLog logr.Logger,
 	event event.Event,
 	kymaRepo *kymarepo.Repository,
+	secretRepo *secretrepo.Repository,
 ) {
 	options.RateLimiter = internal.RateLimiter(flagVar.FailureBaseDelay,
 		flagVar.FailureMaxDelay, flagVar.RateLimiterFrequency, flagVar.RateLimiterBurst)
@@ -566,7 +567,7 @@ func setupManifestReconciler(mgr ctrl.Manager,
 	}, options.RateLimiter,
 		metrics.NewManifestMetrics(sharedMetrics), mandatoryModulesMetrics, manifestClient, orphanDetectionService,
 		specResolver, clientCache, skrClient, kcpClient, cachedManifestParser, customStateCheck,
-		flagVar.SkrImagePullSecret); err != nil {
+		flagVar.SkrImagePullSecret, secretRepo, flagVar.GetRestrictedDefaultModules()); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Manifest")
 		os.Exit(bootstrapFailedExitCode)
 	}

--- a/internal/controller/manifest/setup.go
+++ b/internal/controller/manifest/setup.go
@@ -13,10 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	declarativev2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"github.com/kyma-project/lifecycle-manager/internal/manifest/spec"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/metrics"
+	secretrepo "github.com/kyma-project/lifecycle-manager/internal/repository/secret"
 	"github.com/kyma-project/lifecycle-manager/pkg/queue"
 )
 
@@ -41,7 +43,19 @@ func SetupWithManager(mgr manager.Manager,
 	cachedManifestParser declarativev2.CachedManifestParser,
 	customStateCheck declarativev2.StateCheck,
 	skrImagePullSecretName string,
+	restrictedDefaultModules []string,
 ) error {
+	var transforms []declarativev2.ResourceTransform
+	if skrImagePullSecretName != "" {
+		transforms = append(transforms, declarativev2.CreateSkrImagePullSecretTransform(skrImagePullSecretName))
+	}
+	if len(restrictedDefaultModules) > 0 {
+		secretRepo := secretrepo.NewRepository(kcpClient, shared.DefaultControlPlaneNamespace)
+		deployerTransform := declarativev2.CreateRestrictedDefaultModuleImagePullSecretTransform(
+			secretRepo, restrictedDefaultModules)
+		transforms = append(transforms, deployerTransform)
+	}
+
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Manifest{}).
 		Named(controllerName).
@@ -52,7 +66,7 @@ func SetupWithManager(mgr manager.Manager,
 		Complete(declarativev2.NewReconciler(
 			requeueIntervals, rateLimiter, manifestMetrics, mandatoryModulesMetrics, manifestClient,
 			orphanDetectionService, specResolver, skrClientCache, skrClient, kcpClient, cachedManifestParser,
-			customStateCheck, skrImagePullSecretName)); err != nil {
+			customStateCheck, transforms)); err != nil {
 		return fmt.Errorf("failed to setup manager for manifest controller: %w", err)
 	}
 

--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -109,7 +109,7 @@ func NewReconciler(requeueIntervals queue.RequeueIntervals,
 	kcpClient client.Client,
 	cachedManifestParser CachedManifestParser,
 	stateCheck StateCheck,
-	skrImagePullSecretName string,
+	resourceTransforms []ResourceTransform,
 ) *Reconciler {
 	reconciler := &Reconciler{}
 	reconciler.manifestMetrics = metrics
@@ -123,11 +123,7 @@ func NewReconciler(requeueIntervals queue.RequeueIntervals,
 	reconciler.skrClientCache = clientCache
 	reconciler.skrClient = skrClient
 
-	reconciler.resourceTransforms = GetDefaultResourceTransforms()
-	if skrImagePullSecretName != "" {
-		reconciler.resourceTransforms = append(reconciler.resourceTransforms,
-			CreateSkrImagePullSecretTransform(skrImagePullSecretName))
-	}
+	reconciler.resourceTransforms = append(GetDefaultResourceTransforms(), resourceTransforms...)
 
 	reconciler.kcpClient = kcpClient
 	reconciler.cachedManifestParser = cachedManifestParser

--- a/internal/declarative/v2/restricted_default_module_image_pull_secret_transform.go
+++ b/internal/declarative/v2/restricted_default_module_image_pull_secret_transform.go
@@ -1,0 +1,58 @@
+package v2
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"slices"
+
+	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+)
+
+// SecretRepository fetches secrets from the KCP control plane namespace.
+type SecretRepository interface {
+	Get(ctx context.Context, name string) (*apicorev1.Secret, error)
+}
+
+func CreateRestrictedDefaultModuleImagePullSecretTransform(
+	secretRepo SecretRepository, restrictedModules []string,
+) ResourceTransform {
+	return func(ctx context.Context, obj Object, resources []*unstructured.Unstructured) error {
+		manifest, ok := obj.(*v1beta2.Manifest)
+		if !ok {
+			return fmt.Errorf("%w, got %T", ErrResourceTransformExpectedManifestType, obj)
+		}
+
+		moduleName := manifest.GetLabels()[shared.ModuleName]
+		if moduleName == "" || !slices.Contains(restrictedModules, moduleName) {
+			return nil
+		}
+
+		for _, resource := range resources {
+			if resource.GetKind() != "Secret" {
+				continue
+			}
+			if resource.GetAnnotations()[shared.ReplaceFromKCPAnnotation] != shared.EnableLabelValue {
+				continue
+			}
+
+			kcpSecret, err := secretRepo.Get(ctx, resource.GetName())
+			if err != nil {
+				return fmt.Errorf("failed to get KCP secret %s: %w", resource.GetName(), err)
+			}
+
+			data := make(map[string]any, len(kcpSecret.Data))
+			for k, v := range kcpSecret.Data {
+				data[k] = base64.StdEncoding.EncodeToString(v)
+			}
+			if err := unstructured.SetNestedMap(resource.Object, data, "data"); err != nil {
+				return fmt.Errorf("failed to replace secret data for %s: %w", resource.GetName(), err)
+			}
+		}
+		return nil
+	}
+}

--- a/tests/integration/controller/manifest/custom_resource_check/suite_test.go
+++ b/tests/integration/controller/manifest/custom_resource_check/suite_test.go
@@ -163,7 +163,7 @@ var _ = BeforeSuite(func() {
 		manifestClient, orphanDetectionService, spec.NewResolver(keyChainLookup, extractor),
 		skrclientcache.NewService(),
 		skrclient.NewService(mgr.GetConfig().QPS, mgr.GetConfig().Burst, accessManagerService),
-		kcpClient, cachedManifestParser, statecheck.NewManagerStateCheck(statefulChecker, deploymentChecker), "")
+		kcpClient, cachedManifestParser, statecheck.NewManagerStateCheck(statefulChecker, deploymentChecker), nil)
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Manifest{}).

--- a/tests/integration/controller/manifest/oci_reg_secret/suite_test.go
+++ b/tests/integration/controller/manifest/oci_reg_secret/suite_test.go
@@ -165,7 +165,7 @@ var _ = BeforeSuite(func() {
 		kcpClient,
 		cachedManifestParser,
 		declarativev2.NewExistsStateCheck(),
-		"",
+		nil,
 	)
 
 	err = ctrl.NewControllerManagedBy(mgr).

--- a/tests/integration/controller/manifest/suite_test.go
+++ b/tests/integration/controller/manifest/suite_test.go
@@ -160,7 +160,7 @@ var _ = BeforeSuite(func() {
 		manifestClient, orphanDetectionService, spec.NewResolver(keyChainLookup, extractor),
 		skrclientcache.NewService(),
 		skrclient.NewService(mgr.GetConfig().QPS, mgr.GetConfig().Burst, accessManagerService),
-		kcpClient, cachedManifestParser, declarativev2.NewExistsStateCheck(), "")
+		kcpClient, cachedManifestParser, declarativev2.NewExistsStateCheck(), nil)
 
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta2.Manifest{}).


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- adds a new transform replacing the data of secrets for restricted default modules
- fetches a secret of the same name in kcp-system and replaces the data with the value from scp-system
  - works also on data updates on kcp-system
- transform is only added if restricted default modules are configured to KLM
- transform only applies for resources of restricted default modules
- transform only applies for secrets annotated with operator.kyma-project.io/replace-from-kcp: "true"

### Testing

Secret in Module Manifest

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: custom-image-pull-secret
  namespace: template-operator-system
  annotations:
    operator.kyma-project.io/replace-from-kcp: "true"
type: kubernetes.io/dockerconfigjson
data:
  .dockerconfigjson: |
    eyJhdXRocyI6IHt9fQo=
```

Secret on KCP

```yaml
apiVersion: v1
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJzb21lIG5ldyBjcmVkZW50aWFscyJ9fX0K
kind: Secret
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{".dockerconfigjson":"eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJvcGVuc2VzYW1lIn19fQo=\n"},"kind":"Secret","metadata":{"annotations":{},"name":"template-operator-custom-image-pull-secret","namespace":"kcp-system"},"type":"kubernetes.io/dockerconfigjson"}
  creationTimestamp: "2026-06-10T12:54:54Z"
  name: template-operator-custom-image-pull-secret
  namespace: kcp-system
  resourceVersion: "4203"
  uid: c0f820b5-05bb-4530-88b5-8301c1bb8ee4
type: kubernetes.io/dockerconfigjson
```

Secret applied to SKR

```yaml
apiVersion: v1
data:
  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJzb21lIG5ldyBjcmVkZW50aWFscyJ9fX0K
kind: Secret
metadata:
  annotations:
    deprecated-operator.kyma-project.io/owned-by: kcp-system/kyma-sample-template-operator-2235966007
    operator.kyma-project.io/managed-by-reconciler-disclaimer: |-
      DO NOT EDIT - This resource is managed by Kyma.
      Any modifications are discarded and the resource is reverted to the original state.
    operator.kyma-project.io/replace-from-kcp: "true"
  creationTimestamp: "2026-06-10T12:55:09Z"
  labels:
    app.kubernetes.io/component: kyma-sample-template-operator-2235966007
    app.kubernetes.io/part-of: Kyma
    operator.kyma-project.io/managed-by: kyma
  name: template-operator-custom-image-pull-secret
  namespace: template-operator-system
  resourceVersion: "1689"
  uid: 6af3b192-d5c7-42f7-986d-dcb99f3d1908
type: kubernetes.io/dockerconfigjson

```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
