### PR TITLE
feat: Re-align Kyma Deletion Controller with env Variable

### DIFF
--- a/internal/controller/kyma/controller.go
+++ b/internal/controller/kyma/controller.go
@@ -161,6 +161,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	err := r.SkrContextFactory.Init(ctx, kyma.GetNamespacedName())
 	if !kyma.DeletionTimestamp.IsZero() && errors.Is(err, accessmanager.ErrAccessSecretNotFound) {
+		if !useLegacyKymaDeletion() {
+			return r.processDeletion(ctx, kyma)
+		}
 		return r.handleDeletedSkr(ctx, req, kyma)
 	}
 
@@ -171,12 +174,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, r.updateStatusWithError(ctx, kyma, err)
 	}
 
-	if !kyma.DeletionTimestamp.IsZero() {
-		envValue, isDefined := os.LookupEnv("ENABLE_LEGACY_KYMA_DELETION")
-		useLegacyKymaDeletion := isDefined && envValue == "true"
-		if !useLegacyKymaDeletion {
-			return r.processDeletion(ctx, kyma)
-		}
+	if !kyma.DeletionTimestamp.IsZero() && !useLegacyKymaDeletion() {
+		return r.processDeletion(ctx, kyma)
 	}
 
 	err = skrContext.CreateKymaNamespace(ctx)
@@ -706,6 +705,11 @@ func (r *Reconciler) deleteOrphanedCertificate(ctx context.Context, kymaName str
 		}
 	}
 	return nil
+}
+
+func useLegacyKymaDeletion() bool {
+	envValue, isDefined := os.LookupEnv("ENABLE_LEGACY_KYMA_DELETION")
+	return isDefined && envValue == "true"
 }
 
 func setModuleStatusesToError(kyma *v1beta2.Kyma, message string) {

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -316,18 +316,27 @@ var _ = Describe("Kyma sync default module list into Remote Cluster", Ordered, f
 	})
 
 	It("Default module list should be recreated if remote Kyma gets deleted", func() {
+		By("Wait for KCP Kyma to reach Ready state after previous spec")
+		Eventually(func() bool {
+			kcpKyma, err := GetKyma(ctx, kcpClient, kyma.GetName(), kyma.GetNamespace())
+			if err != nil {
+				return false
+			}
+			return kcpKyma.Status.State == shared.StateReady
+		}, Timeout, Interval).Should(BeTrue())
+
 		By("Delete remote Kyma")
 		Eventually(DeleteCR, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma).Should(Succeed())
 		By("Remote Kyma contains default module")
-		Eventually(ContainsModuleInSpec, Timeout, Interval).
+		Eventually(ContainsModuleInSpec, 2*Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma.Name, skrKyma.Namespace, moduleInKCP.Name).
 			Should(Succeed())
 
 		By("KCP Manifest is being created")
-		Eventually(ManifestExists, Timeout, Interval).
+		Eventually(ManifestExists, 2*Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), moduleInKCP.Name).
 			Should(Succeed())

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -329,13 +329,13 @@ var _ = Describe("Kyma sync default module list into Remote Cluster", Ordered, f
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma).Should(Succeed())
 		By("Remote Kyma contains default module")
-		Eventually(ContainsModuleInSpec, Timeout, Interval).
+		Eventually(ContainsModuleInSpec, 2*Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma.Name, skrKyma.Namespace, moduleInKCP.Name).
 			Should(Succeed())
 
 		By("KCP Manifest is being created")
-		Eventually(ManifestExists, Timeout, Interval).
+		Eventually(ManifestExists, 2*Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), moduleInKCP.Name).
 			Should(Succeed())

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -10,13 +10,15 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+
 	"github.com/kyma-project/lifecycle-manager/internal/descriptor/types/ocmidentity"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/flags"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 var ErrNotContainsExpectedCondition = errors.New("kyma CR does not contain expected condition")
