### PR TITLE
feat: Inject image pull secret data from KCP for deployer module

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,6 +93,8 @@ jobs:
           - restricted-default-module
           - restricted-default-module-catalog-sync
           - restricted-module-normal-installation
+          - deployer-module-image-pull-secret-injection
+          - block-non-deployer-module-image-pull-secret-injection
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -131,6 +133,8 @@ jobs:
             restricted-default-module | \
             restricted-module-normal-installation | \
             restricted-default-module-catalog-sync | \
+            deployer-module-image-pull-secret-injection | \
+            block-non-deployer-module-image-pull-secret-injection | \
             kyma-deprovision-with-foreground-propagation | \
             kyma-deprovision-with-background-propagation | \
             kyma-metrics | \

--- a/api/shared/operator_annotations.go
+++ b/api/shared/operator_annotations.go
@@ -13,7 +13,8 @@ const (
 	UnmanagedAnnotation       = OperatorGroup + Separator + "is-unmanaged"
 	// InjectDataFromKCPAnnotation, when set to "true" on a Secret in a module Manifest, signals
 	// that the Secret's .data MUST be replaced at apply-time with the .data of a matching Secret
-	// fetched from KCP. Only honored for restricted default module "deployer" (see the corresponding resource
-	// transform in internal/declarative/v2).
+	// fetched from KCP. The Secret's .stringData is also cleared to prevent it from overriding the
+	// injected .data. Only honored for restricted default module "deployer" (see the corresponding
+	// resource transform in internal/declarative/v2).
 	InjectDataFromKCPAnnotation = OperatorGroup + Separator + "inject-data-from-kcp"
 )

--- a/api/shared/operator_annotations.go
+++ b/api/shared/operator_annotations.go
@@ -11,4 +11,9 @@ const (
 	OwnedByFormat             = "%s/%s"
 	IsClusterScopedAnnotation = OperatorGroup + Separator + "is-cluster-scoped"
 	UnmanagedAnnotation       = OperatorGroup + Separator + "is-unmanaged"
+	// InjectDataFromKCPAnnotation, when set to "true" on a Secret in a module Manifest, signals
+	// that the Secret's .data MUST be replaced at apply-time with the .data of a matching Secret
+	// fetched from KCP. Only honored for restricted default module "deployer" (see the corresponding resource
+	// transform in internal/declarative/v2).
+	InjectDataFromKCPAnnotation = OperatorGroup + Separator + "inject-data-from-kcp"
 )

--- a/cmd/composition/service/manifest/render/render.go
+++ b/cmd/composition/service/manifest/render/render.go
@@ -2,21 +2,32 @@
 package render
 
 import (
+	"slices"
+
 	declarativev2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
 	"github.com/kyma-project/lifecycle-manager/internal/service/manifest/render"
 )
 
 // ComposeRenderService wires the manifest ResourceRenderService: the default
-// transform chain, plus the optional SkrImagePullSecret transform when
-// skrImagePullSecretName is non-empty.
+// transform chain, plus optional transforms enabled by configuration.
+//
+// The SkrImagePullSecret transform is appended when skrImagePullSecretName is non-empty.
+// The RestrictedDefaultModuleImagePullSecret transform is appended only when the
+// deployer module is configured as a restricted default module — see issue #3345.
 func ComposeRenderService(
 	parser declarativev2.CachedManifestParser,
 	skrImagePullSecretName string,
+	secretRepo declarativev2.SecretRepository,
+	restrictedDefaultModules []string,
 ) *render.Service {
 	transforms := declarativev2.GetDefaultResourceTransforms()
 	if skrImagePullSecretName != "" {
 		transforms = append(transforms,
 			declarativev2.CreateSkrImagePullSecretTransform(skrImagePullSecretName))
+	}
+	if slices.Contains(restrictedDefaultModules, declarativev2.DeployerModuleName) {
+		transforms = append(transforms,
+			declarativev2.CreateDeployerModuleImagePullSecretTransform(secretRepo))
 	}
 	return render.NewService(parser, transforms)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -307,7 +307,7 @@ func setupManager(flagVar *flags.FlagVar, cacheOptions cache.Options, scheme *ma
 		kymaMetrics, logger, maintenanceWindow, ociRegistry.GetReference(), kymaDeletionSvc, kymaLookupSvc,
 		mtEventHandlerMapFunc, mrmEventHandler, restrictedModuleDefaulter)
 	setupManifestReconciler(mgr, flagVar, options, sharedMetrics, mandatoryModulesMetrics, accessManagerService, logger,
-		eventRecorder, kymaRepo)
+		eventRecorder, kymaRepo, secretRepo)
 	setupMandatoryModuleReconciler(mgr, descriptorProvider, mrmRepo, mtRepo, flagVar, options, mandatoryModulesMetrics,
 		logger, ociRegistry.GetReference(), mandatoryMrmHandlerMapFunc)
 	setupMandatoryModuleDeletionReconciler(mgr, eventRecorder, mrmRepo, manifestRepo, flagVar, options, logger)
