### PR TITLE
chore: Add `runtime-watcher` image to `component-config.yaml`

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -2,3 +2,4 @@ name: kyma-project.io/kyma-runtime/kcp-components/lifecycle-manager
 team: kyma/jellyfish
 images:
   - europe-docker.pkg.dev/kyma-project/prod/lifecycle-manager:latest
+  - europe-docker.pkg.dev/kyma-project/prod/runtime-watcher:latest


### PR DESCRIPTION
**Description**
It would also be helpful to have `runtime-watcher` monitored in a similar fashion to #3368 as well.

**Related issue(s)**
Resolves #3350 