### PR TITLE
fix: Replace `ErrAccessSecretNotFound` checks with `ErrSkrClientNotFound`

### DIFF
--- a/internal/service/kyma/deletion/usecases/delete_skr_crd.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd.go
@@ -7,8 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
+	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 //nolint:iface // we accept the duplication for clarity
@@ -36,7 +37,7 @@ func (u *DeleteSkrCrd) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma) 
 
 	exists, err := u.skrCrdRepo.Exists(ctx, kcpKyma.GetNamespacedName())
 
-	if errors.Is(err, accessmanager.ErrAccessSecretNotFound) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
 		return false, nil
 	}
 

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
-	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 //nolint:iface // we accept the duplication for clarity
@@ -37,7 +36,7 @@ func (u *DeleteSkrCrd) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma) 
 
 	exists, err := u.skrCrdRepo.Exists(ctx, kcpKyma.GetNamespacedName())
 
-	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) {
 		return false, nil
 	}
 

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
@@ -2,7 +2,6 @@ package usecases_test
 
 import (
 	"context"
-	"syscall"
 	"testing"
 	"time"
 
@@ -52,28 +51,6 @@ func TestDeleteSkrCrd_IsApplicable_False_SkrClientNotFoundInCache(t *testing.T) 
 
 	crdRepo := &crdRepoStub{
 		err: errorsinternal.ErrSkrClientNotFound,
-	}
-
-	uc := usecases.NewDeleteSkrCrd(crdRepo, result.UseCase(random.Name()))
-	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
-
-	require.NoError(t, err)
-	assert.False(t, applicable)
-	assert.True(t, crdRepo.existsCalled)
-	assert.Equal(t, kcpKyma.GetNamespacedName(), crdRepo.namespacedName)
-}
-
-func TestDeleteSkrCrd_IsApplicable_False_ConnectionRelatedError(t *testing.T) {
-	kcpKyma := &v1beta2.Kyma{
-		ObjectMeta: apimetav1.ObjectMeta{
-			Name:              random.Name(),
-			Namespace:         random.Name(),
-			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
-		},
-	}
-
-	crdRepo := &crdRepoStub{
-		err: syscall.ECONNREFUSED,
 	}
 
 	uc := usecases.NewDeleteSkrCrd(crdRepo, result.UseCase(random.Name()))

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
@@ -2,6 +2,7 @@ package usecases_test
 
 import (
 	"context"
+	"syscall"
 	"testing"
 	"time"
 
@@ -51,6 +52,28 @@ func TestDeleteSkrCrd_IsApplicable_False_SkrClientNotFoundInCache(t *testing.T) 
 
 	crdRepo := &crdRepoStub{
 		err: errorsinternal.ErrSkrClientNotFound,
+	}
+
+	uc := usecases.NewDeleteSkrCrd(crdRepo, result.UseCase(random.Name()))
+	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
+
+	require.NoError(t, err)
+	assert.False(t, applicable)
+	assert.True(t, crdRepo.existsCalled)
+	assert.Equal(t, kcpKyma.GetNamespacedName(), crdRepo.namespacedName)
+}
+
+func TestDeleteSkrCrd_IsApplicable_False_ConnectionRelatedError(t *testing.T) {
+	kcpKyma := &v1beta2.Kyma{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:              random.Name(),
+			Namespace:         random.Name(),
+			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
+		},
+	}
+
+	crdRepo := &crdRepoStub{
+		err: syscall.ECONNREFUSED,
 	}
 
 	uc := usecases.NewDeleteSkrCrd(crdRepo, result.UseCase(random.Name()))

--- a/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_crd_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/deletion/usecases"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
@@ -40,7 +40,7 @@ func TestDeleteSkrCrd_IsApplicable_False_KcpKymaNotDeleting(t *testing.T) {
 	assert.False(t, applicable)
 }
 
-func TestDeleteSkrCrd_IsApplicable_False_AccessSecretNotFound(t *testing.T) {
+func TestDeleteSkrCrd_IsApplicable_False_SkrClientNotFoundInCache(t *testing.T) {
 	kcpKyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:              random.Name(),
@@ -50,7 +50,7 @@ func TestDeleteSkrCrd_IsApplicable_False_AccessSecretNotFound(t *testing.T) {
 	}
 
 	crdRepo := &crdRepoStub{
-		err: accessmanager.ErrAccessSecretNotFound,
+		err: errorsinternal.ErrSkrClientNotFound,
 	}
 
 	uc := usecases.NewDeleteSkrCrd(crdRepo, result.UseCase(random.Name()))

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
+	"github.com/kyma-project/lifecycle-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
 )
 
 //nolint:iface // we accept the duplication for clarity
@@ -34,7 +35,7 @@ func (u *DeleteSkrKyma) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma)
 	}
 
 	exists, err := u.skrKymaRepo.Exists(ctx, kcpKyma.GetNamespacedName())