@@ -315,27 +317,18 @@ var _ = Describe("Kyma sync default module list into Remote Cluster", Ordered, f
 	})
 
 	It("Default module list should be recreated if remote Kyma gets deleted", func() {
-		By("Wait for KCP Kyma to reach Ready state after previous spec")
-		Eventually(func() bool {
-			kcpKyma, err := GetKyma(ctx, kcpClient, kyma.GetName(), kyma.GetNamespace())
-			if err != nil {
-				return false
-			}
-			return kcpKyma.Status.State == shared.StateReady
-		}, Timeout, Interval).Should(BeTrue())
-
 		By("Delete remote Kyma")
 		Eventually(DeleteCR, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma).Should(Succeed())
 		By("Remote Kyma contains default module")
-		Eventually(ContainsModuleInSpec, 2*Timeout, Interval).
+		Eventually(ContainsModuleInSpec, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma.Name, skrKyma.Namespace, moduleInKCP.Name).
 			Should(Succeed())
 
 		By("KCP Manifest is being created")
-		Eventually(ManifestExists, 2*Timeout, Interval).
+		Eventually(ManifestExists, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), moduleInKCP.Name).
 			Should(Succeed())
@@ -467,15 +460,6 @@ var _ = Describe("CRDs sync to SKR and annotations updated in KCP kyma", Ordered
 	})
 
 	It("Should re-apply ModuleTemplate CRD on SKR after it is deleted", func() {
-		By("Wait for CRDs sync condition to stabilize after previous spec")
-		Eventually(func() bool {
-			kcpKyma, err := GetKyma(ctx, kcpClient, kyma.GetName(), kyma.GetNamespace())
-			if err != nil {
-				return false
-			}
-			return kcpKyma.ContainsCondition(v1beta2.ConditionTypeCRDsSync, apimetav1.ConditionTrue)
-		}, Timeout, Interval).Should(BeTrue())
-
 		var moduleTemplateCrd *apiextensionsv1.CustomResourceDefinition
 		Eventually(func() error {
 			var err error

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -330,13 +330,13 @@ var _ = Describe("Kyma sync default module list into Remote Cluster", Ordered, f
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma).Should(Succeed())
 		By("Remote Kyma contains default module")
-		Eventually(ContainsModuleInSpec, 2*Timeout, Interval).
+		Eventually(ContainsModuleInSpec, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(skrClient, skrKyma.Name, skrKyma.Namespace, moduleInKCP.Name).
 			Should(Succeed())
 
 		By("KCP Manifest is being created")
-		Eventually(ManifestExists, 2*Timeout, Interval).
+		Eventually(ManifestExists, Timeout, Interval).
 			WithContext(ctx).
 			WithArguments(kcpClient, kyma.GetName(), kyma.GetNamespace(), moduleInKCP.Name).
 			Should(Succeed())

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -3,7 +3,6 @@ package kcp_test
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -492,6 +491,6 @@ var _ = Describe("CRDs sync to SKR and annotations updated in KCP kyma", Ordered
 		Eventually(func() error {
 			_, err := fetchCrd(skrClient, shared.ModuleTemplateKind)
 			return err
-		}, 30*time.Second, Interval).WithContext(ctx).Should(Succeed())
+		}, Timeout, Interval).WithContext(ctx).Should(Succeed())
 	})
 })

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -460,6 +460,15 @@ var _ = Describe("CRDs sync to SKR and annotations updated in KCP kyma", Ordered
 	})
 
 	It("Should re-apply ModuleTemplate CRD on SKR after it is deleted", func() {
+		By("Wait for CRDs sync condition to stabilize after previous spec")
+		Eventually(func() bool {
+			kcpKyma, err := GetKyma(ctx, kcpClient, kyma.GetName(), kyma.GetNamespace())
+			if err != nil {
+				return false
+			}
+			return kcpKyma.ContainsCondition(v1beta2.ConditionTypeCRDsSync, apimetav1.ConditionTrue)
+		}, Timeout, Interval).Should(BeTrue())
+
 		var moduleTemplateCrd *apiextensionsv1.CustomResourceDefinition
 		Eventually(func() error {
 			var err error

--- a/tests/integration/controller/kcp/remote_sync_test.go
+++ b/tests/integration/controller/kcp/remote_sync_test.go
@@ -3,6 +3,7 @@ package kcp_test
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,15 +11,13 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
-
 	"github.com/kyma-project/lifecycle-manager/internal/descriptor/types/ocmidentity"
 	"github.com/kyma-project/lifecycle-manager/internal/pkg/flags"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/builder"
 
+	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	. "github.com/kyma-project/lifecycle-manager/pkg/testutils"
 )
 
 var ErrNotContainsExpectedCondition = errors.New("kyma CR does not contain expected condition")
@@ -484,6 +483,6 @@ var _ = Describe("CRDs sync to SKR and annotations updated in KCP kyma", Ordered
 		Eventually(func() error {
 			_, err := fetchCrd(skrClient, shared.ModuleTemplateKind)
 			return err
-		}, Timeout, Interval).WithContext(ctx).Should(Succeed())
+		}, 30*time.Second, Interval).WithContext(ctx).Should(Succeed())
 	})
 })


### PR DESCRIPTION
**Description**
- Extends `ENABLE_LEGACY_KYMA_DELETION` guard to cover the `ErrAccessSecretNotFound` path, routing to `processDeletion()` upon enablement.

**Related Issues**
Resolves #3298 