### PR TITLE
chore: Drop unused structured-merge-diff/v7 from api/go.mod

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -8,7 +8,7 @@ require (
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
 	sigs.k8s.io/controller-runtime v0.25.0
-	// required by applyconfiguration-gen (k8s.io/code-generator); can be dropped once the generator supports a newer version
+	// required by applyconfiguration-gen (k8s.io/code-generator); can be updated to v7 once the generator supports it
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2
 )
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,8 +8,8 @@ require (
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
 	sigs.k8s.io/controller-runtime v0.25.0
+	// required by applyconfiguration-gen (k8s.io/code-generator); can be dropped once the generator supports a newer version
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2
-	sigs.k8s.io/structured-merge-diff/v7 v7.0.0
 )
 
 require (

--- a/api/go.sum
+++ b/api/go.sum
@@ -161,6 +161,5 @@ sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2 h1:qdOxHwrl2Kaag1aQEarlYcOA9vSyGCp3CIki3aW8c4Q=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
-sigs.k8s.io/structured-merge-diff/v7 v7.0.0/go.mod h1:xKoMSgtnJnkfRR+CTNSQ1dBVhkKJR5OQl5RxX/OqHbI=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=


### PR DESCRIPTION
## Summary

- Removes the unused `sigs.k8s.io/structured-merge-diff/v7` dependency from `api/go.mod` and `api/go.sum`
- Adds a comment on the remaining `v6` entry explaining it is required by `applyconfiguration-gen` (`k8s.io/code-generator`), which hardcodes `v6` imports in generated files, and can be dropped once the generator supports a newer version