-	if errors.Is(err, accessmanager.ErrAccessSecretNotFound) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
 		return false, nil
 	}
 	if err != nil {

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 
-	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
-	"github.com/kyma-project/lifecycle-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
+	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 //nolint:iface // we accept the duplication for clarity

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma.go
@@ -10,7 +10,6 @@ import (
 	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 //nolint:iface // we accept the duplication for clarity
@@ -35,7 +34,7 @@ func (u *DeleteSkrKyma) IsApplicable(ctx context.Context, kcpKyma *v1beta2.Kyma)
 	}
 
 	exists, err := u.skrKymaRepo.Exists(ctx, kcpKyma.GetNamespacedName())
-	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) {
 		return false, nil
 	}
 	if err != nil {

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
@@ -2,6 +2,7 @@ package usecases_test
 
 import (
 	"context"
+	"syscall"
 	"testing"
 	"time"
 
@@ -52,6 +53,29 @@ func TestIsApplicable_SkrClientNotFoundInCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, applicable)
 	assert.True(t, skrKymaRepo.called)
+	assert.Equal(t, kcpKyma.GetNamespacedName(), skrKymaRepo.namespacedName)
+}
+
+func TestIsApplicable_ConnectionRelatedError(t *testing.T) {
+	kcpKyma := &v1beta2.Kyma{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:              random.Name(),
+			Namespace:         random.Name(),
+			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
+		},
+	}
+
+	skrKymaRepo := &skrKymaRepoStub{
+		err: syscall.ECONNREFUSED,
+	}
+
+	uc := usecases.NewDeleteSkrKyma(skrKymaRepo)
+	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
+
+	require.NoError(t, err)
+	assert.False(t, applicable)
+	assert.True(t, skrKymaRepo.called)
+	assert.Equal(t, kcpKyma.GetNamespacedName(), skrKymaRepo.namespacedName)
 }
 
 func TestIsApplicable_KymaExists(t *testing.T) {

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
@@ -2,7 +2,6 @@ package usecases_test
 
 import (
 	"context"
-	"syscall"
 	"testing"
 	"time"
 
@@ -45,28 +44,6 @@ func TestIsApplicable_SkrClientNotFoundInCache(t *testing.T) {
 
 	skrKymaRepo := &skrKymaRepoStub{
 		err: errorsinternal.ErrSkrClientNotFound,
-	}
-
-	uc := usecases.NewDeleteSkrKyma(skrKymaRepo)
-	applicable, err := uc.IsApplicable(t.Context(), kcpKyma)
-
-	require.NoError(t, err)
-	assert.False(t, applicable)
-	assert.True(t, skrKymaRepo.called)
-	assert.Equal(t, kcpKyma.GetNamespacedName(), skrKymaRepo.namespacedName)
-}
-
-func TestIsApplicable_ConnectionRelatedError(t *testing.T) {
-	kcpKyma := &v1beta2.Kyma{
-		ObjectMeta: apimetav1.ObjectMeta{
-			Name:              random.Name(),
-			Namespace:         random.Name(),
-			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
-		},
-	}
-
-	skrKymaRepo := &skrKymaRepoStub{
-		err: syscall.ECONNREFUSED,
 	}
 
 	uc := usecases.NewDeleteSkrKyma(skrKymaRepo)

--- a/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_kyma_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/deletion/usecases"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
@@ -33,7 +33,7 @@ func TestIsApplicable_KcpKymaNotDeleting(t *testing.T) {
 	assert.False(t, applicable)
 }
 
-func TestIsApplicable_AccessSecretNotFound(t *testing.T) {
+func TestIsApplicable_SkrClientNotFoundInCache(t *testing.T) {
 	kcpKyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:              random.Name(),
@@ -43,7 +43,7 @@ func TestIsApplicable_AccessSecretNotFound(t *testing.T) {
 	}
 
 	skrKymaRepo := &skrKymaRepoStub{
-		err: accessmanager.ErrAccessSecretNotFound,
+		err: errorsinternal.ErrSkrClientNotFound,
 	}
 
 	uc := usecases.NewDeleteSkrKyma(skrKymaRepo)

--- a/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
+	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 var (
@@ -41,6 +43,9 @@ func (u *DeleteSkrWebhookResources) IsApplicable(ctx context.Context, kyma *v1be
 	}
 
 	resourcesExist, err := u.skrWebhookResourcesRepo.ResourcesExist(ctx, kyma.GetNamespacedName())
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
+		return false, nil
+	}
 	if err != nil {
 		return false, errors.Join(errFailedToDetermineApplicability, err)
 	}

--- a/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources.go
@@ -11,7 +11,6 @@ import (
 	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
 var (
@@ -43,7 +42,7 @@ func (u *DeleteSkrWebhookResources) IsApplicable(ctx context.Context, kyma *v1be
 	}
 
 	resourcesExist, err := u.skrWebhookResourcesRepo.ResourcesExist(ctx, kyma.GetNamespacedName())
-	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsConnectionRelatedError(err) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) {
 		return false, nil
 	}
 	if err != nil {

--- a/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_skr_webhook_resources_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/deletion/usecases"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
@@ -109,6 +110,24 @@ func TestDeleteSkrWebhookResources_IsApplicable(t *testing.T) {
 			resourcesExistErr:          errors.New("failed to check resources"),
 			expectedApplicable:         false,
 			expectError:                true,
+			expectResourcesExistCalled: true,
+		},
+		{
+			name: "not applicable when SKR client not in cache",
+			kyma: &v1beta2.Kyma{
+				ObjectMeta: apimetav1.ObjectMeta{
+					Name:              random.Name(),
+					Namespace:         random.Name(),
+					DeletionTimestamp: &now,
+				},
+				Status: v1beta2.KymaStatus{
+					State: shared.StateDeleting,
+				},
+			},
+			resourcesExist:             false,
+			resourcesExistErr:          errorsinternal.ErrSkrClientNotFound,
+			expectedApplicable:         false,
+			expectError:                false,
 			expectResourcesExistCalled: true,
 		},
 	}

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
@@ -37,8 +37,7 @@ func (u *SetSkrKymaStateDeleting) IsApplicable(ctx context.Context, kcpKyma *v1b
 	status, err := u.skrKymaStatusRepo.Get(ctx, kcpKyma.GetNamespacedName())
 
 	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) ||
-		util.IsNotFound(err) ||
-		util.IsConnectionRelatedError(err) {
+		util.IsNotFound(err) {
 		return false, nil
 	}
 

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
 	"github.com/kyma-project/lifecycle-manager/pkg/util"
 )
 
@@ -36,7 +36,7 @@ func (u *SetSkrKymaStateDeleting) IsApplicable(ctx context.Context, kcpKyma *v1b
 
 	status, err := u.skrKymaStatusRepo.Get(ctx, kcpKyma.GetNamespacedName())
 
-	if errors.Is(err, accessmanager.ErrAccessSecretNotFound) || util.IsNotFound(err) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsNotFound(err) {
 		return false, nil
 	}
 

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting.go
@@ -36,7 +36,9 @@ func (u *SetSkrKymaStateDeleting) IsApplicable(ctx context.Context, kcpKyma *v1b
 
 	status, err := u.skrKymaStatusRepo.Get(ctx, kcpKyma.GetNamespacedName())
 
-	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) || util.IsNotFound(err) {
+	if errors.Is(err, errorsinternal.ErrSkrClientNotFound) ||
+		util.IsNotFound(err) ||
+		util.IsConnectionRelatedError(err) {
 		return false, nil
 	}
 

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
@@ -2,6 +2,7 @@ package usecases_test
 
 import (
 	"context"
+	"syscall"
 	"testing"
 	"time"
 
@@ -98,6 +99,29 @@ func TestIsApplicable_False_ClientNotFoundInCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, applicable)
 	assert.True(t, kymaStatusRepo.called)
+}
+
+func TestIsApplicable_False_ConnectionRelatedError(t *testing.T) {
+	kyma := &v1beta2.Kyma{
+		ObjectMeta: apimetav1.ObjectMeta{
+			Name:              random.Name(),
+			Namespace:         random.Name(),
+			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
+		},
+	}
+
+	kymaStatusRepo := &skrKymaStatusRepoStub{
+		err: syscall.ECONNREFUSED,
+	}
+
+	uc := usecases.NewSetSkrKymaStateDeleting(kymaStatusRepo)
+
+	applicable, err := uc.IsApplicable(t.Context(), kyma)
+
+	require.NoError(t, err)
+	assert.False(t, applicable)
+	assert.True(t, kymaStatusRepo.called)
+	assert.Equal(t, kyma.GetNamespacedName(), kymaStatusRepo.namespacedName)
 }
 
 func TestIsApplicable_False_KymaAlreadyInDeletingState(t *testing.T) {

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
@@ -2,7 +2,6 @@ package usecases_test
 
 import (
 	"context"
-	"syscall"
 	"testing"
 	"time"
 
@@ -99,29 +98,6 @@ func TestIsApplicable_False_ClientNotFoundInCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, applicable)
 	assert.True(t, kymaStatusRepo.called)
-}
-
-func TestIsApplicable_False_ConnectionRelatedError(t *testing.T) {
-	kyma := &v1beta2.Kyma{
-		ObjectMeta: apimetav1.ObjectMeta{
-			Name:              random.Name(),
-			Namespace:         random.Name(),
-			DeletionTimestamp: &apimetav1.Time{Time: time.Now()},
-		},
-	}
-
-	kymaStatusRepo := &skrKymaStatusRepoStub{
-		err: syscall.ECONNREFUSED,
-	}
-
-	uc := usecases.NewSetSkrKymaStateDeleting(kymaStatusRepo)
-
-	applicable, err := uc.IsApplicable(t.Context(), kyma)
-
-	require.NoError(t, err)
-	assert.False(t, applicable)
-	assert.True(t, kymaStatusRepo.called)
-	assert.Equal(t, kyma.GetNamespacedName(), kymaStatusRepo.namespacedName)
 }
 
 func TestIsApplicable_False_KymaAlreadyInDeletingState(t *testing.T) {

--- a/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
+++ b/internal/service/kyma/deletion/usecases/set_skr_kyma_state_deleting_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/kyma-project/lifecycle-manager/api/shared"
 	"github.com/kyma-project/lifecycle-manager/api/v1beta2"
+	errorsinternal "github.com/kyma-project/lifecycle-manager/internal/errors"
 	"github.com/kyma-project/lifecycle-manager/internal/result/kyma/usecase"
-	"github.com/kyma-project/lifecycle-manager/internal/service/accessmanager"
 	"github.com/kyma-project/lifecycle-manager/internal/service/kyma/deletion/usecases"
 	"github.com/kyma-project/lifecycle-manager/pkg/testutils/random"
 )
@@ -78,7 +78,7 @@ func TestIsApplicable_False_DeletionTimestampNotSet(t *testing.T) {
 	assert.False(t, applicable)
 }
 
-func TestIsApplicable_False_AccessSecretNotFound(t *testing.T) {
+func TestIsApplicable_False_ClientNotFoundInCache(t *testing.T) {
 	kyma := &v1beta2.Kyma{
 		ObjectMeta: apimetav1.ObjectMeta{
 			Name:              random.Name(),
@@ -88,7 +88,7 @@ func TestIsApplicable_False_AccessSecretNotFound(t *testing.T) {
 	}
 
 	kymaStatusRepo := &skrKymaStatusRepoStub{
-		err: accessmanager.ErrAccessSecretNotFound,
+		err: errorsinternal.ErrSkrClientNotFound,
 	}
 
 	uc := usecases.NewSetSkrKymaStateDeleting(kymaStatusRepo)


### PR DESCRIPTION
**Description**

There was a tiny mix-up in the description of the [original issue](https://github.com/kyma-project/lifecycle-manager/issues/3296) about which exact errors to check for and handle.

Context comment: https://github.com/kyma-project/lifecycle-manager/issues/3296#issuecomment-5201821548

Changes proposed in this pull request:
- replace `ErrAccessSecretNotFound` checks with `ErrSkrClientNotFound`
- update the unit tests

**Related issue(s)**
Fixes #3296 and extends #3457