### PR TITLE
chore: bump modulectl to 3.3.0 and ocm-cli to 0.47.0

### DIFF
--- a/tests/e2e/moduletemplate/moduletemplate_template_operator_transferred.yaml
+++ b/tests/e2e/moduletemplate/moduletemplate_template_operator_transferred.yaml
@@ -155,9 +155,9 @@ spec:
         - access:
             commit: d04757ab29f1c52bd79a99c49668c41ba0b581eb
             repoUrl: https://github.com/kyma-project/template-operator
-            type: gitHub
+            type: GitHub
           name: module-sources
-          type: Github
+          type: git
           version: 1.0.5
       version: 1.0.5
     meta:

--- a/versions.yaml
+++ b/versions.yaml
@@ -12,8 +12,8 @@ k8s: "1.32.2" # kubernetes version used in e2e tests
 envtest_k8s: "1.32.0" # kubernetes version used in integration tests
 kubectl: "1.31.3"
 kustomize: "5.4.3"
-modulectl: "3.2.1"
-ocm-cli: "0.32.0"
+modulectl: "3.3.0"
+ocm-cli: "0.47.0"
 template-operator: "1.0.5"
 yq: "4.45.1"
 envtest: "0.21" # tracks controller-runtime minor version (sigs.k8s.io/controller-runtime/tools/setup-envtest@release-<minor>); bump manually alongside controller-runtime upgrades


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump `modulectl` from `3.2.1` to `3.3.0` — fixes incorrect OCM type names emitted in component descriptors (`gitHub` → `GitHub`, `Github` → `git`, `PlainText` → `plainText`)
- Bump `ocm-cli` from `0.32.0` to `0.47.0` — required companion: `"GitHub"` access type was added to the stable OCM v1 library in v0.41.0; running with v0.32.0 would store it as an opaque blob instead of a resolved access spec
- Update e2e test fixture `moduletemplate_template_operator_transferred.yaml` to reflect the corrected type values produced by the new modulectl

**Related issue(s)**
kyma-project/modulectl#444