### PR TITLE
fix: Module Manifest Management Sync

### DIFF
--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -182,12 +182,8 @@ func (r *Runner) updateAvailableManifestSpec(ctx context.Context,
 func NeedToUpdate(manifestInCluster, newManifest *v1beta2.Manifest, moduleInStatus *v1beta2.ModuleStatus,
 	module *modulecommon.Module,
 ) bool {
-	if manifestInCluster == nil {
+	if manifestInCluster == nil || manifestInCluster.IsUnmanaged() {
 		return !(module.IsUnmanaged)
-	}
-
-	if manifestInCluster.IsUnmanaged() {
-		return !module.IsUnmanaged
 	}
 
 	if module.IsUnmanaged {

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -187,7 +187,7 @@ func NeedToUpdate(manifestInCluster, newManifest *v1beta2.Manifest, moduleInStat
 	}
 
 	if manifestInCluster.IsUnmanaged() {
-		return false
+		return !module.IsUnmanaged
 	}
 
 	if module.IsUnmanaged {

--- a/pkg/module/sync/runner.go
+++ b/pkg/module/sync/runner.go
@@ -183,7 +183,7 @@ func NeedToUpdate(manifestInCluster, newManifest *v1beta2.Manifest, moduleInStat
 	module *modulecommon.Module,
 ) bool {
 	if manifestInCluster == nil || manifestInCluster.IsUnmanaged() {
-		return !(module.IsUnmanaged)
+		return !module.IsUnmanaged
 	}
 
 	if module.IsUnmanaged {

--- a/pkg/module/sync/runner_test.go
+++ b/pkg/module/sync/runner_test.go
@@ -179,7 +179,7 @@ func TestNeedToUpdate(t *testing.T) {
 			false,
 		},
 		{
-			"When cluster Manifest is unmanaged and module is managed, expect no update",
+			"When cluster Manifest is unmanaged and module is managed, expect update",
 			args{
 				&v1beta2.Manifest{
 					ObjectMeta: apimetav1.ObjectMeta{
@@ -207,7 +207,7 @@ func TestNeedToUpdate(t *testing.T) {
 					IsUnmanaged: false,
 				},
 			},
-			false,
+			true,
 		},
 		{
 			"When cluster Manifest is managed and module is unmanaged, expect update",

--- a/unit-test-coverage-lifecycle-manager.yaml
+++ b/unit-test-coverage-lifecycle-manager.yaml
@@ -64,7 +64,7 @@ packages:
   internal/watch/modulereleasemeta: 97.6
   internal/watch/modulereleasemeta/events: 100
 
-  pkg/module/sync: 11
+  pkg/module/sync: 9
   pkg/status: 20
   pkg/templatelookup: 79.7
   pkg/templatelookup/moduletemplateinfolookup: 100


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- When Manifest contains the `is-unmanaged=true` annotation && Module is unmanaged:
  - Setting Module back to managed, removes the annotation and restores Manifest reconciliation

**Related issue(s)**
Fixes #3470
