### PR TITLE
test: Port cluster-scoped CRD deletion-blocking E2E tests to self-contained Makefile

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -148,6 +148,8 @@ jobs:
             module-deletion-blocking-with-default-cr-with-finalizer | \
             module-deletion-blocking-with-cross-namespace-ignore-policy | \
             module-deletion-blocking-with-cross-namespace-create-and-delete-policy | \
+            module-deletion-blocking-with-cluster-scoped-crs-ignore-policy | \
+            module-deletion-blocking-with-cluster-scoped-crs-create-and-delete-policy | \
             module-status-decoupling-with-statefulset | \
             module-status-decoupling-with-deployment | \
             module-without-default-cr | \

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -192,10 +192,10 @@ module-deletion-blocking-with-cross-namespace-create-and-delete-policy:
 	$(MAKE) -f $(MAKEFILE_DIR)/e2e.standard_module_setup.mk test "GINKGO_FOCUS=Blocking Module Deletion With Module CRs in Different Namespaces with CreateAndDelete Policy"
 
 module-deletion-blocking-with-cluster-scoped-crs-ignore-policy:
-	$(GO_TEST) "Blocking Module Deletion With Cluster-Scoped CRs with Ignore Policy"
+	$(MAKE) -f $(MAKEFILE_DIR)/module_deletion_blocking_cluster_scoped_test.mk test "GINKGO_FOCUS=Blocking Module Deletion With Cluster-Scoped CRs with Ignore Policy"
 
 module-deletion-blocking-with-cluster-scoped-crs-create-and-delete-policy:
-	$(GO_TEST) "Blocking Module Deletion With Cluster-Scoped CRs with CreateAndDelete Policy"
+	$(MAKE) -f $(MAKEFILE_DIR)/module_deletion_blocking_cluster_scoped_test.mk test "GINKGO_FOCUS=Blocking Module Deletion With Cluster-Scoped CRs with CreateAndDelete Policy"
 
 module-transferred-to-another-oci-registry:
 	$(GO_TEST) "Module Transferred to Another OCI Registry"

--- a/tests/e2e/module_deletion_blocking_cluster_scoped_test.mk
+++ b/tests/e2e/module_deletion_blocking_cluster_scoped_test.mk
@@ -1,0 +1,48 @@
+.DEFAULT_GOAL := test
+.PHONY: test $(MAKECMDGOALS)
+
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))e2e.common.mk
+
+ifndef GINKGO_FOCUS
+$(error GINKGO_FOCUS is not set. Usage: make -f module_deletion_blocking_cluster_scoped_test.mk test "GINKGO_FOCUS=<focus string>")
+endif
+
+.PHONY: klm-patch
+klm-patch:
+	@echo "::group::KLM patch"
+	@echo "No test-specific KLM patches"
+	@echo "::endgroup::"
+
+.PHONY: module-setup
+module-setup:
+	@echo "::group::Module setup with cluster-scoped CRD"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(TEMPLATE_OPERATOR_DIR) > /dev/null
+	cp $(SCRIPTS_DIR)/deploy_moduletemplate.sh .
+	cp $(SCRIPTS_DIR)/ocm-config-local-registry.yaml .
+	yq eval '.images[0].newTag = "$(MODULE_DEPLOYABLE_VERSION)"' -i config/manager/deployment/kustomization.yaml
+	make build-manifests
+	crd_selector='select(.kind == "CustomResourceDefinition" and .metadata.name == "samples.operator.kyma-project.io")'
+	yq eval "($${crd_selector} | .spec.scope) = \"Cluster\"" -i template-operator.yaml
+	./deploy_moduletemplate.sh $(MODULE_NAME) $(MODULE_DEPLOYABLE_VERSION) $(MODULE_DEPLOYABLE_VERSION) true false true false
+	$(SCRIPTS_DIR)/deploy_modulereleasemeta.sh $(MODULE_NAME) regular:$(MODULE_DEPLOYABLE_VERSION)
+	@popd > /dev/null
+	@echo "::endgroup::"
+
+.PHONY: test-run
+test-run: log-tool-versions
+	@echo "::group::Setting kubeconfig variables"
+	@export KCP_KUBECONFIG=$(shell k3d kubeconfig write kcp)
+	@export SKR_KUBECONFIG=$(shell k3d kubeconfig write skr)
+	@echo "::endgroup::"
+
+	@echo "::group::E2E test: $(GINKGO_FOCUS)"
+	@export PATH=$(LOCALBIN):$$PATH
+	@pushd $(E2E_TESTS_DIR) > /dev/null
+	set +e; $(GO) test -timeout 20m -ginkgo.v -ginkgo.focus "$(GINKGO_FOCUS)"; status=$$?; set -e
+	@popd > /dev/null
+	@echo "::endgroup::"
+	exit $${status}
+
+.PHONY: test
+test: create-clusters klm-patch deploy-klm module-setup test-run


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add `module_deletion_blocking_cluster_scoped_test.mk` — a `GINKGO_FOCUS`-parameterised self-contained test file for the two cluster-scoped CRD deletion-blocking tests. The `module-setup` target bypasses `module-setup-latest` and calls `deploy_moduletemplate.sh` directly, injecting a `yq` patch that flips the Sample CRD `spec.scope` to `Cluster` before the template is applied, then deploys a single-channel MRM (`regular:MODULE_DEPLOYABLE_VERSION`).
- Update `tests/e2e/Makefile`: both `module-deletion-blocking-with-cluster-scoped-crs-*` targets now dispatch to the new `.mk` file instead of calling `$(GO_TEST)` directly.
- Update `.github/workflows/test-e2e.yml`: add both tests to the `self-contained=true` case so the `Deploy lifecycle-manager` and `Deploy template-operator` GHA steps are skipped for them.

**Related issue(s)**

Resolves #3338