### PR TITLE
chore: Update runtime watcher tag to `2.1.12`

### DIFF
--- a/.run/Launch KLM locally.run.xml
+++ b/.run/Launch KLM locally.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Launch KLM locally" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="lifecycle-manager" />
     <working_directory value="$PROJECT_DIR$" />
-    <parameters value="--skr-watcher-image-tag=2.1.10 --oci-registry-host=http://k3d-kcp-registry.localhost:5000 --leader-elect=false" />
+    <parameters value="--skr-watcher-image-tag=2.1.12 --oci-registry-host=http://k3d-kcp-registry.localhost:5000 --leader-elect=false" />
     <envs>
       <env name="KUBECONFIG" value="$USER_HOME$/.k3d/kcp-local.yaml" />
     </envs>

--- a/config/watcher/kustomization.yaml
+++ b/config/watcher/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
     patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --skr-watcher-image-tag=2.1.10
+        value: --skr-watcher-image-tag=2.1.12
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --skr-watcher-image-registry=europe-docker.pkg.dev/kyma-project/prod


### PR DESCRIPTION
**Description**

Update runtime watcher tag to `2.1.12`

Changes proposed in this pull request:

- Updated kustomization
- Updated local run profile
