### PR TITLE
fix: Manifest name truncation leaving trailing dashes

### DIFF
--- a/pkg/module/common/module.go
+++ b/pkg/module/common/module.go
@@ -79,12 +79,15 @@ func (m *Module) ContainsExpectedOwnerReference(ownerName string) bool {
 	return false
 }
 
+// maxModuleNameLength is the DNS label limit (63 chars). The manifest name is written as a label value on SKR
+// resources (app.kubernetes.io/component), so it must conform to this stricter limit.
 const maxModuleNameLength = validation.DNS1035LabelMaxLength
 
-// CreateModuleName takes an OCM Component Name and a prefix and generates a human-readable unique interpretation of
-// a name combination.
-// e.g. kyma-project.io/module/some-module and default-id => "default-id-some-module-34180237"
-// e.g. domain.com/some-module and default-id => "default-id-some-module-1238916".
+// CreateModuleName generates a Manifest name in the format "{prefix}-{lastSegment}-{hash}", where lastSegment is the
+// part of compName after the last "/". moduleName is not part of the visible name but is included in the FNV-32 hash
+// together with compName to ensure uniqueness across different module names sharing the same component name.
+// e.g. kyma-project.io/module/some-module, default-id => "default-id-some-module-34180237"
+// e.g. domain.com/some-module, default-id => "default-id-some-module-1238916".
 func CreateModuleName(compName, prefix, moduleName string) string {
 	lastSeparatorIdx := strings.LastIndexByte(compName, '/')
 	var lastPart string
@@ -97,8 +100,10 @@ func CreateModuleName(compName, prefix, moduleName string) string {
 	_, _ = hash.Write([]byte(compName + moduleName))
 	hashed := hash.Sum32()
 	name := fmt.Sprintf("%s-%s-%v", prefix, lastPart, hashed)
+	// this is truncating to 62 instead of 63 chars for unknown reasons
 	if len(name) >= maxModuleNameLength {
 		name = name[:maxModuleNameLength-1]
+		name = strings.TrimRight(name, "-")
 	}
 	return name
 }

--- a/pkg/module/common/module_test.go
+++ b/pkg/module/common/module_test.go
@@ -158,6 +158,20 @@ func TestCreateModuleName(t *testing.T) {
 			moduleName:    "module1",
 			expected:      "default-id-simple-component-3590401810",
 		},
+		{
+			testName:      "Component name landing at exactly 62 chars",
+			componentName: "simple-compone",
+			prefix:        "9b9437b0-e148-430b-9ad6-4537adc41557",
+			moduleName:    "module1",
+			expected:      "9b9437b0-e148-430b-9ad6-4537adc41557-simple-compone-3786713812",
+		},
+		{
+			testName:      "Component name leading to trailing dashes after length truncation",
+			componentName: "simple-component-----------------------------------------",
+			prefix:        "default-id",
+			moduleName:    "module1",
+			expected:      "default-id-simple-component",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- manifest names are enforced to have a max length of 62 chars
  - reasoning is most likely that the name is applied as label value on the SKR resources for that module where 63 chars is the max length
  - it is not known why we truncate it to 62 chars instead of 63. Assumption is that the very same problem we are trying to solve here already appeared earlier and the fix was to just truncate down one more char
- the problem was that after truncation, we had a manifest name that ended in dash (`-`). This is not allowed by K8s. Therefore, this PR adds to also truncate any trailing dashes resulting from a previous length-based truncation
- we only truncate dashes after length-based truncation as a valid module name before truncation cannot have a trailing dash

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
