### PR TITLE
fix: Remove redundant eventing RBAC rules

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -35,10 +35,3 @@ rules:
     verbs:
       - create
       - patch
-  - apiGroups:
-      - "events.k8s.io"
-    resources:
-      - events
-    verbs:
-      - create
-      - patch

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -14,16 +14,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - watch
-  - apiGroups:
       - "events.k8s.io"
     resources:
       - events

--- a/tests/e2e/rbac_privileges_test.go
+++ b/tests/e2e/rbac_privileges_test.go
@@ -56,11 +56,6 @@ var _ = Describe("RBAC Privileges", func() {
 					Resources: []string{"events"},
 					Verbs:     []string{"create", "patch"},
 				},
-				{
-					APIGroups: []string{"events.k8s.io"},
-					Resources: []string{"events"},
-					Verbs:     []string{"create", "patch"},
-				},
 			}
 			Expect(GetRoleBindingRolePolicyRules(ctx,
 				kcpClient,
@@ -74,11 +69,6 @@ var _ = Describe("RBAC Privileges", func() {
 					APIGroups: []string{""},
 					Resources: []string{"configmaps"},
 					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events"},
-					Verbs:     []string{"create", "get", "list", "patch", "watch"},
 				},
 				{
 					APIGroups: []string{"events.k8s.io"},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove `events.k8s.io` rule from `leader_election_role`: controller-runtime v0.24.1 leader election still calls `recorderProvider.GetEventRecorderFor()` (old core `""` API) due to an upstream client-go limitation ([kubernetes/kubernetes#82846](https://github.com/kubernetes/kubernetes/issues/82846)) — the `events.k8s.io` entry added in #3194 was never exercised by the leader election path.
- Remove core `""` events rule from `manager_role`: KLM exclusively uses `mgr.GetEventRecorder()` (new `events.k8s.io` API) since the controller-runtime bump in #3099 — no production code path calls the deprecated `GetEventRecorderFor()`.
- Update `tests/e2e/rbac_privileges_test.go` expected policy rules to match the trimmed role definitions.

**Related issue(s)**
Closes #3204