### PR TITLE
chore: Bump Go to `1.27.0`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,8 @@ linters:
   disable:
     - contextcheck # too many false positives
     - depguard # checks if package imports are whitelisted
-    - exhaustruct # too subjective and harms code readability
+    - exhaustruct # deprecated and replaced by exhaustruct_v5 in golangci-lint v2.13.0
+    - exhaustruct_v5 # too subjective and harms code readability
     - nlreturn # too strict and mostly code is not more readable
     - paralleltest # should be enabled consciously for long running tests
     - lll # revive.line-length-limit serve same purpose
@@ -27,9 +28,6 @@ linters:
         - "*.DeepCopyObject"
     cyclop:
       max-complexity: 20
-    exhaustruct:
-      exclude:
-        - gdfs
     funlen:
       lines: 80
     gomoddirectives:
@@ -220,6 +218,9 @@ linters:
         - v1.Layer
         - authn.Keychain
         - ratelimiter.RateLimiter
+    modernize:
+      disable:
+        - "embedlit" # embedlit is not good for Kubernetes-based projects, with lots of core types embedding.
     nestif:
       min-complexity: 6
     nolintlint:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
 
 WORKDIR /lifecycle-manager
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/api
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/gardener/cert-management/pkg/apis v0.27.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager
 
-go 1.26.6
+go 1.27.0
 
 replace (
 	//module rename in version v1.6.8

--- a/internal/repository/kyma/kyma_repo_drop_kyma_finalizer_test.go
+++ b/internal/repository/kyma/kyma_repo_drop_kyma_finalizer_test.go
@@ -22,7 +22,8 @@ func TestRepository_DropAllFinalizers(t *testing.T) {
 	testKymaName := random.Name()
 
 	t.Run("successfully drops Kyma finalizer", func(t *testing.T) {
-		finalizers := []string{random.Name(), random.Name()}
+		finalizers := make([]string, 0, 3)
+		finalizers = append(finalizers, random.Name(), random.Name())
 		stub := &clientStub{
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{
@@ -138,7 +139,8 @@ func TestRepository_DropAllFinalizers(t *testing.T) {
 	})
 
 	t.Run("returns error when patch fails", func(t *testing.T) {
-		finalizers := []string{random.Name(), random.Name()}
+		finalizers := make([]string, 0, 3)
+		finalizers = append(finalizers, random.Name(), random.Name())
 		stub := &clientStub{
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{
@@ -159,7 +161,8 @@ func TestRepository_DropAllFinalizers(t *testing.T) {
 	})
 
 	t.Run("ignores not found error on patch", func(t *testing.T) {
-		finalizers := []string{random.Name(), random.Name()}
+		finalizers := make([]string, 0, 3)
+		finalizers = append(finalizers, random.Name(), random.Name())
 		stub := &clientStub{
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{

--- a/internal/repository/skr/webhook/skrwebhook_repo_test.go
+++ b/internal/repository/skr/webhook/skrwebhook_repo_test.go
@@ -344,10 +344,10 @@ func TestResourceRepository_DeleteWebhookResources(t *testing.T) {
 
 	t.Run("deletes all resources in parallel", func(t *testing.T) {
 		// This test verifies parallel execution by checking that all resources are processed
-		var deletedCount int32
+		var deletedCount atomic.Int32
 		mockClient := &mockSkrClient{
 			deleteFunc: func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-				atomic.AddInt32(&deletedCount, 1)
+				deletedCount.Add(1)
 				return nil
 			},
 		}
@@ -358,7 +358,7 @@ func TestResourceRepository_DeleteWebhookResources(t *testing.T) {
 		err := repo.DeleteWebhookResources(context.Background(), kymaName)
 
 		require.NoError(t, err)
-		assert.Equal(t, int32(5), atomic.LoadInt32(&deletedCount)) // 3 base + 2 generated
+		assert.Equal(t, int32(5), deletedCount.Load()) // 3 base + 2 generated
 	})
 }
 

--- a/internal/repository/watcher/certificate/certmanager/certificate/certificate_repo_renew_test.go
+++ b/internal/repository/watcher/certificate/certmanager/certificate/certificate_repo_renew_test.go
@@ -171,7 +171,7 @@ func (s *statusWriterStub) Update(_ context.Context, obj client.Object, _ ...cli
 		return *s.updateErr
 	}
 
-	*s.receivedObj = *(obj.(*certmanagerv1.Certificate))
+	*s.receivedObj = *obj.(*certmanagerv1.Certificate)
 
 	return nil
 }

--- a/internal/repository/watcher/certificate/gcm/certificate/certificate_repo_renew_test.go
+++ b/internal/repository/watcher/certificate/gcm/certificate/certificate_repo_renew_test.go
@@ -98,7 +98,7 @@ func (c *clientStub) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 		return c.getErr
 	}
 
-	*(obj.(*gcertv1alpha1.Certificate)) = gcertv1alpha1.Certificate{
+	*obj.(*gcertv1alpha1.Certificate) = gcertv1alpha1.Certificate{
 		Spec: gcertv1alpha1.CertificateSpec{
 			EnsureRenewedAfter: &apimetav1.Time{Time: time.Now()},
 		},
@@ -109,7 +109,7 @@ func (c *clientStub) Get(_ context.Context, key client.ObjectKey, obj client.Obj
 
 func (c *clientStub) Update(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 	c.updateCalls++
-	c.updateCallArg = *(obj.(*gcertv1alpha1.Certificate))
+	c.updateCallArg = *obj.(*gcertv1alpha1.Certificate)
 	if c.updateErr != nil {
 		return c.updateErr
 	}

--- a/internal/service/kyma/deletion/usecases/delete_watcher_certificate_setup_test.go
+++ b/internal/service/kyma/deletion/usecases/delete_watcher_certificate_setup_test.go
@@ -47,7 +47,7 @@ func TestDeleteWatcherCertificateSetup_IsApplicable(t *testing.T) {
 			expectError:        false,
 			expectedCertName:   "test-kyma-webhook-tls",
 		},
-		{
+		{ //nolint:gosec //false positive: "G101: Potential hardcoded credentials"
 			name: "applicable when only secret exists",
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{
@@ -83,7 +83,7 @@ func TestDeleteWatcherCertificateSetup_IsApplicable(t *testing.T) {
 			expectedCertName:   "test-kyma-webhook-tls",
 			expectedSecretName: "", // secret repo is not called because cert repo already leads to IsApplicable
 		},
-		{
+		{ //nolint:gosec //false positive: "G101: Potential hardcoded credentials"
 			name: "not applicable when neither certificate nor secret exist",
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{
@@ -150,7 +150,7 @@ func TestDeleteWatcherCertificateSetup_IsApplicable(t *testing.T) {
 			expectError:        true,
 			expectedCertName:   "test-kyma-webhook-tls",
 		},
-		{
+		{ //nolint:gosec //false positive: "G101: Potential hardcoded credentials"
 			name: "error when secret Exists fails",
 			kyma: &v1beta2.Kyma{
 				ObjectMeta: apimetav1.ObjectMeta{

--- a/internal/service/kyma/status/modules/generator/fromerror/generator.go
+++ b/internal/service/kyma/status/modules/generator/fromerror/generator.go
@@ -76,7 +76,7 @@ func newDefaultErrorStatus(moduleName, desiredChannel, componentName string, err
 	return &v1beta2.ModuleStatus{
 		Name:             moduleName,
 		Channel:          desiredChannel,
-		FQDN:             componentName, // Deprecated in favor of OCMComponentName, but set for backward compatibility
+		FQDN:             componentName, //nolint:staticcheck // FQDN is deprecated
 		OCMComponentName: componentName,
 		State:            shared.StateError,
 		Message:          err.Error(),

--- a/internal/service/kyma/status/modules/generator/fromerror/generator_test.go
+++ b/internal/service/kyma/status/modules/generator/fromerror/generator_test.go
@@ -257,7 +257,7 @@ func createStatus() *v1beta2.ModuleStatus {
 	return &v1beta2.ModuleStatus{
 		Name:             "test-module",
 		Channel:          "test-channel",
-		FQDN:             "example.org/default-module/backend", // Ensure backward compatibility
+		FQDN:             "example.org/default-module/backend", //nolint:staticcheck // FQDN is deprecated
 		OCMComponentName: "example.org/default-module/backend",
 		Version:          "test-version",
 		Message:          "test-message",

--- a/internal/service/kyma/status/modules/generator/generator.go
+++ b/internal/service/kyma/status/modules/generator/generator.go
@@ -57,7 +57,7 @@ func (m *ModuleStatusGenerator) GenerateModuleStatus(module *modulecommon.Module
 	templateAPIVersion, templateKind := module.TemplateInfo.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	moduleStatus := &v1beta2.ModuleStatus{
 		Name:             module.ModuleName,
-		FQDN:             module.OCMComponentName, // Set for backwards compatibility
+		FQDN:             module.OCMComponentName, //nolint:staticcheck // FQDN is deprecated
 		OCMComponentName: module.OCMComponentName,
 		State:            manifest.Status.State,
 		Channel:          module.TemplateInfo.DesiredChannel,

--- a/internal/service/kyma/status/modules/handler.go
+++ b/internal/service/kyma/status/modules/handler.go
@@ -59,7 +59,7 @@ func (m *StatusHandler) UpdateModuleStatuses(ctx context.Context, kyma *v1beta2.
 		if err != nil {
 			newModuleStatus = &v1beta2.ModuleStatus{
 				Name:             module.ModuleName,
-				FQDN:             module.OCMComponentName, // Set for backward compatibility
+				FQDN:             module.OCMComponentName, //nolint:staticcheck // FQDN is deprecated.
 				OCMComponentName: module.OCMComponentName,
 				State:            shared.StateError,
 				Message:          err.Error(),

--- a/internal/util/collections/diffcalc.go
+++ b/internal/util/collections/diffcalc.go
@@ -23,7 +23,7 @@ func (d *DiffCalc[E]) NotExistingIn(second []E) []*E {
 	// Calculate diff
 	for i := range d.First {
 		if _, isInSecond := presentInSecond[d.Identity(d.First[i])]; !isInSecond {
-			onlyInFirst = append(onlyInFirst, &(d.First[i]))
+			onlyInFirst = append(onlyInFirst, &d.First[i])
 		}
 	}
 	return onlyInFirst

--- a/maintenancewindows/go.mod
+++ b/maintenancewindows/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/lifecycle-manager/maintenancewindows
 
-go 1.26.6
+go 1.27.0
 
 require github.com/stretchr/testify v1.12.0
 

--- a/maintenancewindows/resolver/resolver.go
+++ b/maintenancewindows/resolver/resolver.go
@@ -53,6 +53,7 @@ func GetMaintenancePolicyPool() (map[string]*[]byte, error) {
 			continue
 		}
 
+		//nolint:gosec // path comes from a trusted env var; name is an os.ReadDir entry filtered to .json files
 		data, err := os.ReadFile(filepath.Join(path, name))
 		if err != nil {
 			return nil, fmt.Errorf("error while reading the file %s: %w", name, err)

--- a/pkg/templatelookup/moduletemplateinfolookup/with_maintenance_window_decorator_test.go
+++ b/pkg/templatelookup/moduletemplateinfolookup/with_maintenance_window_decorator_test.go
@@ -64,7 +64,7 @@ func Test_WithMWDecorator_Lookup_ReturnsModuleTemplateInfo_WhenNoMWRequired(t *t
 		DesiredChannel: "test",
 		ModuleTemplate: &v1beta2.ModuleTemplate{
 			Spec: v1beta2.ModuleTemplateSpec{
-				Channel: "test",
+				Channel: "test", //nolint:staticcheck // Channel is deprecated.
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func Test_WithMWDecorator_Lookup_ReturnsError_WhenIsActiveReturnsError(t *testin
 		moduleTemplateInfo: templatelookup.ModuleTemplateInfo{
 			ModuleTemplate: &v1beta2.ModuleTemplate{
 				Spec: v1beta2.ModuleTemplateSpec{
-					Channel: "test",
+					Channel: "test", //nolint:staticcheck // Channel is deprecated.
 				},
 			},
 		},
@@ -123,7 +123,7 @@ func Test_WithMWDecorator_Lookup_ReturnsError_WhenMWIsRequiredAndNotActive(t *te
 		moduleTemplateInfo: templatelookup.ModuleTemplateInfo{
 			ModuleTemplate: &v1beta2.ModuleTemplate{
 				Spec: v1beta2.ModuleTemplateSpec{
-					Channel: "test",
+					Channel: "test", //nolint:staticcheck // Channel is deprecated.
 				},
 			},
 		},
@@ -151,7 +151,7 @@ func Test_WithMWDecorator_Lookup_ReturnsModuleTemplateInfo_WhenMWIsRequiredAndAc
 		DesiredChannel: "test",
 		ModuleTemplate: &v1beta2.ModuleTemplate{
 			Spec: v1beta2.ModuleTemplateSpec{
-				Channel: "test",
+				Channel: "test", //nolint:staticcheck // Channel is deprecated.
 			},
 		},
 	}

--- a/pkg/testutils/manifest.go
+++ b/pkg/testutils/manifest.go
@@ -55,6 +55,10 @@ var (
 	errManifestInstallRepoNotCorrect = errors.New("manifest install image spec repo is not correct")
 )
 
+const (
+	trueStr = "true"
+)
+
 func NewTestManifest(prefix string) *v1beta2.Manifest {
 	return builder.NewManifestBuilder().WithName(fmt.Sprintf("%s-%s", prefix,
 		random.Name())).WithNamespace(ControlPlaneNamespace).WithLabel(shared.KymaName,
@@ -199,7 +203,7 @@ func MandatoryManifestExistsWithLabelAndAnnotation(ctx context.Context, clnt cli
 ) error {
 	manifests := v1beta2.ManifestList{}
 	if err := clnt.List(ctx, &manifests, &client.ListOptions{
-		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: "true"}),
+		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: trueStr}),
 	}); err != nil {
 		return fmt.Errorf("failed listing manifests: %w", err)
 	}
@@ -323,7 +327,7 @@ func SetSkipLabelToMandatoryManifests(ctx context.Context, clnt client.Client, i
 ) error {
 	manifestList := v1beta2.ManifestList{}
 	if err := clnt.List(ctx, &manifestList, &client.ListOptions{
-		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: "true"}),
+		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: trueStr}),
 	}); err != nil {
 		return fmt.Errorf("failed to list manifests: %w", err)
 	}
@@ -342,7 +346,7 @@ func MandatoryModuleManifestExistWithCorrectVersion(ctx context.Context, clnt cl
 ) error {
 	manifestList := v1beta2.ManifestList{}
 	if err := clnt.List(ctx, &manifestList, &client.ListOptions{
-		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: "true"}),
+		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: trueStr}),
 	}); err != nil {
 		return fmt.Errorf("failed to list manifests: %w", err)
 	}
@@ -372,7 +376,7 @@ func MandatoryModuleManifestContainsExpectedLabel(ctx context.Context, clnt clie
 ) error {
 	manifestList := v1beta2.ManifestList{}
 	if err := clnt.List(ctx, &manifestList, &client.ListOptions{
-		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: "true"}),
+		LabelSelector: k8slabels.SelectorFromSet(k8slabels.Set{shared.IsMandatoryModule: trueStr}),
 	}); err != nil {
 		return fmt.Errorf("failed to list manifests: %w", err)
 	}
@@ -401,7 +405,7 @@ func SkipLabelExistsInManifest(ctx context.Context,
 		return false
 	}
 
-	return manifest.Labels[shared.SkipReconcileLabel] == "true"
+	return manifest.Labels[shared.SkipReconcileLabel] == trueStr
 }
 
 func CheckManifestIsInState(

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -76,8 +76,7 @@ func IsConnectionRelatedError(err error) bool {
 }
 
 func isNoSuchHostError(err error) bool {
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if dnsErr, ok := errors.AsType[*net.DNSError](err); ok {
 		return dnsErr.IsNotFound
 	}
 	return false

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -169,6 +169,7 @@ func getKubeConfigs() (*[]byte, *[]byte, error) {
 	if controlPlaneConfigFile == "" {
 		return nil, nil, fmt.Errorf("%w: %s", errEmptyEnvVar, kcpConfigEnvVar)
 	}
+	//nolint:gosec // path comes from a trusted env var, not user input
 	controlPlaneConfig, err := os.ReadFile(controlPlaneConfigFile)
 	if err != nil {
 		return nil, nil, err
@@ -178,6 +179,7 @@ func getKubeConfigs() (*[]byte, *[]byte, error) {
 	if runtimeConfigFile == "" {
 		return nil, nil, fmt.Errorf("%w: %s", errEmptyEnvVar, skrConfigEnvVar)
 	}
+	//nolint:gosec // path comes from a trusted env var, not user input
 	runtimeConfig, err := os.ReadFile(runtimeConfigFile)
 	if err != nil {
 		return nil, nil, err

--- a/unit-test-coverage-lifecycle-manager.yaml
+++ b/unit-test-coverage-lifecycle-manager.yaml
@@ -1,7 +1,7 @@
 packages:
   internal/controller: 100
-  internal/controller/istiogatewaysecret: 35.5
-  internal/controller/manifest: 4.4
+  internal/controller/istiogatewaysecret: 28.6
+  internal/controller/manifest: 4.1
   internal/crd: 88
   internal/descriptor/cache: 90
   internal/descriptor/provider: 100
@@ -14,11 +14,11 @@ packages:
   internal/manifest/img: 67.1
   internal/manifest/keychainprovider: 76.9
   internal/manifest/labelsremoval: 100
-  internal/manifest/manifestclient: 5
-  internal/manifest/modulecr: 56.9
+  internal/manifest/manifestclient: 4.2
+  internal/manifest/modulecr: 55.6
   internal/manifest/skrresources: 38.1
-  internal/manifest/statecheck: 74.2
-  internal/manifest/status: 73.8
+  internal/manifest/statecheck: 73.6
+  internal/manifest/status: 68.9
   internal/maintenancewindows: 91.2
   internal/pkg/metrics: 39.3
   internal/pkg/resources: 97.5
@@ -58,14 +58,14 @@ packages:
   internal/service/restrictedmodule: 100
   internal/service/skrsync: 100
 
-  internal/setup: 71.9
+  internal/setup: 67.5
   internal/util/collections: 87.9
 
   internal/watch/modulereleasemeta: 97.6
   internal/watch/modulereleasemeta/events: 100
 
-  pkg/module/sync: 9
-  pkg/status: 20
+  pkg/module/sync: 8.4
+  pkg/status: 15
   pkg/templatelookup: 79.7
   pkg/templatelookup/moduletemplateinfolookup: 100
   pkg/watcher: 10.6

--- a/versions.yaml
+++ b/versions.yaml
@@ -4,8 +4,8 @@ gardenerCertManager: "0.18.0"
 applyconfiguration_gen: "0.36.0" # underscore instead of dash to avoid issues with parsing with yq
 controllerTools: "0.20.1"
 docker: "27.5.1"
-go: "1.26.6"
-golangciLint: "2.9.0"
+go: "1.27.0"
+golangciLint: "2.13.1" # 2.13.0 was crashing on a Linux machine: "goanalysis_metalinter: [...] internal error: unhandled builtin recover"
 istio: "1.26.4" # https://github.com/kyma-project/lifecycle-manager/issues/2797
 k3d: "5.8.3"
 k8s: "1.32.2" # kubernetes version used in e2e tests


### PR DESCRIPTION

**Description**

Updated Go version to `1.27.0`

Changes proposed in this pull request:

- Bump Go version to `1.27.0`
- updated `golangci-lint` from version `2.9.0` to `2.13.1` - because `2.13.0` was crashing on my machine (`goanalysis_metalinter`)
- disabled `embedlit` check of `modernize` linter: It wants to "flatten" embedded structs literals, which is very bad for reading out structure of Kubernetes resources.
- **updated code coverage metrics** (see below)
- handled new linter warnings, mainly about duplicates string literals and other minor fixes
- suppressed linter warnings aboug usage of deprecated API fields
- suppressed false-positive `gosec` findings about path traversal and embedded secrets

**Note about code coverage**: It looks weird, probably the code coverage metrics is calculated in a different way in this release. For example, metrics for `internal/setup` package dropped from `71.9` to `67.5` - although I haven't touched any file in that package path. 