@@ -545,6 +545,7 @@ func setupManifestReconciler(mgr ctrl.Manager,
 	setupLog logr.Logger,
 	event event.Event,
 	kymaRepo *kymarepo.Repository,
+	secretRepo *secretrepo.Repository,
 ) {
 	options.RateLimiter = internal.RateLimiter(flagVar.FailureBaseDelay,
 		flagVar.FailureMaxDelay, flagVar.RateLimiterFrequency, flagVar.RateLimiterBurst)
@@ -560,7 +561,8 @@ func setupManifestReconciler(mgr ctrl.Manager,
 
 	kcpClient := mgr.GetClient()
 	cachedManifestParser := declarativev2.NewInMemoryCachedManifestParser(declarativev2.DefaultInMemoryParseTTL)
-	renderService := manifestrendercmpse.ComposeRenderService(cachedManifestParser, flagVar.SkrImagePullSecret)
+	renderService := manifestrendercmpse.ComposeRenderService(cachedManifestParser, flagVar.SkrImagePullSecret,
+		secretRepo, flagVar.GetRestrictedDefaultModules())
 	statefulChecker := statecheck.NewStatefulSetStateCheck()
 	deploymentChecker := statecheck.NewDeploymentStateCheck()
 	customStateCheck := statecheck.NewManagerStateCheck(statefulChecker, deploymentChecker)

--- a/internal/declarative/v2/deployer_module_image_pull_secret_transform.go
+++ b/internal/declarative/v2/deployer_module_image_pull_secret_transform.go
@@ -67,6 +67,10 @@ func CreateDeployerModuleImagePullSecretTransform(secretRepo SecretRepository) R
 		}
 
 		for _, resource := range resources {
+			if resource == nil {
+				continue
+			}
+
 			if !isInjectableSecret(resource) {
 				continue
 			}

--- a/internal/declarative/v2/deployer_module_image_pull_secret_transform.go
+++ b/internal/declarative/v2/deployer_module_image_pull_secret_transform.go
@@ -1,0 +1,135 @@
+package v2
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+)
+
+// DeployerModuleName is the only module for which
+// CreateDeployerModuleImagePullSecretTransform takes effect. The transform
+// MUST NOT silently apply to any other module: image-pull-secret data injection is
+// reserved for the deployer module per the feature design (issue #3345).
+const DeployerModuleName = "deployer"
+
+const secretKind = "Secret"
+
+var (
+	// ErrInjectDataFromKCP is the umbrella sentinel for every error returned by
+	// CreateDeployerModuleImagePullSecretTransform. The Manifest
+	// reconciler keys on it (errors.Is) to mark the manifest as StateError and
+	// short-circuit SSA — see renderResourcesForInstall in reconciler.go.
+	ErrInjectDataFromKCP = errors.New("inject-data-from-kcp transform failed")
+
+	ErrInjectFromKCPSecretMissingModuleLabel = fmt.Errorf(
+		"%w: kcp source secret is missing the required %s label", ErrInjectDataFromKCP, shared.ModuleName)
+	ErrInjectFromKCPSecretModuleLabelMismatch = fmt.Errorf(
+		"%w: kcp source secret %s label does not match the manifest module", ErrInjectDataFromKCP, shared.ModuleName)
+)
+
+// SecretRepository reads Secrets from a fixed namespace (kcp-system).
+type SecretRepository interface {
+	Get(ctx context.Context, name string) (*apicorev1.Secret, error)
+}
+
+// CreateDeployerModuleImagePullSecretTransform returns a ResourceTransform
+// that replaces the .data of any Secret resource in the manifest annotated with
+// shared.InjectDataFromKCPAnnotation=true with the .data of a same-named Secret
+// fetched from the KCP control-plane namespace.
+//
+// To prevent module A from reading module B's secret data, the KCP secret MUST
+// carry the shared.ModuleName label matching the manifest's module-name label.
+//
+// The transform is a no-op for any module other than the hardcoded
+// DeployerModuleName.
+func CreateDeployerModuleImagePullSecretTransform(secretRepo SecretRepository) ResourceTransform {
+	return func(ctx context.Context, obj Object, resources []*unstructured.Unstructured) error {
+		manifest, ok := obj.(*v1beta2.Manifest)
+		if !ok {
+			return fmt.Errorf("%w, got %T", ErrResourceTransformExpectedManifestType, obj)
+		}
+
+		// Hardcoded module-name gate: only the deployer module is allowed to inject
+		// secret data from KCP. See DeployerModuleName above.
+		moduleName := manifest.GetLabels()[shared.ModuleName]
+		if moduleName != DeployerModuleName {
+			return nil
+		}
+		if secretRepo == nil {
+			return fmt.Errorf("%w: secret repository is nil", ErrInjectDataFromKCP)
+		}
+
+		for _, resource := range resources {
+			if !isInjectableSecret(resource) {
+				continue
+			}
+			if err := injectDataFromKCP(ctx, secretRepo, moduleName, resource); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func isInjectableSecret(resource *unstructured.Unstructured) bool {
+	if resource.GetKind() != secretKind {
+		return false
+	}
+	return resource.GetAnnotations()[shared.InjectDataFromKCPAnnotation] == shared.EnableLabelValue
+}
+
+func injectDataFromKCP(ctx context.Context, secretRepo SecretRepository,
+	moduleName string, resource *unstructured.Unstructured,
+) error {
+	kcpSecret, err := secretRepo.Get(ctx, resource.GetName())
+	if err != nil {
+		return fmt.Errorf("%w: failed to fetch kcp secret %q: %w", ErrInjectDataFromKCP, resource.GetName(), err)
+	}
+	if kcpSecret.Namespace != shared.DefaultControlPlaneNamespace {
+		return fmt.Errorf("%w: kcp source secret %q must be in namespace %q (got %q)",
+			ErrInjectDataFromKCP, kcpSecret.Name, shared.DefaultControlPlaneNamespace, kcpSecret.Namespace)
+	}
+
+	if err := assertSecretBelongsToModule(kcpSecret, moduleName); err != nil {
+		return err
+	}
+
+	return replaceSecretData(resource, kcpSecret.Data)
+}
+
+func assertSecretBelongsToModule(kcpSecret *apicorev1.Secret, moduleName string) error {
+	srcModule, present := kcpSecret.Labels[shared.ModuleName]
+	switch {
+	case !present:
+		return fmt.Errorf("%w: secret=%s", ErrInjectFromKCPSecretMissingModuleLabel, kcpSecret.Name)
+	case srcModule != moduleName:
+		return fmt.Errorf("%w: secret=%s expected=%s actual=%s",
+			ErrInjectFromKCPSecretModuleLabelMismatch, kcpSecret.Name, moduleName, srcModule)
+	}
+	return nil
+}
+
+func replaceSecretData(resource *unstructured.Unstructured, data map[string][]byte) error {
+	// Secret JSON encoding for .data is map<string, base64-string>; we receive the
+	// already-decoded raw bytes from the typed Secret and re-encode here.
+	//
+	// If present, stringData can override data during apply, so remove it to ensure
+	// the injected .data is effective.
+	unstructured.RemoveNestedField(resource.Object, "stringData")
+
+	encoded := make(map[string]any, len(data))
+	for key, value := range data {
+		encoded[key] = base64.StdEncoding.EncodeToString(value)
+	}
+	if err := unstructured.SetNestedMap(resource.Object, encoded, "data"); err != nil {
+		return fmt.Errorf("%w: failed to set .data on secret %q: %w", ErrInjectDataFromKCP, resource.GetName(), err)
+	}
+	return nil
+}

--- a/internal/declarative/v2/deployer_module_image_pull_secret_transform_test.go
+++ b/internal/declarative/v2/deployer_module_image_pull_secret_transform_test.go
@@ -260,6 +260,26 @@ func TestDeployerModuleImagePullSecretTransform_ReplacesAllAnnotatedSecrets(t *t
 	}
 }
 
+func TestDeployerModuleImagePullSecretTransform_SkipsNilResource(t *testing.T) {
+	t.Parallel()
+
+	srcData := map[string][]byte{".dockerconfigjson": []byte(`{"auths":{}}`)}
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		testKCPSecretName: newKCPSecret(testKCPSecretName, testDeployerModule, srcData),
+	}}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{nil, resource})
+	require.NoError(t, err)
+
+	gotData, found, err := unstructured.NestedStringMap(resource.Object, "data")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, base64.StdEncoding.EncodeToString(srcData[".dockerconfigjson"]), gotData[".dockerconfigjson"])
+}
+
 func TestDeployerModuleImagePullSecretTransform_Errors_WhenObjectIsNotManifest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/v2/deployer_module_image_pull_secret_transform_test.go
+++ b/internal/declarative/v2/deployer_module_image_pull_secret_transform_test.go
@@ -1,0 +1,283 @@
+package v2_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apicorev1 "k8s.io/api/core/v1"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	machineryruntime "k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	declarativev2 "github.com/kyma-project/lifecycle-manager/internal/declarative/v2"
+)
+
+const (
+	testKCPSecretName  = "deployer-image-pull" //nolint:gosec // not a credential, just a Secret resource name
+	testDeployerModule = "deployer"
+	testOtherModule    = "other-module"
+)
+
+// secretRepoStub satisfies declarativev2.SecretRepository for the unit tests.
+type secretRepoStub struct {
+	secrets  map[string]*apicorev1.Secret
+	getError error
+}
+
+func (s *secretRepoStub) Get(_ context.Context, name string) (*apicorev1.Secret, error) {
+	if s.getError != nil {
+		return nil, s.getError
+	}
+	secret, ok := s.secrets[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return secret, nil
+}
+
+func newKCPSecret(name, moduleLabel string, data map[string][]byte) *apicorev1.Secret {
+	labels := map[string]string{}
+	if moduleLabel != "" {
+		labels[shared.ModuleName] = moduleLabel
+	}
+	return &apicorev1.Secret{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:      name,
+			Namespace: shared.DefaultControlPlaneNamespace,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+}
+
+func newManifest(moduleName string) *v1beta2.Manifest {
+	manifest := &v1beta2.Manifest{}
+	if moduleName != "" {
+		manifest.SetLabels(map[string]string{shared.ModuleName: moduleName})
+	}
+	return manifest
+}
+
+func newSecretResource(name string, annotations map[string]string, data map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name": name,
+		},
+	}
+	if data != nil {
+		obj["data"] = data
+	}
+	res := &unstructured.Unstructured{Object: obj}
+	if len(annotations) > 0 {
+		res.SetAnnotations(annotations)
+	}
+	return res
+}
+
+func TestDeployerModuleImagePullSecretTransform_ReplacesData_WhenDeployerAndAnnotated(t *testing.T) {
+	t.Parallel()
+
+	srcData := map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"registry":{}}}`)}
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		testKCPSecretName: newKCPSecret(testKCPSecretName, testDeployerModule, srcData),
+	}}
+
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue},
+		map[string]any{".dockerconfigjson": base64.StdEncoding.EncodeToString([]byte("dummy"))})
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.NoError(t, err)
+
+	gotData, found, err := unstructured.NestedStringMap(resource.Object, "data")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, base64.StdEncoding.EncodeToString(srcData[".dockerconfigjson"]), gotData[".dockerconfigjson"])
+	require.Len(t, gotData, 1)
+}
+
+func TestDeployerModuleImagePullSecretTransform_NoOp_WhenManifestIsNotDeployer(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		testKCPSecretName: newKCPSecret(testKCPSecretName, testOtherModule,
+			map[string][]byte{"k": []byte("v")}),
+	}}
+	originalData := map[string]any{"k": base64.StdEncoding.EncodeToString([]byte("dummy"))}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue},
+		originalData)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testOtherModule), []*unstructured.Unstructured{resource})
+	require.NoError(t, err)
+
+	gotData, _, err := unstructured.NestedStringMap(resource.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, originalData["k"], gotData["k"])
+}
+
+func TestDeployerModuleImagePullSecretTransform_NoOp_WhenManifestHasNoModuleNameLabel(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{}}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(""), []*unstructured.Unstructured{resource})
+	require.NoError(t, err)
+}
+
+func TestDeployerModuleImagePullSecretTransform_IgnoresSecret_WhenAnnotationMissing(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{}}
+	originalData := map[string]any{"k": base64.StdEncoding.EncodeToString([]byte("dummy"))}
+	resource := newSecretResource(testKCPSecretName, nil, originalData)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.NoError(t, err)
+
+	gotData, _, err := unstructured.NestedStringMap(resource.Object, "data")
+	require.NoError(t, err)
+	require.Equal(t, originalData["k"], gotData["k"])
+}
+
+func TestDeployerModuleImagePullSecretTransform_IgnoresNonSecretResource_WithAnnotation(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{}}
+	configMap := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":        "decoy",
+			"annotations": map[string]any{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue},
+		},
+	}}
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{configMap})
+	require.NoError(t, err)
+}
+
+func TestDeployerModuleImagePullSecretTransform_Errors_WhenKCPSecretMissingModuleLabel(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		testKCPSecretName: newKCPSecret(testKCPSecretName, "", map[string][]byte{"k": []byte("v")}),
+	}}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.ErrorIs(t, err, declarativev2.ErrInjectFromKCPSecretMissingModuleLabel)
+	require.ErrorIs(t, err, declarativev2.ErrInjectDataFromKCP)
+}
+
+func TestDeployerModuleImagePullSecretTransform_Errors_WhenKCPSecretLabelMismatch(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		testKCPSecretName: newKCPSecret(testKCPSecretName, testOtherModule, map[string][]byte{"k": []byte("v")}),
+	}}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.ErrorIs(t, err, declarativev2.ErrInjectFromKCPSecretModuleLabelMismatch)
+	require.ErrorIs(t, err, declarativev2.ErrInjectDataFromKCP)
+}
+
+func TestDeployerModuleImagePullSecretTransform_Errors_WhenKCPSecretInWrongNamespace(t *testing.T) {
+	t.Parallel()
+
+	wrongNs := newKCPSecret(testKCPSecretName, testDeployerModule, map[string][]byte{"k": []byte("v")})
+	wrongNs.Namespace = "default"
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{testKCPSecretName: wrongNs}}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.ErrorIs(t, err, declarativev2.ErrInjectDataFromKCP)
+}
+
+func TestDeployerModuleImagePullSecretTransform_PropagatesRepositoryError(t *testing.T) {
+	t.Parallel()
+
+	repoErr := errors.New("kcp api unavailable")
+	repo := &secretRepoStub{getError: repoErr}
+	resource := newSecretResource(testKCPSecretName,
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule), []*unstructured.Unstructured{resource})
+	require.ErrorIs(t, err, repoErr)
+	require.ErrorIs(t, err, declarativev2.ErrInjectDataFromKCP)
+}
+
+func TestDeployerModuleImagePullSecretTransform_ReplacesAllAnnotatedSecrets(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{secrets: map[string]*apicorev1.Secret{
+		"secret-a": newKCPSecret("secret-a", testDeployerModule, map[string][]byte{"a": []byte("aa")}),
+		"secret-b": newKCPSecret("secret-b", testDeployerModule, map[string][]byte{"b": []byte("bb")}),
+	}}
+	resourceA := newSecretResource("secret-a",
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+	resourceB := newSecretResource("secret-b",
+		map[string]string{shared.InjectDataFromKCPAnnotation: shared.EnableLabelValue}, nil)
+
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+	err := transform(t.Context(), newManifest(testDeployerModule),
+		[]*unstructured.Unstructured{resourceA, resourceB})
+	require.NoError(t, err)
+
+	for _, pair := range []struct {
+		resource *unstructured.Unstructured
+		key      string
+		raw      []byte
+	}{
+		{resourceA, "a", []byte("aa")},
+		{resourceB, "b", []byte("bb")},
+	} {
+		got, _, err := unstructured.NestedStringMap(pair.resource.Object, "data")
+		require.NoError(t, err)
+		require.Equal(t, base64.StdEncoding.EncodeToString(pair.raw), got[pair.key])
+	}
+}
+
+func TestDeployerModuleImagePullSecretTransform_Errors_WhenObjectIsNotManifest(t *testing.T) {
+	t.Parallel()
+
+	repo := &secretRepoStub{}
+	transform := declarativev2.CreateDeployerModuleImagePullSecretTransform(repo)
+
+	err := transform(t.Context(), &nonManifestObject{}, nil)
+	require.ErrorIs(t, err, declarativev2.ErrResourceTransformExpectedManifestType)
+}
+
+// nonManifestObject implements declarativev2.Object without being a *v1beta2.Manifest,
+// to exercise the type assertion guard inside the transform.
+type nonManifestObject struct {
+	apicorev1.ConfigMap
+}
+
+func (n *nonManifestObject) GetStatus() shared.Status  { return shared.Status{} }
+func (n *nonManifestObject) SetStatus(_ shared.Status) {}
+func (n *nonManifestObject) DeepCopyObject() machineryruntime.Object {
+	return &nonManifestObject{ConfigMap: n.ConfigMap}
+}

--- a/internal/declarative/v2/reconciler.go
+++ b/internal/declarative/v2/reconciler.go
@@ -216,6 +216,12 @@ func (r *Reconciler) install(ctx context.Context, req ctrl.Request,
 
 	target, current, err := r.renderResourcesForInstall(ctx, skrClient, manifest, spec)
 	if err != nil {
+		// The inject-data-from-kcp transform marks an unrecoverable misconfiguration
+		// of the deployer module's secret wiring. Surface it as StateError so the
+		// Kyma CR reflects the failure; the early return below already skips SSA.
+		if errors.Is(err, ErrInjectDataFromKCP) {
+			manifest.SetStatus(manifest.GetStatus().WithState(shared.StateError).WithErr(err))
+		}
 		return r.finishReconcile(ctx, manifest, metrics.ManifestRenderResources, manifestStatus, err)
 	}
 

--- a/pkg/testutils/modulecr.go
+++ b/pkg/testutils/modulecr.go
@@ -24,6 +24,8 @@ const (
 	ModuleManagedCRName                = "template-operator-managed-resource"
 	ModuleDeploymentNameInNewerVersion = "template-operator-v2-controller-manager"
 	ModuleDeploymentNameInOlderVersion = "template-operator-v1-controller-manager"
+
+	DeployerModuleName = "deployer"
 )
 
 var (

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -58,6 +58,10 @@ func NewTemplateOperator(channel string) v1beta2.Module {
 	return NewTestModuleWithFixName(TestModuleName, channel, "")
 }
 
+func NewDeployer(channel string) v1beta2.Module {
+	return NewTestModuleWithFixName(DeployerModuleName, channel, "")
+}
+
 func NewTestModuleWithFixName(name, channel, version string) v1beta2.Module {
 	return v1beta2.Module{
 		Name:    name,

--- a/scripts/tests/deploy_moduletemplate_e2e.sh
+++ b/scripts/tests/deploy_moduletemplate_e2e.sh
@@ -52,8 +52,8 @@ make build-manifests
 yq eval "(. | select(.kind == \"Deployment\") | .metadata.name) = \"${DEPLOYMENT_NAME}\"" -i template-operator.yaml
 
 for resource in "${ADDITIONAL_RESOURCES[@]}"; do
-  printf '\n' >> template-operator.yaml
-  cat "$resource" >> template-operator.yaml
+  yq eval-all '.' template-operator.yaml "$resource" > template-operator.yaml.tmp
+  mv template-operator.yaml.tmp template-operator.yaml
 done
 
 ./deploy_moduletemplate.sh \

--- a/scripts/tests/deploy_moduletemplate_e2e.sh
+++ b/scripts/tests/deploy_moduletemplate_e2e.sh
@@ -12,17 +12,19 @@ MANDATORY=false
 INCLUDE_DEFAULT_CR=true
 REQUIRES_DOWNTIME=false
 DEPLOY_MODULETEMPLATE=true
+ADDITIONAL_RESOURCES=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --module-name)        MODULE_NAME="$2";            shift 2 ;;
-    --version)            RELEASE_VERSION="$2";        shift 2 ;;
-    --deployment-name)    DEPLOYMENT_NAME="$2";        shift 2 ;;
-    --deployable-version) DEPLOYABLE_VERSION="$2";     shift 2 ;;
-    --mandatory)          MANDATORY=true;               shift   ;;
-    --no-default-cr)      INCLUDE_DEFAULT_CR=false;    shift   ;;
-    --requires-downtime)  REQUIRES_DOWNTIME=true;      shift   ;;
-    --skip-apply)         DEPLOY_MODULETEMPLATE=false;  shift   ;;
+    --module-name)           MODULE_NAME="$2";                    shift 2 ;;
+    --version)               RELEASE_VERSION="$2";                shift 2 ;;
+    --deployment-name)       DEPLOYMENT_NAME="$2";                shift 2 ;;
+    --deployable-version)    DEPLOYABLE_VERSION="$2";             shift 2 ;;
+    --mandatory)             MANDATORY=true;                       shift   ;;
+    --no-default-cr)         INCLUDE_DEFAULT_CR=false;            shift   ;;
+    --requires-downtime)     REQUIRES_DOWNTIME=true;              shift   ;;
+    --skip-apply)            DEPLOY_MODULETEMPLATE=false;          shift   ;;
+    --additional-resources)  ADDITIONAL_RESOURCES+=("$2");        shift 2 ;;
     *) echo "Unknown flag: $1"; exit 1 ;;
   esac
 done
@@ -48,6 +50,11 @@ echo "=== Preparing module template: ${MODULE_NAME} ${RELEASE_VERSION} ==="
 yq eval ".images[0].newTag = \"${RELEASE_VERSION}\"" -i config/manager/deployment/kustomization.yaml
 make build-manifests
 yq eval "(. | select(.kind == \"Deployment\") | .metadata.name) = \"${DEPLOYMENT_NAME}\"" -i template-operator.yaml
+
+for resource in "${ADDITIONAL_RESOURCES[@]}"; do
+  printf '\n' >> template-operator.yaml
+  cat "$resource" >> template-operator.yaml
+done
 
 ./deploy_moduletemplate.sh \
   "${MODULE_NAME}" \

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -223,3 +223,9 @@ restricted-default-module-catalog-sync:
 
 restricted-module-normal-installation:
 	$(MAKE) -f $(MAKEFILE_DIR)/restricted_module_normal_module_installation_test.mk test
+
+deployer-module-image-pull-secret-injection:
+	$(MAKE) -f $(MAKEFILE_DIR)/deployer_module_image_pull_secret_injection_test.mk test
+
+block-non-deployer-module-image-pull-secret-injection:
+	$(MAKE) -f $(MAKEFILE_DIR)/block_non_deployer_module_image_pull_secret_injection_test.mk test

--- a/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.go
+++ b/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.go
@@ -1,0 +1,57 @@
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
+	. "github.com/kyma-project/lifecycle-manager/tests/e2e/commontestutils"
+)
+
+const notDeployerModuleName = "not-deployer"
+
+var _ = Describe("2 Block Non Deployer Module Image Pull Secret Injection", Ordered, func() {
+	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	// this global account id is added to the module release meta in the Makefile
+	kyma.Labels["kyma-project.io/global-account-id"] = GlobalAccountID2
+	moduleCR := NewTestModuleCR(RemoteNamespace)
+
+	InitEmptyKymaBeforeAll(kyma)
+	CleanupKymaAfterAll(kyma)
+
+	Context("Given SKR Cluster", func() {
+		It("Then the not-deployer module is installed as a restricted default module", func() {
+			Eventually(ContainsModuleInSpec).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), notDeployerModuleName).
+				Should(Succeed())
+			By("And the Module CR has been installed on the SKR cluster")
+			Eventually(ModuleCRExists).
+				WithContext(ctx).
+				WithArguments(skrClient, moduleCR).
+				Should(Succeed())
+			By("And the Module Operator Deployment is ready on the SKR cluster")
+			Eventually(DeploymentIsReady).
+				WithContext(ctx).
+				WithArguments(skrClient, ModuleDeploymentNameInOlderVersion, TestModuleResourceNamespace).
+				Should(Succeed())
+		})
+
+		It("Then the annotated image-pull-secret on the SKR is not patched", func() {
+			Consistently(SecretDataEquals).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					"image-pull-secret",
+					TestModuleResourceNamespace,
+					".dockerconfigjson",
+					[]byte(`{"auths": {}}`+"\n"),
+				).
+				WithTimeout(ConsistentDuration).
+				WithPolling(interval).
+				Should(Succeed())
+		})
+	})
+})

--- a/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.mk
+++ b/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.mk
@@ -13,7 +13,7 @@ klm-patch: kustomize-install
 	@export PATH=$(LOCALBIN):$$PATH
 	@pushd $(LIFECYCLE_MANAGER_DIR)/config/watcher_local_test > /dev/null
 	kustomize edit add patch --kind Deployment --patch \
-		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=deployer,$(MODULE_NAME)"}]'
+		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=${DEPLOYER_MODULE_NAME},$(MODULE_NAME)"}]'
 	@popd > /dev/null
 	@echo "::endgroup::"
 

--- a/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.mk
+++ b/tests/e2e/block_non_deployer_module_image_pull_secret_injection_test.mk
@@ -1,0 +1,69 @@
+.DEFAULT_GOAL := test
+.PHONY: test $(MAKECMDGOALS)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
+
+MODULE_NAME := not-deployer
+DEPLOYER_MODULE_NAME := deployer
+GLOBAL_ACCOUNT_ID ?= f6e5d4c3-b2a1-9087-6543-210fedcba987
+
+.PHONY: klm-patch
+klm-patch: kustomize-install
+	@echo "::group::KLM patch"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(LIFECYCLE_MANAGER_DIR)/config/watcher_local_test > /dev/null
+	kustomize edit add patch --kind Deployment --patch \
+		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=deployer,$(MODULE_NAME)"}]'
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: module-setup
+module-setup:
+	@echo "::group::Test-specific module metadata setup"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(TEMPLATE_OPERATOR_DIR) > /dev/null
+# not-deployer module fulfills the criteria for image pull secret injection;
+	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh \
+		--module-name $(MODULE_NAME) \
+		--version $(MODULE_OLDER_VERSION) \
+		--deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) \
+		--deployable-version $(MODULE_DEPLOYABLE_VERSION) \
+		--additional-resources $(E2E_TESTS_DIR)/testdata/skr-deployer-image-pull-secret.yaml
+	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
+	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["$(GLOBAL_ACCOUNT_ID)"]}]' module-release-meta.yaml
+	kubectl apply -f module-release-meta.yaml
+	rm -f module-release-meta.yaml
+# deployer module is required to exist because it is configured as a restricted default module;
+# its kymaSelector uses a non-matching global-account-id so it is not installed for the test Kyma CR
+	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh \
+		--module-name $(DEPLOYER_MODULE_NAME) \
+		--version $(MODULE_OLDER_VERSION) \
+		--deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) \
+		--deployable-version $(MODULE_DEPLOYABLE_VERSION)
+	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(DEPLOYER_MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
+	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["00000000-0000-0000-0000-000000000000"]}]' module-release-meta.yaml
+	kubectl apply -f module-release-meta.yaml
+	rm -f module-release-meta.yaml
+# KCP secret: data that should NOT be injected because the module is not named "deployer"
+	kubectl apply -f $(E2E_TESTS_DIR)/testdata/kcp-not-deployer-image-pull-secret.yaml
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: test-run
+test-run: log-tool-versions
+	@echo "::group::Setting kubeconfig variables"
+	@export KCP_KUBECONFIG=$(shell k3d kubeconfig write kcp)
+	@export SKR_KUBECONFIG=$(shell k3d kubeconfig write skr)
+	@echo "::endgroup::"
+
+	@echo "::group::E2E test: Block Non Deployer Module Image Pull Secret Injection"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(E2E_TESTS_DIR) > /dev/null
+	set +e; $(GO) test -timeout 20m -ginkgo.v -ginkgo.focus "2 Block Non Deployer Module Image Pull Secret Injection"; status=$$?; set -e
+	@popd > /dev/null
+	@echo "::endgroup::"
+	exit $${status}
+
+
+.PHONY: test
+test: create-clusters klm-patch deploy-klm module-setup test-run

--- a/tests/e2e/deployer_module_image_pull_secret_injection_test.go
+++ b/tests/e2e/deployer_module_image_pull_secret_injection_test.go
@@ -1,0 +1,143 @@
+package e2e_test
+
+import (
+	"fmt"
+
+	"github.com/kyma-project/lifecycle-manager/api/shared"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
+	. "github.com/kyma-project/lifecycle-manager/tests/e2e/commontestutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("1 Deployer Module Image Pull Secret Injection", Ordered, func() {
+	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
+	// this global account id is added to the module release meta in the Makefile
+	kyma.Labels["kyma-project.io/global-account-id"] = GlobalAccountID2
+	moduleCR := NewTestModuleCR(RemoteNamespace)
+
+	imagePullResourceName := "image-pull-secret"
+	injectFromKCPTransform := "inject-data-from-kcp transform failed"
+	errMsgModuleLabelMismatch := fmt.Sprintf(
+		"%s: kcp source secret %s label does not match the manifest module"+
+			": secret=%s expected=deployer actual=not-deployer",
+		injectFromKCPTransform, shared.ModuleName, imagePullResourceName)
+	errMsgMissingModuleLabel := fmt.Sprintf(
+		"%s: kcp source secret is missing the required %s label: secret=%s",
+		injectFromKCPTransform, shared.ModuleName, imagePullResourceName)
+	errMsgFetchKCPSecret := fmt.Sprintf(
+		"%s: failed to fetch kcp secret %q: failed to get secret %s-kcp-system: secrets %q not found",
+		injectFromKCPTransform, imagePullResourceName, imagePullResourceName, imagePullResourceName)
+
+	InitEmptyKymaBeforeAll(kyma)
+	CleanupKymaAfterAll(kyma)
+
+	Context("Given SKR Cluster", func() {
+		It("Then the deployer module is enabled as a restricted default module", func() {
+			Eventually(ContainsModuleInSpec).
+				WithContext(ctx).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName).
+				Should(Succeed())
+			By("And the Module CR has been installed on the SKR cluster")
+			Eventually(ModuleCRExists).
+				WithContext(ctx).
+				WithArguments(skrClient, moduleCR).
+				Should(Succeed())
+			By("And the Module Operator Deployment is ready on the SKR cluster")
+			Eventually(DeploymentIsReady).
+				WithContext(ctx).
+				WithArguments(skrClient, ModuleDeploymentNameInOlderVersion, TestModuleResourceNamespace).
+				Should(Succeed())
+		})
+
+		It("Then the image-pull-secret on the SKR has data injected from KCP", func() {
+			Consistently(SecretDataEquals).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					imagePullResourceName,
+					TestModuleResourceNamespace,
+					".dockerconfigjson",
+					[]byte(`{"auths":{"e2e-test.example.com":{"username":"test","password":"test"}}}`+"\n"),
+				).
+				WithTimeout(ConsistentDuration).
+				WithPolling(interval).
+				Should(Succeed())
+		})
+
+		It("Then the non-annotated pull secret on the SKR retains its original data", func() {
+			Consistently(SecretDataEquals).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					"non-inject-pull-secret",
+					TestModuleResourceNamespace,
+					".dockerconfigjson",
+					[]byte(`{"auths": {}}`+"\n"),
+				).
+				WithTimeout(ConsistentDuration).
+				WithPolling(interval).
+				Should(Succeed())
+		})
+
+		It("Then after the KCP secret module-name label is changed, the Manifest reports a module label mismatch error",
+			func() {
+				By("When the KCP image-pull-secret module-name label is changed to a non-matching value")
+				Expect(UpdateSecretLabel(ctx, kcpClient, imagePullResourceName,
+					shared.DefaultControlPlaneNamespace, shared.ModuleName, "not-deployer")).To(Succeed())
+				By("Then the Manifest reports a module label mismatch error")
+				Eventually(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgModuleLabelMismatch).
+					Should(Succeed())
+				Consistently(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgModuleLabelMismatch).
+					WithTimeout(ConsistentDuration).
+					WithPolling(interval).
+					Should(Succeed())
+			})
+
+		It("Then with the KCP secret module-name label removed, the Manifest reports a missing module label error",
+			func() {
+				By("When the KCP image-pull-secret module-name label is removed entirely")
+				Expect(RemoveSecretLabel(ctx, kcpClient, imagePullResourceName,
+					shared.DefaultControlPlaneNamespace, shared.ModuleName)).To(Succeed())
+				By("Then the Manifest reports a missing module label error")
+				Eventually(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgMissingModuleLabel).
+					Should(Succeed())
+				Consistently(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgMissingModuleLabel).
+					WithTimeout(ConsistentDuration).
+					WithPolling(interval).
+					Should(Succeed())
+			})
+		It("Then with the KCP secret deleted, the Manifest reports a failure to fetch the KCP secret",
+			func() {
+				By("When the KCP image-pull-secret is deleted")
+				Expect(DeleteAnySecret(ctx, imagePullResourceName, kcpClient)).To(Succeed())
+				By("Then the Manifest reports a failure to fetch the KCP secret")
+				Eventually(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgFetchKCPSecret).
+					Should(Succeed())
+				Consistently(ManifestStatusOperationContainsMessage).
+					WithContext(ctx).
+					WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName,
+						errMsgFetchKCPSecret).
+					WithTimeout(ConsistentDuration).
+					WithPolling(interval).
+					Should(Succeed())
+			})
+	})
+})

--- a/tests/e2e/deployer_module_image_pull_secret_injection_test.go
+++ b/tests/e2e/deployer_module_image_pull_secret_injection_test.go
@@ -67,6 +67,25 @@ var _ = Describe("1 Deployer Module Image Pull Secret Injection", Ordered, func(
 				Should(Succeed())
 		})
 
+		It("Then a change to the KCP secret data eventually propagates to the SKR", func() {
+			updatedDockerConfig := []byte(
+				`{"auths":{"e2e-test.example.com":{"username":"updated","password":"updated"}}}` + "\n")
+			By("When the KCP image-pull-secret data is updated")
+			Expect(UpdateSecretDataKey(ctx, kcpClient, imagePullResourceName,
+				shared.DefaultControlPlaneNamespace, ".dockerconfigjson", updatedDockerConfig)).To(Succeed())
+			By("Then the updated data eventually arrives at the SKR image-pull-secret")
+			Eventually(SecretDataEquals).
+				WithContext(ctx).
+				WithArguments(
+					skrClient,
+					imagePullResourceName,
+					TestModuleResourceNamespace,
+					".dockerconfigjson",
+					updatedDockerConfig,
+				).
+				Should(Succeed())
+		})
+
 		It("Then the non-annotated pull secret on the SKR retains its original data", func() {
 			Consistently(SecretDataEquals).
 				WithContext(ctx).

--- a/tests/e2e/deployer_module_image_pull_secret_injection_test.mk
+++ b/tests/e2e/deployer_module_image_pull_secret_injection_test.mk
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL := test
+.PHONY: test $(MAKECMDGOALS)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
+
+MODULE_NAME := deployer
+GLOBAL_ACCOUNT_ID ?= f6e5d4c3-b2a1-9087-6543-210fedcba987
+
+.PHONY: klm-patch
+klm-patch: kustomize-install
+	@echo "::group::KLM patch"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(LIFECYCLE_MANAGER_DIR)/config/watcher_local_test > /dev/null
+	kustomize edit add patch --kind Deployment --patch \
+		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=$(MODULE_NAME)"}]'
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: module-setup
+module-setup:
+	@echo "::group::Test-specific module metadata setup"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(TEMPLATE_OPERATOR_DIR) > /dev/null
+	$(SCRIPTS_DIR)/deploy_moduletemplate_e2e.sh \
+		--module-name $(MODULE_NAME) \
+		--version $(MODULE_OLDER_VERSION) \
+		--deployment-name $(MODULE_DEPLOYMENT_OLDER_VERSION) \
+		--deployable-version $(MODULE_DEPLOYABLE_VERSION) \
+		--additional-resources $(E2E_TESTS_DIR)/testdata/skr-deployer-image-pull-secret.yaml \
+		--additional-resources $(E2E_TESTS_DIR)/testdata/skr-deployer-non-inject-pull-secret.yaml
+	KEEP_FILE=true $(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(MODULE_NAME) fast:$(MODULE_OLDER_VERSION) regular:$(MODULE_OLDER_VERSION)
+	yq -i '.spec.kymaSelector.matchExpressions = [{"key": "kyma-project.io/global-account-id", "operator": "In", "values": ["$(GLOBAL_ACCOUNT_ID)"]}]' module-release-meta.yaml
+	kubectl apply -f module-release-meta.yaml
+	rm -f module-release-meta.yaml
+# KCP secret: actual data that KLM should inject into the deployer module's secret on SKR
+	kubectl apply -f $(E2E_TESTS_DIR)/testdata/kcp-deployer-image-pull-secret.yaml
+# KCP secret with matching name but no annotation on the SKR counterpart — should not be injected
+	kubectl apply -f $(E2E_TESTS_DIR)/testdata/kcp-deployer-non-inject-pull-secret.yaml
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: test-run
+test-run: log-tool-versions
+	@echo "::group::Setting kubeconfig variables"
+	@export KCP_KUBECONFIG=$(shell k3d kubeconfig write kcp)
+	@export SKR_KUBECONFIG=$(shell k3d kubeconfig write skr)
+	@echo "::endgroup::"
+
+	@echo "::group::E2E test: Deployer Module Image Pull Secret Injection"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(E2E_TESTS_DIR) > /dev/null
+	set +e; $(GO) test -timeout 20m -ginkgo.v -ginkgo.focus "1 Deployer Module Image Pull Secret Injection"; status=$$?; set -e
+	@popd > /dev/null
+	@echo "::endgroup::"
+	exit $${status}
+
+
+.PHONY: test
+test: create-clusters klm-patch deploy-klm module-setup test-run

--- a/tests/e2e/restricted_default_module_catalog_sync_test.go
+++ b/tests/e2e/restricted_default_module_catalog_sync_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("Restricted Default Module Catalog Sync", Ordered, func() {
 	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
-	module := NewTemplateOperator(v1beta2.DefaultChannel)
+	module := NewDeployer(v1beta2.DefaultChannel)
 
 	InitEmptyKymaBeforeAll(kyma)
 	CleanupKymaAfterAll(kyma)

--- a/tests/e2e/restricted_default_module_catalog_sync_test.mk
+++ b/tests/e2e/restricted_default_module_catalog_sync_test.mk
@@ -3,13 +3,15 @@
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
 
+MODULE_NAME := deployer
+
 .PHONY: klm-patch
 klm-patch: kustomize-install
 	@echo "::group::KLM patch"
 	@export PATH=$(LOCALBIN):$$PATH
 	@pushd $(LIFECYCLE_MANAGER_DIR)/config/watcher_local_test > /dev/null
 	kustomize edit add patch --kind Deployment --patch \
-		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=template-operator"}]'
+		'[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--restricted-default-modules=$(MODULE_NAME)"}]'
 	@popd > /dev/null
 	@echo "::endgroup::"
 

--- a/tests/e2e/restricted_default_module_test.go
+++ b/tests/e2e/restricted_default_module_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("Restricted Default Modules", Ordered, func() {
 	kyma := NewKymaWithNamespaceName("kyma-sample", ControlPlaneNamespace, v1beta2.DefaultChannel)
 	// this global account id is added to the module release meta in the Makefile
-	kyma.Labels["kyma-project.io/global-account-id"] = "f6e5d4c3-b2a1-9087-6543-210fedcba987"
+	kyma.Labels["kyma-project.io/global-account-id"] = GlobalAccountID2
 	moduleCR := NewTestModuleCR(RemoteNamespace)
 
 	InitEmptyKymaBeforeAll(kyma)

--- a/tests/e2e/restricted_default_module_test.go
+++ b/tests/e2e/restricted_default_module_test.go
@@ -25,12 +25,12 @@ var _ = Describe("Restricted Default Modules", Ordered, func() {
 		It("Then the matching restricted module is enabled on the KCP cluster", func() {
 			Eventually(ContainsModuleInSpec).
 				WithContext(ctx).
-				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), TestModuleName).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), DeployerModuleName).
 				Should(Succeed())
 			By("And the non-matching restricted module is not enabled on the KCP cluster")
 			Eventually(NotContainsModuleInSpec).
 				WithContext(ctx).
-				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "not-"+TestModuleName).
+				WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), "not-"+DeployerModuleName).
 				Should(Succeed())
 			By("And the Module CR has been installed on the SKR cluster")
 			Eventually(ModuleCRExists).
@@ -47,7 +47,7 @@ var _ = Describe("Restricted Default Modules", Ordered, func() {
 		It("When the restricted module is disabled on the SKR cluster", func() {
 			Eventually(DisableModule).
 				WithContext(ctx).
-				WithArguments(skrClient, defaultRemoteKymaName, RemoteNamespace, TestModuleName).
+				WithArguments(skrClient, defaultRemoteKymaName, RemoteNamespace, DeployerModuleName).
 				Should(Succeed())
 
 			By("Then the Module CR is removed from the SKR cluster")
@@ -77,7 +77,7 @@ var _ = Describe("Restricted Default Modules", Ordered, func() {
 			Eventually(EnableModule).
 				WithContext(ctx).
 				WithArguments(skrClient, defaultRemoteKymaName, RemoteNamespace,
-					NewTemplateOperator(v1beta2.DefaultChannel)).
+					NewDeployer(v1beta2.DefaultChannel)).
 				Should(Succeed())
 
 			By("And the Module CR has been installed on the SKR cluster")

--- a/tests/e2e/restricted_default_module_test.mk
+++ b/tests/e2e/restricted_default_module_test.mk
@@ -3,6 +3,8 @@
 
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
 
+MODULE_NAME := deployer
+
 RESTRICTED_DEFAULT_MODULES ?= $(MODULE_NAME),not-$(MODULE_NAME)
 GLOBAL_ACCOUNT_ID_1 ?= a1c1d2e3-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 # this global account id is added to the Kyma labels in the test

--- a/tests/e2e/testdata/kcp-deployer-image-pull-secret.yaml
+++ b/tests/e2e/testdata/kcp-deployer-image-pull-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret
+  namespace: kcp-system
+  labels:
+    operator.kyma-project.io/module-name: deployer
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJlMmUtdGVzdC5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6InRlc3QiLCJwYXNzd29yZCI6InRlc3QifX19Cg==

--- a/tests/e2e/testdata/kcp-deployer-non-inject-pull-secret.yaml
+++ b/tests/e2e/testdata/kcp-deployer-non-inject-pull-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: non-inject-pull-secret
+  namespace: kcp-system
+  labels:
+    operator.kyma-project.io/module-name: deployer
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJlMmUtdGVzdC5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6InRlc3QiLCJwYXNzd29yZCI6InRlc3QifX19Cg==

--- a/tests/e2e/testdata/kcp-not-deployer-image-pull-secret.yaml
+++ b/tests/e2e/testdata/kcp-not-deployer-image-pull-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret
+  namespace: kcp-system
+  labels:
+    operator.kyma-project.io/module-name: not-deployer
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJlMmUtdGVzdC5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6InRlc3QiLCJwYXNzd29yZCI6InRlc3QifX19Cg==

--- a/tests/e2e/testdata/skr-deployer-image-pull-secret.yaml
+++ b/tests/e2e/testdata/skr-deployer-image-pull-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/e2e/testdata/skr-deployer-image-pull-secret.yaml
+++ b/tests/e2e/testdata/skr-deployer-image-pull-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: image-pull-secret
+  namespace: template-operator-system
+  annotations:
+    operator.kyma-project.io/inject-data-from-kcp: "true"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6IHt9fQo=

--- a/tests/e2e/testdata/skr-deployer-non-inject-pull-secret.yaml
+++ b/tests/e2e/testdata/skr-deployer-non-inject-pull-secret.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Secret
 metadata:

--- a/tests/e2e/testdata/skr-deployer-non-inject-pull-secret.yaml
+++ b/tests/e2e/testdata/skr-deployer-non-inject-pull-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: non-inject-pull-secret
+  namespace: template-operator-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6IHt9fQo=

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -46,6 +47,10 @@ const (
 	moduleCRFinalizer       = "cr-finalizer"
 	NewerVersion            = "2.4.2-e2e-test"
 	MisconfiguredModuleName = "template-operator-misconfigured"
+	// GlobalAccountID1 is unused in Go tests but defined here to match
+	// GLOBAL_ACCOUNT_ID_1 in restricted_default_module_test.mk.
+	GlobalAccountID1 = "a1c1d2e3-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+	GlobalAccountID2 = "f6e5d4c3-b2a1-9087-6543-210fedcba987"
 )
 
 // ModuleVersionToBeUsed is the template-operator version used in tests.
@@ -304,6 +309,50 @@ func DeploymentPodSpecHasImagePullSecret(ctx context.Context,
 		}
 	}
 	return fmt.Errorf("imagePullSecret %s not found in deployment %s", secretName, deploymentName)
+}
+
+func SecretDataEquals(
+	ctx context.Context, clnt client.Client, name, namespace, dataKey string, expectedData []byte,
+) error {
+	secret := &apicorev1.Secret{}
+	if err := clnt.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		return err
+	}
+	actualData, ok := secret.Data[dataKey]
+	if !ok {
+		return fmt.Errorf("secret %s/%s does not have key %q", namespace, name, dataKey)
+	}
+	if !bytes.Equal(actualData, expectedData) {
+		return fmt.Errorf("secret %s/%s key %q data does not match", namespace, name, dataKey)
+	}
+	return nil
+}
+
+func UpdateSecretLabel(
+	ctx context.Context, clnt client.Client, name, namespace, labelKey, labelValue string,
+) error {
+	secret := &apicorev1.Secret{}
+	if err := clnt.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(secret.DeepCopy())
+	if secret.Labels == nil {
+		secret.Labels = make(map[string]string)
+	}
+	secret.Labels[labelKey] = labelValue
+	return clnt.Patch(ctx, secret, patch)
+}
+
+func RemoveSecretLabel(
+	ctx context.Context, clnt client.Client, name, namespace, labelKey string,
+) error {
+	secret := &apicorev1.Secret{}
+	if err := clnt.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(secret.DeepCopy())
+	delete(secret.Labels, labelKey)
+	return clnt.Patch(ctx, secret, patch)
 }
 
 func DeploymentContainersHaveImagePullSecretEnv(ctx context.Context,

--- a/tests/e2e/utils_test.go
+++ b/tests/e2e/utils_test.go
@@ -355,6 +355,21 @@ func RemoveSecretLabel(
 	return clnt.Patch(ctx, secret, patch)
 }
 
+func UpdateSecretDataKey(
+	ctx context.Context, clnt client.Client, name, namespace, dataKey string, data []byte,
+) error {
+	secret := &apicorev1.Secret{}
+	if err := clnt.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(secret.DeepCopy())
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[dataKey] = data
+	return clnt.Patch(ctx, secret, patch)
+}
+
 func DeploymentContainersHaveImagePullSecretEnv(ctx context.Context,
 	deploymentName, namespace, secretName string, clnt client.Client,
 ) error {


### PR DESCRIPTION
## What

Adds a resource transform that replaces the `.data` of any `Secret` in a Manifest annotated with `operator.kyma-project.io/inject-data-from-kcp: "true"` with the `.data` of a same-named Secret in `kcp-system`.

## Constraints

- Transform registered only when `deployer` is in `--restricted-default-modules`.
- Per-Manifest no-op unless its `operator.kyma-project.io/module-name` label equals `deployer`.
- KCP source secret MUST carry `operator.kyma-project.io/module-name=deployer`; missing/mismatching label is rejected (prevents cross-module reads).
- Only `.data` is replaced; other fields untouched.

## Changes

- `api/shared/operator_annotations.go` — new `InjectDataFromKCPAnnotation` constant.
- `internal/declarative/v2/restricted_default_module_image_pull_secret_transform.go` — new transform + consumer-defined `SecretRepository` interface.
- `cmd/composition/service/manifest/render/render.go` — append the transform when `deployer` is configured.
- `cmd/main.go` — thread `secretRepo` and the restricted-modules list into render composition.

## Known Limitations

- there is no E2E test verifying that the transform is only registered when "deployer" module is in the list of restricted default modules. There is a test verifying that the transform skips if the module name is not "deployer".
- an error in the transform stops updating the module resources and reports that error on the manifest => if the KCP secret is removed or re-labelled at some point, the Manifest goes to error state and the resources on the SKR remain in their state from that point of time. KLM does not revert them to the "un-injected" state.

Resolves https://github.com/kyma-project/lifecycle-manager/issues/3345
